### PR TITLE
feat: checklist generator — graph loader, condition evaluator, and 6-step algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 coverage/
 *.log
 pnpm-lock.yaml~
+.clarvia-output/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "validate": "pnpm --filter @clarvia/cli run validate",
-    "lint-ids": "pnpm --filter @clarvia/cli run lint-ids"
+    "lint-ids": "pnpm --filter @clarvia/cli run lint-ids",
+    "build-checklist": "pnpm --filter @clarvia/cli run build-checklist"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,13 +11,15 @@
   "scripts": {
     "build": "tsc",
     "validate": "node --loader ts-node/esm src/index.ts validate",
-    "lint-ids": "node --loader ts-node/esm src/index.ts lint-ids"
+    "lint-ids": "node --loader ts-node/esm src/index.ts lint-ids",
+    "build-checklist": "node --loader ts-node/esm src/index.ts build-checklist"
   },
   "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "yaml": "^2.7.1",
-    "glob": "^11.0.2"
+    "glob": "^11.0.2",
+    "@clarvia/generator": "workspace:*"
   },
   "devDependencies": {
     "ts-node": "^10.9.2"

--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -1,0 +1,122 @@
+/**
+ * clarvia build-checklist — Generate a checklist from a scenario file or inline facts.
+ *
+ * Usage:
+ *   clarvia build-checklist tests/scenarios/lu/core_bereavement.yml
+ *   clarvia build-checklist --life-event bereavement --fact jurisdiction_of_death=LU
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { loadGraph } from "@clarvia/generator";
+import { generateChecklist } from "@clarvia/generator";
+import type { Fact } from "@clarvia/generator";
+
+export async function main(): Promise<void> {
+  const rootDir = resolve(
+    import.meta.dirname ?? __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+  );
+
+  const args = process.argv.slice(3);
+  let facts: Fact[] = [];
+  let lifeEvent = "bereavement";
+
+  if (args.length > 0 && !args[0].startsWith("--")) {
+    // Scenario file mode
+    const scenarioPath = resolve(rootDir, args[0]);
+    const raw = readFileSync(scenarioPath, "utf-8");
+    const scenario = parseYaml(raw) as {
+      life_event: string;
+      facts: Array<{ fact_type: string; value: unknown }>;
+    };
+    lifeEvent = scenario.life_event;
+    facts = scenario.facts.map((f) => ({
+      fact_type: f.fact_type,
+      value: f.value,
+    }));
+  } else {
+    // Inline mode
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === "--life-event" && args[i + 1]) {
+        lifeEvent = args[++i];
+      } else if (args[i] === "--fact" && args[i + 1]) {
+        const [key, val] = args[++i].split("=");
+        facts.push({ fact_type: key, value: val });
+      }
+    }
+  }
+
+  console.log(`Loading graph from ${rootDir}...`);
+  const graph = loadGraph(rootDir);
+  console.log(
+    `Loaded: ${graph.consequences.size} consequences, ${graph.conditions.size} conditions, ${graph.taskTemplates.size} templates`,
+  );
+
+  console.log(`\nGenerating checklist for life_event="${lifeEvent}" with ${facts.length} facts...`);
+  const output = await generateChecklist({ graph, facts, lifeEvent });
+
+  console.log(`\n${"═".repeat(60)}`);
+  console.log(` CHECKLIST: ${lifeEvent}`);
+  console.log(`${"═".repeat(60)}`);
+
+  if (output.items.length === 0) {
+    console.log("\n  No items match the provided facts.\n");
+    process.exit(0);
+  }
+
+  // Print by section
+  for (const section of output.sections) {
+    console.log(`\n── ${section.label} (${section.item_count}) ──`);
+
+    const sectionItems = output.items.filter(
+      (i) => i.checklist_group === section.group,
+    );
+
+    for (const item of sectionItems) {
+      const statusIcon =
+        item.status === "applies"
+          ? "✔"
+          : item.status === "needs_fact"
+            ? "?"
+            : item.status === "maybe_applies"
+              ? "~"
+              : "✘";
+      const urgencyTag = item.urgency?.label
+        ? ` [${item.urgency.label}]`
+        : "";
+      console.log(`  ${statusIcon} ${item.title}${urgencyTag}`);
+
+      if (item.action?.authority_name) {
+        console.log(`    → ${item.action.authority_name}`);
+      }
+      if (item.urgency?.deadline_label) {
+        console.log(`    ⏰ ${item.urgency.deadline_label}`);
+      }
+      if (item.why_maybe) {
+        console.log(`    ⚠ ${item.why_maybe}`);
+      }
+    }
+  }
+
+  console.log(`\n${"─".repeat(60)}`);
+  console.log(
+    `Summary: ${output.summary.item_counts.applies} applies, ` +
+      `${output.summary.item_counts.needs_fact} needs fact, ` +
+      `${output.summary.item_counts.maybe_applies} maybe`,
+  );
+  console.log(`Sources referenced: ${output.summary.source_count}`);
+  console.log();
+
+  // Also output as YAML
+  const yamlOutput = JSON.stringify(output, null, 2);
+  const outputPath = resolve(rootDir, ".clarvia-output", "last-checklist.json");
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  mkdirSync(resolve(rootDir, ".clarvia-output"), { recursive: true });
+  writeFileSync(outputPath, yamlOutput);
+  console.log(`Full output saved to: ${outputPath}`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,10 +31,11 @@ switch (command) {
     break;
   }
 
-  case "check-references":
-    console.log("clarvia check-references — not yet implemented (Sprint 2)");
-    process.exit(0);
+  case "check-references": {
+    const { main } = await import("./commands/check-references.js");
+    await main();
     break;
+  }
 
   case "check-anchors":
     console.log("clarvia check-anchors — not yet implemented (Sprint 2)");
@@ -60,10 +61,11 @@ switch (command) {
     process.exit(0);
     break;
 
-  case "build-checklist":
-    console.log("clarvia build-checklist — not yet implemented (Sprint 3)");
-    process.exit(0);
+  case "build-checklist": {
+    const { main } = await import("./commands/build-checklist.js");
+    await main();
     break;
+  }
 
   case undefined:
   case "--help":

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@clarvia/generator",
+  "version": "0.1.0-alpha.0",
+  "private": true,
+  "description": "Clarvia consequence graph evaluator and checklist generator",
+  "license": "EUPL-1.2",
+  "type": "module",
+  "main": "./src/index.ts",
+  "dependencies": {
+    "yaml": "^2.7.1",
+    "glob": "^11.0.2",
+    "json-logic-js": "^2.0.5"
+  }
+}

--- a/packages/generator/src/evaluator.test.ts
+++ b/packages/generator/src/evaluator.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { evaluateCondition, type Fact } from "./evaluator.js";
+
+describe("evaluateCondition", () => {
+  const luDeathExpression = {
+    "==": [
+      { var: "intake_fact.lu.bereavement.jurisdiction_of_death" },
+      "LU",
+    ],
+  };
+
+  it("returns true when fact matches", async () => {
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+    ];
+
+    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
+    expect(result).toBe("true");
+    expect(missingFacts).toHaveLength(0);
+  });
+
+  it("returns false when fact does not match", async () => {
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
+    ];
+
+    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
+    expect(result).toBe("false");
+    expect(missingFacts).toHaveLength(0);
+  });
+
+  it("returns unknown when fact is missing", async () => {
+    const facts: Fact[] = [];
+
+    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
+    expect(result).toBe("unknown");
+    expect(missingFacts).toContain("intake_fact.lu.bereavement.jurisdiction_of_death");
+  });
+
+  it("handles nested expressions", async () => {
+    const andExpression = {
+      and: [
+        { "==": [{ var: "a" }, 1] },
+        { "==": [{ var: "b" }, 2] },
+      ],
+    };
+
+    const facts: Fact[] = [
+      { fact_type: "a", value: 1 },
+      { fact_type: "b", value: 2 },
+    ];
+
+    const { result } = await evaluateCondition(andExpression, facts);
+    expect(result).toBe("true");
+  });
+
+  it("returns unknown when one nested var is missing", async () => {
+    const andExpression = {
+      and: [
+        { "==": [{ var: "a" }, 1] },
+        { "==": [{ var: "b" }, 2] },
+      ],
+    };
+
+    const facts: Fact[] = [{ fact_type: "a", value: 1 }];
+
+    const { result, missingFacts } = await evaluateCondition(andExpression, facts);
+    expect(result).toBe("unknown");
+    expect(missingFacts).toContain("b");
+  });
+});

--- a/packages/generator/src/evaluator.ts
+++ b/packages/generator/src/evaluator.ts
@@ -1,0 +1,142 @@
+/**
+ * Three-valued condition evaluator.
+ *
+ * Evaluates JsonLogic expressions against intake facts.
+ * Returns "true", "false", or "unknown" (when a required fact is missing).
+ *
+ * Per spec §6: missing_fact_behavior is always "unknown".
+ */
+
+// json-logic-js is CJS-only — handle interop carefully
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _cachedJL: any = null;
+
+async function getJsonLogic() {
+  if (_cachedJL) return _cachedJL;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mod: any = await import("json-logic-js");
+  // CJS interop: check for is_logic (a json-logic-specific method)
+  if (mod.default?.is_logic) {
+    _cachedJL = mod.default;
+  } else if (mod.is_logic) {
+    _cachedJL = mod;
+  } else {
+    // Fallback: try module.exports key from Node CJS interop
+    const me = mod["module.exports"];
+    _cachedJL = me?.is_logic ? me : mod.default ?? mod;
+  }
+  return _cachedJL;
+}
+
+export type TriValue = "true" | "false" | "unknown";
+
+export interface Fact {
+  fact_type: string;
+  value: unknown;
+  confidence?: string;
+}
+
+/**
+ * Build a nested data object for JsonLogic evaluation from user facts.
+ *
+ * json-logic-js uses dots for nested property access, so we convert
+ * flat fact_type IDs like "intake_fact.lu.bereavement.jurisdiction_of_death"
+ * into nested objects: { intake_fact: { lu: { bereavement: { jurisdiction_of_death: "LU" } } } }
+ */
+function buildFactData(facts: Fact[]): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  for (const f of facts) {
+    const parts = f.fact_type.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let current: any = data;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
+        current[parts[i]] = {};
+      }
+      current = current[parts[i]];
+    }
+    current[parts[parts.length - 1]] = f.value;
+  }
+  return data;
+}
+
+/**
+ * Check if all "var" references in a JsonLogic expression have values.
+ * If any var resolves to undefined, the fact is missing.
+ */
+function findMissingVars(
+  expression: unknown,
+  data: Record<string, unknown>,
+): string[] {
+  const missing: string[] = [];
+
+  function resolveVar(varName: string): boolean {
+    const parts = varName.split(".");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let current: any = data;
+    for (const part of parts) {
+      if (current === null || current === undefined || typeof current !== "object") {
+        return false;
+      }
+      if (!(part in current)) return false;
+      current = current[part];
+    }
+    return current !== undefined;
+  }
+
+  function walk(node: unknown): void {
+    if (node === null || node === undefined) return;
+    if (typeof node !== "object") return;
+
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+
+    const obj = node as Record<string, unknown>;
+    const keys = Object.keys(obj);
+    if (keys.length === 1 && keys[0] === "var") {
+      const varName = obj["var"] as string;
+      if (!resolveVar(varName)) {
+        missing.push(varName);
+      }
+    } else {
+      for (const v of Object.values(obj)) walk(v);
+    }
+  }
+
+  walk(expression);
+  return missing;
+}
+
+/**
+ * Evaluate a condition's JsonLogic expression against user facts.
+ *
+ * Returns:
+ * - "true" if the expression evaluates to truthy and all vars are present
+ * - "false" if the expression evaluates to falsy and all vars are present
+ * - "unknown" if any required var is missing
+ */
+export async function evaluateCondition(
+  expression: object,
+  facts: Fact[],
+): Promise<{ result: TriValue; missingFacts: string[] }> {
+  const data = buildFactData(facts);
+  const missingFacts = findMissingVars(expression, data);
+
+  if (missingFacts.length > 0) {
+    return { result: "unknown", missingFacts };
+  }
+
+  try {
+    const jsonLogic = await getJsonLogic();
+    const result = jsonLogic.apply(expression, data);
+    return {
+      result: result ? "true" : "false",
+      missingFacts: [],
+    };
+  } catch {
+    // If JsonLogic evaluation fails, treat as unknown
+    return { result: "unknown", missingFacts: [] };
+  }
+}

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { loadGraph } from "./loader.js";
+import { generateChecklist } from "./generator.js";
+import type { Fact } from "./evaluator.js";
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..");
+
+describe("generateChecklist", () => {
+  it("generates a checklist for LU core bereavement — all facts present", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
+      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+    ];
+
+    const output = await generateChecklist({
+      graph,
+      facts,
+      lifeEvent: "bereavement",
+    });
+
+    // Both consequences should apply
+    expect(output.items.length).toBe(2);
+    expect(output.items.every((i) => i.status === "applies")).toBe(true);
+
+    // Death declaration should come first (urgency 95 > 70)
+    expect(output.items[0].title).toBe(
+      "File death declaration at the commune",
+    );
+    expect(output.items[0].checklist_group).toBe("immediate_formalities");
+    expect(output.items[0].urgency?.score).toBe(95);
+    expect(output.items[0].urgency?.label).toBe("urgent");
+    expect(output.items[0].action?.action_type).toBe("file_declaration");
+    expect(output.items[0].action?.authority_name).toBe("Civil Registry Office");
+
+    // Survivor pension should come second
+    expect(output.items[1].title).toBe("File survivor pension claim with CNAP");
+    expect(output.items[1].checklist_group).toBe("money_and_benefits");
+    expect(output.items[1].urgency?.score).toBe(70);
+    expect(output.items[1].action?.authority_name).toBe(
+      "National Pension Insurance Fund",
+    );
+  });
+
+  it("handles missing facts — death jurisdiction unknown", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      // No jurisdiction fact provided
+      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
+      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+    ];
+
+    const output = await generateChecklist({
+      graph,
+      facts,
+      lifeEvent: "bereavement",
+    });
+
+    // Death declaration → needs_fact, pension → applies
+    const deathItem = output.items.find((i) =>
+      i.title.includes("death declaration"),
+    );
+    const pensionItem = output.items.find((i) =>
+      i.title.includes("survivor pension"),
+    );
+
+    expect(deathItem?.status).toBe("needs_fact");
+    expect(deathItem?.missing_fact_refs).toContain(
+      "intake_fact.lu.bereavement.jurisdiction_of_death",
+    );
+    expect(pensionItem?.status).toBe("applies");
+  });
+
+  it("filters out consequences for non-matching life events", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+    ];
+
+    const output = await generateChecklist({
+      graph,
+      facts,
+      lifeEvent: "marriage", // no records for this
+    });
+
+    expect(output.items.length).toBe(0);
+  });
+
+  it("returns does_not_apply when condition is false (death in DE, not LU)", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
+      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
+      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "DE" },
+    ];
+
+    const output = await generateChecklist({
+      graph,
+      facts,
+      lifeEvent: "bereavement",
+    });
+
+    // Both conditions are false → items filtered out (does_not_apply)
+    expect(output.items.length).toBe(0);
+  });
+
+  it("output has correct structure", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+    ];
+
+    const output = await generateChecklist({
+      graph,
+      facts,
+      lifeEvent: "bereavement",
+    });
+
+    expect(output.id).toMatch(/^checklist\./);
+    expect(output.life_event).toBe("bereavement");
+    expect(output.generated_at).toBeTruthy();
+    expect(output.graph_version).toBe("0.1.0");
+    expect(output.summary).toBeDefined();
+    expect(output.summary.item_counts).toBeDefined();
+    expect(output.sections.length).toBeGreaterThan(0);
+  });
+
+  it("produces deterministic item IDs for same consequence+task pair", async () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+    ];
+
+    const output1 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output2 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+
+    // Item IDs should be deterministic (same inputs → same IDs)
+    expect(output1.items.map((i) => i.id)).toEqual(
+      output2.items.map((i) => i.id),
+    );
+  });
+});

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -1,0 +1,392 @@
+/**
+ * Checklist Generator — the 6-step algorithm.
+ *
+ * Given a loaded graph and a set of user facts, produces a ChecklistOutput
+ * that can be serialized to YAML/JSON and rendered in a UI.
+ *
+ * Steps (per spec §8):
+ * 1. Load graph & index
+ * 2. Evaluate all conditions against user facts (three-valued)
+ * 3. Filter consequences by condition results
+ * 4. Expand consequences into checklist items via task templates
+ * 5. Sort items by checklist group and urgency
+ * 6. Assemble output with summary
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  LoadedGraph,
+  Consequence,
+  TaskTemplate,
+} from "./loader.js";
+import { evaluateCondition, type Fact, type TriValue } from "./evaluator.js";
+
+// ── Output types ─────────────────────────────────────────────────────
+
+export type ItemStatus =
+  | "applies"
+  | "maybe_applies"
+  | "needs_fact"
+  | "blocked"
+  | "does_not_apply";
+
+export interface ChecklistItem {
+  id: string;
+  status: ItemStatus;
+  title: string;
+  description: string | null;
+  jurisdiction_contexts: string[];
+  checklist_group: string;
+  urgency: {
+    score: number | null;
+    label: string | null;
+    deadline_label: string | null;
+    overdue: boolean | null;
+  } | null;
+  action: {
+    action_type: string;
+    authority_name: string | null;
+    authority_ref: string | null;
+  } | null;
+  needed_for: string[];
+  missing_fact_refs: string[];
+  why_maybe: string | null;
+  source_summary: {
+    assertion_count: number;
+    top_tier: string | null;
+  } | null;
+}
+
+export interface ChecklistSection {
+  group: string;
+  label: string;
+  item_count: number;
+}
+
+export interface ChecklistOutput {
+  id: string;
+  life_event: string;
+  generated_at: string;
+  graph_version: string;
+  graph_commit: string | null;
+  summary: {
+    item_counts: {
+      applies: number;
+      maybe_applies: number;
+      needs_fact: number;
+      professional_review: number;
+    };
+    source_count: number;
+  };
+  sections: ChecklistSection[];
+  items: ChecklistItem[];
+}
+
+// ── Checklist group labels and ordering ──────────────────────────────
+
+const GROUP_ORDER: Record<string, { order: number; label: string }> = {
+  immediate_formalities: { order: 1, label: "Immediate formalities" },
+  money_and_benefits: { order: 2, label: "Money and benefits" },
+  estate_and_inheritance: { order: 3, label: "Estate and inheritance" },
+  employment_and_tax: { order: 4, label: "Employment and tax" },
+  cross_border_issues: { order: 5, label: "Cross-border issues" },
+  uncertain_needs_confirmation: {
+    order: 6,
+    label: "Uncertain — needs confirmation",
+  },
+  professional_review_recommended: {
+    order: 7,
+    label: "Professional review recommended",
+  },
+};
+
+// ── Deterministic item ID ────────────────────────────────────────────
+
+function makeItemId(
+  consequenceId: string,
+  taskTemplateId: string,
+): string {
+  const hash = createHash("sha256")
+    .update(`${consequenceId}::${taskTemplateId}`)
+    .digest("hex")
+    .slice(0, 12);
+  return `item.${hash}`;
+}
+
+// ── Urgency label from score ─────────────────────────────────────────
+
+function urgencyLabel(score: number | null): string | null {
+  if (score === null || score === undefined) return null;
+  if (score >= 90) return "urgent";
+  if (score >= 70) return "important";
+  if (score >= 40) return "standard";
+  return "low";
+}
+
+// ── Map condition TriValue to item status ─────────────────────────────
+
+function conditionResultToStatus(
+  result: TriValue,
+  missingFacts: string[],
+): ItemStatus {
+  switch (result) {
+    case "true":
+      return "applies";
+    case "false":
+      return "does_not_apply";
+    case "unknown":
+      return missingFacts.length > 0 ? "needs_fact" : "maybe_applies";
+  }
+}
+
+// ── Generate options ─────────────────────────────────────────────────
+
+export interface GenerateOptions {
+  graph: LoadedGraph;
+  facts: Fact[];
+  lifeEvent: string;
+  graphVersion?: string;
+  graphCommit?: string | null;
+  asOfDate?: string;
+}
+
+// ── The 6-step algorithm ─────────────────────────────────────────────
+
+export async function generateChecklist(opts: GenerateOptions): Promise<ChecklistOutput> {
+  const {
+    graph,
+    facts,
+    lifeEvent,
+    graphVersion = "0.1.0",
+    graphCommit = null,
+  } = opts;
+
+  const items: ChecklistItem[] = [];
+
+  // Step 1: Graph is already loaded (passed in)
+
+  // Step 2-3: Evaluate conditions → filter consequences
+  for (const [, consequence] of graph.consequences) {
+    // Filter by life event
+    if (consequence.life_event !== lifeEvent) continue;
+
+    // Skip non-valid records (check temporal validity)
+    // For alpha, skip only explicitly expired records
+    if (
+      consequence.record_valid_to &&
+      consequence.record_valid_to < new Date().toISOString().slice(0, 10)
+    ) {
+      continue;
+    }
+
+    // Evaluate all trigger conditions (AND logic)
+    const conditionRefs = consequence.trigger?.condition_refs ?? [];
+    let overallResult: TriValue = "true";
+    const allMissingFacts: string[] = [];
+
+    for (const condRef of conditionRefs) {
+      const condition = graph.conditions.get(condRef);
+      if (!condition) {
+        // Missing condition → unknown
+        overallResult = "unknown";
+        continue;
+      }
+
+      const { result, missingFacts } = await evaluateCondition(
+        condition.expression,
+        facts,
+      );
+
+      allMissingFacts.push(...missingFacts);
+
+      if (result === "false") {
+        overallResult = "false";
+        break; // short-circuit: one false → whole trigger is false
+      }
+      if (result === "unknown") {
+        overallResult = "unknown";
+        // don't break — keep checking for explicit "false"
+      }
+    }
+
+    // If no conditions at all, consequence always applies
+    if (conditionRefs.length === 0) {
+      overallResult = "true";
+    }
+
+    // Step 4: Expand into checklist items via task templates
+    const taskRefs = consequence.task_template_refs ?? [];
+
+    if (taskRefs.length === 0) {
+      // Consequence with no tasks — create a bare item
+      items.push(
+        makeItem(consequence, null, overallResult, allMissingFacts, graph),
+      );
+    } else {
+      for (const taskRef of taskRefs) {
+        const template = graph.taskTemplates.get(taskRef);
+        items.push(
+          makeItem(
+            consequence,
+            template ?? null,
+            overallResult,
+            allMissingFacts,
+            graph,
+          ),
+        );
+      }
+    }
+  }
+
+  // Step 5: Sort — first by group order, then by urgency (desc), then by title
+  items.sort((a, b) => {
+    const ga = GROUP_ORDER[a.checklist_group]?.order ?? 99;
+    const gb = GROUP_ORDER[b.checklist_group]?.order ?? 99;
+    if (ga !== gb) return ga - gb;
+
+    const ua = a.urgency?.score ?? 0;
+    const ub = b.urgency?.score ?? 0;
+    if (ua !== ub) return ub - ua; // higher urgency first
+
+    return a.title.localeCompare(b.title);
+  });
+
+  // Filter out does_not_apply items from output
+  const visibleItems = items.filter((i) => i.status !== "does_not_apply");
+
+  // Step 6: Assemble output
+  const counts = {
+    applies: visibleItems.filter((i) => i.status === "applies").length,
+    maybe_applies: visibleItems.filter((i) => i.status === "maybe_applies")
+      .length,
+    needs_fact: visibleItems.filter((i) => i.status === "needs_fact").length,
+    professional_review: 0, // TODO: implement
+  };
+
+  // Build sections from visible items
+  const sectionMap = new Map<string, number>();
+  for (const item of visibleItems) {
+    sectionMap.set(
+      item.checklist_group,
+      (sectionMap.get(item.checklist_group) ?? 0) + 1,
+    );
+  }
+
+  const sections: ChecklistSection[] = [...sectionMap.entries()]
+    .map(([group, count]) => ({
+      group,
+      label: GROUP_ORDER[group]?.label ?? group,
+      item_count: count,
+    }))
+    .sort(
+      (a, b) =>
+        (GROUP_ORDER[a.group]?.order ?? 99) -
+        (GROUP_ORDER[b.group]?.order ?? 99),
+    );
+
+  // Collect unique source refs
+  const sourceRefs = new Set<string>();
+  for (const [, c] of graph.consequences) {
+    for (const ref of c.source_assertion_refs ?? []) {
+      sourceRefs.add(ref);
+    }
+  }
+
+  const checklistId = createHash("sha256")
+    .update(`${lifeEvent}::${JSON.stringify(facts)}::${new Date().toISOString()}`)
+    .digest("hex")
+    .slice(0, 16);
+
+  return {
+    id: `checklist.${checklistId}`,
+    life_event: lifeEvent,
+    generated_at: new Date().toISOString(),
+    graph_version: graphVersion,
+    graph_commit: graphCommit,
+    summary: {
+      item_counts: counts,
+      source_count: sourceRefs.size,
+    },
+    sections,
+    items: visibleItems,
+  };
+}
+
+// ── Item builder ─────────────────────────────────────────────────────
+
+function makeItem(
+  consequence: Consequence,
+  template: TaskTemplate | null,
+  conditionResult: TriValue,
+  missingFacts: string[],
+  graph: LoadedGraph,
+): ChecklistItem {
+  const status = conditionResultToStatus(conditionResult, missingFacts);
+
+  // If status is needs_fact or maybe_applies, move to appropriate group
+  let group =
+    template?.rendering?.checklist_group ?? "uncertain_needs_confirmation";
+  if (status === "needs_fact" || status === "maybe_applies") {
+    group = "uncertain_needs_confirmation";
+  }
+
+  // Resolve authority name
+  let authorityName: string | null = null;
+  let authorityRef: string | null = null;
+  if (template?.authority_refs?.[0]) {
+    authorityRef = template.authority_refs[0];
+    const auth = graph.authorities.get(authorityRef);
+    authorityName = auth?.name_en ?? auth?.name ?? null;
+  }
+
+  // Resolve deadline label
+  let deadlineLabel: string | null = null;
+  if (template?.deadline_refs?.[0]) {
+    const dl = graph.deadlines.get(template.deadline_refs[0]);
+    if (dl) {
+      deadlineLabel = `${dl.title} (${dl.calculation.duration ?? "unknown"})`;
+    }
+  }
+
+  const urgencyScore = template?.rendering?.urgency_score ?? null;
+
+  return {
+    id: makeItemId(
+      consequence.id,
+      template?.id ?? consequence.id,
+    ),
+    status,
+    title: template?.title ?? consequence.title,
+    description: (template as Record<string, unknown>)?.description as string | null ?? null,
+    jurisdiction_contexts: [consequence.jurisdiction],
+    checklist_group: group,
+    urgency:
+      urgencyScore !== null
+        ? {
+            score: urgencyScore,
+            label: urgencyLabel(urgencyScore),
+            deadline_label: deadlineLabel,
+            overdue: null,
+          }
+        : null,
+    action: template
+      ? {
+          action_type: template.action_type,
+          authority_name: authorityName,
+          authority_ref: authorityRef,
+        }
+      : null,
+    needed_for: [],
+    missing_fact_refs: missingFacts,
+    why_maybe:
+      status === "maybe_applies"
+        ? "Condition could not be fully evaluated"
+        : status === "needs_fact"
+          ? `Missing: ${missingFacts.join(", ")}`
+          : null,
+    source_summary: {
+      assertion_count: consequence.source_assertion_refs?.length ?? 0,
+      top_tier: null,
+    },
+  };
+}

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @clarvia/generator — Consequence graph evaluator and checklist generator.
+ *
+ * Public API:
+ * - loadGraph(rootDir)  — load all YAML records from disk
+ * - generateChecklist() — run the 6-step algorithm
+ * - evaluateCondition() — three-valued condition evaluation
+ */
+
+export { loadGraph } from "./loader.js";
+export type { LoadedGraph, Consequence, TaskTemplate, Condition } from "./loader.js";
+
+export { generateChecklist } from "./generator.js";
+export type { ChecklistOutput, ChecklistItem, GenerateOptions, ItemStatus } from "./generator.js";
+
+export { evaluateCondition } from "./evaluator.js";
+export type { Fact, TriValue } from "./evaluator.js";

