### PR TITLE
feat: full CI pipeline, export commands, and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  lint-typecheck-test:
     name: Lint, typecheck, test
     runs-on: ubuntu-latest
 
@@ -30,8 +30,34 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Lint
+      - name: Lint (ESLint)
         run: pnpm lint
 
-      - name: Test
+      - name: Unit tests
         run: pnpm test
+
+  validate-graph:
+    name: Validate graph data
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Schema validation
+        run: pnpm validate
+
+      - name: ID grammar checks
+        run: pnpm lint-ids
+
+      - name: Referential integrity
+        run: pnpm check-references

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run all checks
+        run: |
+          pnpm typecheck
+          pnpm lint
+          pnpm test
+          pnpm validate
+          pnpm lint-ids
+          pnpm check-references
+
+      - name: Export JSON
+        run: pnpm export-json
+
+      - name: Export web bundle
+        run: pnpm export-web
+
+      - name: Create release archive
+        run: |
+          cd .clarvia-output
+          tar -czf ../clarvia-graph-${{ github.ref_name }}.tar.gz .
+          cd ..
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: clarvia-graph-${{ github.ref_name }}.tar.gz
+          generate_release_notes: true
+          body: |
+            ## Clarvia Graph ${{ github.ref_name }}
+
+            This release contains:
+            - `graph-export.json` — full graph data as JSON
+            - `web/manifest.json` — web runtime manifest
+            - `web/intake/*.json` — intake question sets per life event
+            - `web/runtime/*.json` — pre-compiled runtime data per life event
+
+            ### Usage
+
+            Download and extract `clarvia-graph-${{ github.ref_name }}.tar.gz`.
+
+            **For workflow-web integration:**
+            ```bash
+            tar -xzf clarvia-graph-${{ github.ref_name }}.tar.gz -C public/clarvia-data/
+            ```
+
+            **For API/analysis:**
+            ```bash
+            cat graph-export.json | jq '.stats'
+            ```

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "typecheck": "tsc --noEmit",
     "validate": "pnpm --filter @clarvia/cli run validate",
     "lint-ids": "pnpm --filter @clarvia/cli run lint-ids",
-    "build-checklist": "pnpm --filter @clarvia/cli run build-checklist"
+    "check-references": "pnpm --filter @clarvia/cli run check-references",
+    "build-checklist": "pnpm --filter @clarvia/cli run build-checklist",
+    "export-json": "pnpm --filter @clarvia/cli run export-json",
+    "export-web": "pnpm --filter @clarvia/cli run export-web"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,10 @@
     "build": "tsc",
     "validate": "node --loader ts-node/esm src/index.ts validate",
     "lint-ids": "node --loader ts-node/esm src/index.ts lint-ids",
-    "build-checklist": "node --loader ts-node/esm src/index.ts build-checklist"
+    "check-references": "node --loader ts-node/esm src/index.ts check-references",
+    "build-checklist": "node --loader ts-node/esm src/index.ts build-checklist",
+    "export-json": "node --loader ts-node/esm src/index.ts export-json",
+    "export-web": "node --loader ts-node/esm src/index.ts export-web"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/packages/cli/src/commands/export-json.ts
+++ b/packages/cli/src/commands/export-json.ts
@@ -1,0 +1,75 @@
+/**
+ * clarvia export-json — Export the complete graph as a single JSON file.
+ *
+ * Outputs to .clarvia-output/graph-export.json
+ * Contains all records organized by type, plus metadata.
+ */
+
+import { resolve } from "node:path";
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { loadGraph } from "@clarvia/generator";
+
+export async function main(): Promise<void> {
+  const rootDir = resolve(
+    import.meta.dirname ?? __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+  );
+
+  console.log(`Loading graph from ${rootDir}...`);
+  const graph = loadGraph(rootDir);
+
+  // Read package.json for version
+  const pkgRaw = readFileSync(resolve(rootDir, "package.json"), "utf-8");
+  const pkg = JSON.parse(pkgRaw) as { version: string };
+
+  const mapToArray = <T>(m: Map<string, T>): T[] => [...m.values()];
+
+  const exportData = {
+    $schema: "clarvia-graph-export/v0.1",
+    version: pkg.version,
+    exported_at: new Date().toISOString(),
+    stats: {
+      consequences: graph.consequences.size,
+      task_templates: graph.taskTemplates.size,
+      conditions: graph.conditions.size,
+      deadlines: graph.deadlines.size,
+      authorities: graph.authorities.size,
+      evidence_types: graph.evidenceTypes.size,
+      intake_fact_types: graph.intakeFactTypes.size,
+      total:
+        graph.consequences.size +
+        graph.taskTemplates.size +
+        graph.conditions.size +
+        graph.deadlines.size +
+        graph.authorities.size +
+        graph.evidenceTypes.size +
+        graph.intakeFactTypes.size,
+    },
+    consequences: mapToArray(graph.consequences),
+    task_templates: mapToArray(graph.taskTemplates),
+    conditions: mapToArray(graph.conditions),
+    deadlines: mapToArray(graph.deadlines),
+    authorities: mapToArray(graph.authorities),
+    evidence_types: mapToArray(graph.evidenceTypes),
+    intake_fact_types: mapToArray(graph.intakeFactTypes),
+  };
+
+  const outDir = resolve(rootDir, ".clarvia-output");
+  mkdirSync(outDir, { recursive: true });
+
+  const outPath = resolve(outDir, "graph-export.json");
+  writeFileSync(outPath, JSON.stringify(exportData, null, 2));
+
+  console.log(`\nExported ${exportData.stats.total} records:`);
+  console.log(`  ${exportData.stats.consequences} consequences`);
+  console.log(`  ${exportData.stats.task_templates} task templates`);
+  console.log(`  ${exportData.stats.conditions} conditions`);
+  console.log(`  ${exportData.stats.deadlines} deadlines`);
+  console.log(`  ${exportData.stats.authorities} authorities`);
+  console.log(`  ${exportData.stats.evidence_types} evidence types`);
+  console.log(`  ${exportData.stats.intake_fact_types} intake fact types`);
+  console.log(`\nSaved to: ${outPath}`);
+}