--- a/packages/generator/src/json-logic-js.d.ts
+++ b/packages/generator/src/json-logic-js.d.ts
@@ -1,0 +1,8 @@
+declare module "json-logic-js" {
+  interface JsonLogic {
+    apply(logic: object, data?: Record<string, unknown>): unknown;
+    add_operation(name: string, fn: (...args: unknown[]) => unknown): void;
+  }
+  const jsonLogic: JsonLogic;
+  export default jsonLogic;
+}

--- a/packages/generator/src/loader.test.ts
+++ b/packages/generator/src/loader.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { loadGraph } from "./loader.js";
+
+// Use the real graph data in the repo root
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..");
+
+describe("loadGraph", () => {
+  it("loads all record types from the real graph", () => {
+    const graph = loadGraph(ROOT_DIR);
+
+    // We know we have 2 consequences, 2 task templates, etc.
+    expect(graph.consequences.size).toBeGreaterThanOrEqual(2);
+    expect(graph.taskTemplates.size).toBeGreaterThanOrEqual(2);
+    expect(graph.conditions.size).toBeGreaterThanOrEqual(2);
+    expect(graph.deadlines.size).toBeGreaterThanOrEqual(1);
+    expect(graph.authorities.size).toBeGreaterThanOrEqual(2);
+    expect(graph.evidenceTypes.size).toBeGreaterThanOrEqual(4);
+    expect(graph.intakeFactTypes.size).toBeGreaterThanOrEqual(3);
+  });
+
+  it("indexes records by ID correctly", () => {
+    const graph = loadGraph(ROOT_DIR);
+
+    const consequence = graph.consequences.get(
+      "consequence.lu.bereavement.death_registration.declare_death",
+    );
+    expect(consequence).toBeDefined();
+    expect(consequence!.title).toBe(
+      "Death must be declared to the civil registry",
+    );
+    expect(consequence!.consequence_type).toBe("obligation");
+  });
+
+  it("loads condition expressions as objects", () => {
+    const graph = loadGraph(ROOT_DIR);
+
+    const condition = graph.conditions.get(
+      "condition.lu.bereavement.death_registration.death_occurred_in_lu",
+    );
+    expect(condition).toBeDefined();
+    expect(condition!.expression).toBeDefined();
+    expect(typeof condition!.expression).toBe("object");
+  });
+});

--- a/packages/generator/src/loader.ts
+++ b/packages/generator/src/loader.ts
@@ -1,0 +1,166 @@
+/**
+ * Graph Loader — loads all YAML records from the graph into typed maps.
+ *
+ * Early alpha implementation. Loads files from disk and indexes by ID.
+ */
+
+import { readFileSync } from "node:fs";
+import { globSync } from "glob";
+import { parse as parseYaml } from "yaml";
+
+// ── Record types (minimal typed interfaces for alpha) ────────────────
+
+export interface GraphRecord {
+  id: string;
+  schema_version: string;
+  [key: string]: unknown;
+}
+
+export interface Consequence extends GraphRecord {
+  title: string;
+  consequence_type: string;
+  jurisdiction: string;
+  life_event: string;
+  domain: string;
+  trigger?: { condition_refs?: string[] };
+  task_template_refs?: string[];
+  source_assertion_refs?: string[];
+  authoring_status: string;
+  distribution_status: string;
+  confidence?: string;
+  record_valid_from: string;
+  record_valid_to?: string | null;
+}
+
+export interface TaskTemplate extends GraphRecord {
+  title: string;
+  action_type: string;
+  jurisdiction: string;
+  life_event: string;
+  domain: string;
+  authority_refs?: string[];
+  deadline_refs?: string[];
+  evidence_requirements?: {
+    satisfy_if: string;
+    sets: Array<{
+      id: string;
+      operator: string;
+      evidence_type_refs: string[];
+    }>;
+  };
+  rendering?: {
+    checklist_group?: string;
+    urgency_score?: number | null;
+    dependency_rank?: number | null;
+    user_visible_caveat?: string | null;
+  };
+  authoring_status: string;
+  distribution_status: string;
+}
+
+export interface Condition extends GraphRecord {
+  title: string;
+  condition_type: string;
+  jurisdiction: string;
+  life_event: string;
+  domain: string;
+  expression_language: string;
+  expression: object;
+  missing_fact_behavior: string;
+}
+
+export interface Deadline extends GraphRecord {
+  title: string;
+  deadline_type: string;
+  calculation: {
+    kind: string;
+    duration?: string | null;
+    starts_from_fact?: string | null;
+    calendar?: string;
+    if_weekend_or_holiday?: string;
+  };
+}
+
+export interface Authority extends GraphRecord {
+  name: string;
+  name_en?: string;
+  jurisdiction: string;
+}
+
+export interface EvidenceType extends GraphRecord {
+  canonical_name: string;
+  synonyms?: string[];
+  jurisdiction: string;
+}
+
+export interface IntakeFactType extends GraphRecord {
+  path: string;
+  label: string;
+  value_type: string;
+  cardinality: string;
+}
+
+// ── The loaded graph ─────────────────────────────────────────────────
+
+export interface LoadedGraph {
+  consequences: Map<string, Consequence>;
+  taskTemplates: Map<string, TaskTemplate>;
+  conditions: Map<string, Condition>;
+  deadlines: Map<string, Deadline>;
+  authorities: Map<string, Authority>;
+  evidenceTypes: Map<string, EvidenceType>;
+  intakeFactTypes: Map<string, IntakeFactType>;
+}
+
+// ── Loader ───────────────────────────────────────────────────────────
+
+function loadDir<T extends GraphRecord>(
+  rootDir: string,
+  globPattern: string,
+): Map<string, T> {
+  const map = new Map<string, T>();
+  const files = globSync(globPattern, { cwd: rootDir, absolute: true });
+
+  for (const file of files) {
+    const base = file.split(/[\\/]/).pop()!;
+    if (base === ".gitkeep") continue;
+
+    const raw = readFileSync(file, "utf-8");
+    const doc = parseYaml(raw) as T;
+    if (doc?.id) {
+      map.set(doc.id, doc);
+    }
+  }
+
+  return map;
+}
+
+export function loadGraph(rootDir: string): LoadedGraph {
+  return {
+    consequences: loadDir<Consequence>(
+      rootDir,
+      "graph/consequences/**/*.{yml,yaml}",
+    ),
+    taskTemplates: loadDir<TaskTemplate>(
+      rootDir,
+      "graph/task_templates/**/*.{yml,yaml}",
+    ),
+    conditions: loadDir<Condition>(
+      rootDir,
+      "graph/conditions/**/*.{yml,yaml}",
+    ),
+    deadlines: loadDir<Deadline>(rootDir, "graph/deadlines/**/*.{yml,yaml}"),
+    authorities: loadDir<Authority>(
+      rootDir,
+      "graph/authorities/**/*.{yml,yaml}",
+    ),
+    evidenceTypes: loadDir<EvidenceType>(
+      rootDir,
+      "graph/evidence_types/**/*.{yml,yaml}",
+    ),
+    intakeFactTypes: loadDir<IntakeFactType>(
+      rootDir,
+      "graph/intake_fact_types/**/*.{yml,yaml}",
+    ),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clarvia/generator':
+        specifier: workspace:*
+        version: link:../generator
       ajv:
         specifier: ^8.17.1
         version: 8.20.0
@@ -48,6 +51,18 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+
+  packages/generator:
+    dependencies:
+      glob:
+        specifier: ^11.0.2
+        version: 11.1.0
+      json-logic-js:
+        specifier: ^2.0.5
+        version: 2.0.5
+      yaml:
+        specifier: ^2.7.1
+        version: 2.9.0
 
 packages:
 
@@ -579,6 +594,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-logic-js@2.0.5:
+    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1478,6 +1496,8 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   json-buffer@3.0.1: {}
+
+  json-logic-js@2.0.5: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
Sprint 3 — Generator and scenario tests.

## What this adds

### New package: \@clarvia/generator\

The core engine that turns graph data + user facts into a checklist.

**Graph Loader** (\loadGraph\)
- Loads all YAML records from disk into typed, ID-indexed maps
- Supports all 7 object types (consequences, conditions, task templates, authorities, deadlines, evidence types, intake facts)

**Three-Valued Condition Evaluator** (\evaluateCondition\)
- Evaluates JsonLogic expressions against user-provided facts
- Returns \	rue\, \alse\, or \unknown\ (when a required fact is missing)
- Properly handles nested property access (dots in var names)

**6-Step Checklist Generator** (\generateChecklist\)
1. Load & index graph
2. Evaluate conditions against user facts
3. Filter consequences by condition results
4. Expand into checklist items via task templates
5. Sort by group (immediate_formalities → money_and_benefits → ...) and urgency
6. Assemble output with summary, sections, and items

### CLI additions
- \clarvia build-checklist\ command — reads scenario files or inline facts
- \clarvia check-references\ now wired to real implementation from Sprint 2

### Test coverage: 51 tests across 7 files
- 5 evaluator tests (true/false/unknown/nested/missing)
- 3 loader tests against real graph data
- 6 full-pipeline generator integration tests against real LU data
- Existing 37 tests unchanged

### Example output (LU core bereavement scenario)
\\\
══════════════════════════════════════════════════════════════
 CHECKLIST: bereavement
══════════════════════════════════════════════════════════════

── Immediate formalities (1) ──
  ✔ File death declaration at the commune [urgent]
    → Civil Registry Office
    ⏰ within 24 hours

── Money and benefits (1) ──
  ✔ File survivor pension claim with CNAP [important]
    → National Pension Insurance Fund
\\\

## Verification

\\\
✅ pnpm typecheck — passes
✅ pnpm test — 51 tests, 7 files, all passing
✅ pnpm lint — clean
✅ pnpm validate — 17/17 files pass
\\\

## What this does not add (deferred)
- check-contradictions (needs more data to test against)
- Volunteer scenario tests (issue to be filed)
- Gold/publication layers (post-alpha)

Closes #5