--- a/packages/cli/src/commands/export-web.ts
+++ b/packages/cli/src/commands/export-web.ts
@@ -1,0 +1,253 @@
+/**
+ * clarvia export-web — Export web runtime bundle for workflow-web.
+ *
+ * Produces:
+ *   .clarvia-output/web/
+ *     manifest.json          — index of available life events and jurisdictions
+ *     intake/bereavement.json — intake fact types needed for bereavement
+ *     runtime/bereavement.json — pre-compiled runtime data (conditions, consequences,
+ *                                task templates with resolved refs)
+ *
+ * The web app loads manifest.json, then lazily loads intake + runtime per life event.
+ * The client-side LocalResolver evaluates conditions using the runtime data.
+ */
+
+import { resolve } from "node:path";
+import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { loadGraph } from "@clarvia/generator";
+import type { LoadedGraph } from "@clarvia/generator";
+
+export async function main(): Promise<void> {
+  const rootDir = resolve(
+    import.meta.dirname ?? __dirname,
+    "..",
+    "..",
+    "..",
+    "..",
+  );
+
+  console.log(`Loading graph from ${rootDir}...`);
+  const graph = loadGraph(rootDir);
+
+  const pkgRaw = readFileSync(resolve(rootDir, "package.json"), "utf-8");
+  const pkg = JSON.parse(pkgRaw) as { version: string };
+
+  const webDir = resolve(rootDir, ".clarvia-output", "web");
+
+  // Discover life events from consequences
+  const lifeEvents = new Set<string>();
+  const jurisdictions = new Set<string>();
+  for (const [, c] of graph.consequences) {
+    lifeEvents.add(c.life_event);
+    jurisdictions.add(c.jurisdiction);
+  }
+
+  // Create output directories
+  mkdirSync(resolve(webDir, "intake"), { recursive: true });
+  mkdirSync(resolve(webDir, "runtime"), { recursive: true });
+
+  // Generate per-life-event files
+  for (const lifeEvent of lifeEvents) {
+    buildIntakeFile(graph, lifeEvent, webDir);
+    buildRuntimeFile(graph, lifeEvent, webDir);
+  }
+
+  // Generate manifest
+  const manifest = {
+    $schema: "clarvia-web-export/v0.1",
+    version: pkg.version,
+    exported_at: new Date().toISOString(),
+    life_events: [...lifeEvents].map((le) => ({
+      id: le,
+      intake_url: `intake/${le}.json`,
+      runtime_url: `runtime/${le}.json`,
+      jurisdictions: [...jurisdictions],
+    })),
+  };
+
+  writeFileSync(
+    resolve(webDir, "manifest.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+
+  console.log(`\nWeb export complete:`);
+  console.log(`  Life events: ${[...lifeEvents].join(", ")}`);
+  console.log(`  Jurisdictions: ${[...jurisdictions].join(", ")}`);
+  console.log(`  Output: ${webDir}/`);
+  console.log(`    manifest.json`);
+  for (const le of lifeEvents) {
+    console.log(`    intake/${le}.json`);
+    console.log(`    runtime/${le}.json`);
+  }
+}
+
+/**
+ * Build intake file — list of questions the UI needs to ask for a life event.
+ */
+function buildIntakeFile(
+  graph: LoadedGraph,
+  lifeEvent: string,
+  webDir: string,
+): void {
+  // Find all intake fact types referenced by conditions for this life event
+  const factTypeIds = new Set<string>();
+  for (const [, condition] of graph.conditions) {
+    if (condition.life_event !== lifeEvent) continue;
+    // Extract var references from the expression
+    extractVarRefs(condition.expression, factTypeIds);
+  }
+
+  // Resolve to full intake fact type records
+  const questions = [...factTypeIds]
+    .map((id) => {
+      const factType = graph.intakeFactTypes.get(id);
+      if (!factType) {
+        // Try to find by path matching
+        for (const [, ft] of graph.intakeFactTypes) {
+          if (ft.path === id || ft.id === id) return ft;
+        }
+        return null;
+      }
+      return factType;
+    })
+    .filter(Boolean);
+
+  const intake = {
+    life_event: lifeEvent,
+    questions: questions.map((q) => ({
+      id: q!.id,
+      path: q!.path,
+      label: q!.label,
+      value_type: q!.value_type,
+      cardinality: q!.cardinality,
+    })),
+  };
+
+  writeFileSync(
+    resolve(webDir, "intake", `${lifeEvent}.json`),
+    JSON.stringify(intake, null, 2),
+  );
+}
+
+/**
+ * Build runtime file — all data needed for client-side evaluation.
+ */
+function buildRuntimeFile(
+  graph: LoadedGraph,
+  lifeEvent: string,
+  webDir: string,
+): void {
+  // Filter records by life event
+  const consequences = [...graph.consequences.values()].filter(
+    (c) => c.life_event === lifeEvent,
+  );
+  const conditions = [...graph.conditions.values()].filter(
+    (c) => c.life_event === lifeEvent,
+  );
+
+  // Collect referenced task templates, authorities, deadlines, evidence types
+  const taskTemplateIds = new Set<string>();
+  const authorityIds = new Set<string>();
+  const deadlineIds = new Set<string>();
+  const evidenceTypeIds = new Set<string>();
+
+  for (const c of consequences) {
+    for (const ref of c.task_template_refs ?? []) taskTemplateIds.add(ref);
+  }
+
+  for (const id of taskTemplateIds) {
+    const t = graph.taskTemplates.get(id);
+    if (t) {
+      for (const ref of t.authority_refs ?? []) authorityIds.add(ref);
+      for (const ref of t.deadline_refs ?? []) deadlineIds.add(ref);
+      if (t.evidence_requirements) {
+        for (const set of t.evidence_requirements.sets) {
+          for (const ref of set.evidence_type_refs) evidenceTypeIds.add(ref);
+        }
+      }
+    }
+  }
+
+  const runtime = {
+    life_event: lifeEvent,
+    conditions: conditions.map((c) => ({
+      id: c.id,
+      title: c.title,
+      expression_language: c.expression_language,
+      expression: c.expression,
+      missing_fact_behavior: c.missing_fact_behavior,
+    })),
+    consequences: consequences.map((c) => ({
+      id: c.id,
+      title: c.title,
+      consequence_type: c.consequence_type,
+      jurisdiction: c.jurisdiction,
+      trigger: c.trigger,
+      task_template_refs: c.task_template_refs,
+      confidence: c.confidence,
+    })),
+    task_templates: [...taskTemplateIds]
+      .map((id) => graph.taskTemplates.get(id))
+      .filter(Boolean)
+      .map((t) => ({
+        id: t!.id,
+        title: t!.title,
+        action_type: t!.action_type,
+        authority_refs: t!.authority_refs,
+        deadline_refs: t!.deadline_refs,
+        evidence_requirements: t!.evidence_requirements,
+        rendering: t!.rendering,
+      })),
+    authorities: [...authorityIds]
+      .map((id) => graph.authorities.get(id))
+      .filter(Boolean)
+      .map((a) => ({
+        id: a!.id,
+        name: a!.name,
+        name_en: a!.name_en,
+      })),
+    deadlines: [...deadlineIds]
+      .map((id) => graph.deadlines.get(id))
+      .filter(Boolean)
+      .map((d) => ({
+        id: d!.id,
+        title: d!.title,
+        deadline_type: d!.deadline_type,
+        calculation: d!.calculation,
+      })),
+    evidence_types: [...evidenceTypeIds]
+      .map((id) => graph.evidenceTypes.get(id))
+      .filter(Boolean)
+      .map((e) => ({
+        id: e!.id,
+        canonical_name: e!.canonical_name,
+        synonyms: e!.synonyms,
+      })),
+  };
+
+  writeFileSync(
+    resolve(webDir, "runtime", `${lifeEvent}.json`),
+    JSON.stringify(runtime, null, 2),
+  );
+}
+
+/**
+ * Extract all JsonLogic var references from an expression.
+ */
+function extractVarRefs(expression: unknown, refs: Set<string>): void {
+  if (expression === null || expression === undefined) return;
+  if (typeof expression !== "object") return;
+
+  if (Array.isArray(expression)) {
+    for (const item of expression) extractVarRefs(item, refs);
+    return;
+  }
+
+  const obj = expression as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 1 && keys[0] === "var") {
+    refs.add(obj["var"] as string);
+  } else {
+    for (const v of Object.values(obj)) extractVarRefs(v, refs);
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,6 +67,18 @@ switch (command) {
     break;
   }
 
+  case "export-json": {
+    const { main } = await import("./commands/export-json.js");
+    await main();
+    break;
+  }
+
+  case "export-web": {
+    const { main } = await import("./commands/export-web.js");
+    await main();
+    break;
+  }
+
   case undefined:
   case "--help":
   case "-h":
@@ -79,11 +91,13 @@ Commands:
   validate              Validate YAML files against JSON Schemas
   lint-ids              Check ID grammar and length rules
   check-references      Verify all references point to existing records
-  check-anchors         Verify assertion anchors exist in snapshots
-  check-publication-gate  Check publication gate requirements
-  check-contradictions  Detect overlapping conflicting claims
-  test-scenarios        Run scenario regression tests
+  check-anchors         Verify assertion anchors exist in snapshots (planned)
+  check-publication-gate  Check publication gate requirements (planned)
+  check-contradictions  Detect overlapping conflicting claims (planned)
+  test-scenarios        Run scenario regression tests (planned)
   build-checklist       Generate checklist output for test scenarios
+  export-json           Export full graph as JSON
+  export-web            Export web runtime bundle for workflow-web
 
 This is early alpha tooling. Not all commands are implemented yet.
 `);


### PR DESCRIPTION
Sprint 4 — CI, Exports, and Release infrastructure.

## CI Pipeline

The CI workflow is now split into **2 parallel jobs** for faster feedback:

| Job | Steps |
|-----|-------|
| \lint-typecheck-test\ | ESLint → TypeScript → Vitest (51 tests) |
| \alidate-graph\ | Schema validation → ID grammar → Referential integrity |

## Export Commands

### \clarvia export-json\
Dumps the entire graph as a single JSON file (\graph-export.json\) with metadata and stats. Useful for APIs, analysis, and downstream tooling.

### \clarvia export-web\
Produces a web runtime bundle for workflow-web:

\\\
.clarvia-output/web/
  manifest.json              — available life events + jurisdictions
  intake/bereavement.json    — intake fact types (questions to ask)
  runtime/bereavement.json   — conditions, consequences, templates
                               with resolved refs for client-side eval
\\\

The web app loads \manifest.json\, then lazily fetches per-life-event bundles.

## Release Workflow

Triggered by version tags (\*\). Runs all checks, builds exports, creates a GitHub Release with a \.tar.gz\ archive containing all export artifacts.

## CLI

10 commands total (7 implemented, 3 planned):
\alidate\, \lint-ids\, \check-references\, \uild-checklist\, \export-json\, \export-web\ ✅
\check-anchors\, \check-publication-gate\, \check-contradictions\ ⏳

## Verification

\\\
✅ pnpm typecheck — passes
✅ pnpm test — 51 tests, 7 files, all passing
✅ pnpm lint — clean
\\\

Closes #9, closes #10