### PR TITLE
feat(evaluator): native three-valued evaluator replacing json-logic-js

### DIFF
--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -58,7 +58,7 @@ export async function main(): Promise<void> {
   );
 
   console.log(`\nGenerating checklist for life_event="${lifeEvent}" with ${facts.length} facts...`);
-  const output = await generateChecklist({ graph, facts, lifeEvent });
+  const output = generateChecklist({ graph, facts, lifeEvent });
 
   console.log(`\n${"═".repeat(60)}`);
   console.log(` CHECKLIST: ${lifeEvent}`);

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -8,7 +8,6 @@
   "main": "./src/index.ts",
   "dependencies": {
     "yaml": "^2.7.1",
-    "glob": "^11.0.2",
-    "json-logic-js": "^2.0.5"
+    "glob": "^11.0.2"
   }
 }

--- a/packages/generator/src/evaluator.test.ts
+++ b/packages/generator/src/evaluator.test.ts
@@ -1,71 +1,534 @@
 import { describe, it, expect } from "vitest";
-import { evaluateCondition, type Fact } from "./evaluator.js";
+import { evaluateCondition, type Fact, type TriValue } from "./evaluator.js";
 
-describe("evaluateCondition", () => {
-  const luDeathExpression = {
-    "==": [
-      { var: "intake_fact.lu.bereavement.jurisdiction_of_death" },
-      "LU",
-    ],
-  };
+describe("evaluateCondition — native three-valued evaluator", () => {
+  // ── Helper ──────────────────────────────────────────────────────
+  function eval_(
+    expression: object,
+    facts: Fact[],
+  ): { result: TriValue; missingFacts: string[] } {
+    return evaluateCondition(expression, facts);
+  }
 
-  it("returns true when fact matches", async () => {
-    const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
-    ];
+  // ── var resolution ──────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("true");
-    expect(missingFacts).toHaveLength(0);
+  describe("var resolution", () => {
+    it("resolves dot-path variables", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("missing var returns unknown", () => {
+      const { result, missingFacts } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+      expect(missingFacts).toContain("death.place.country");
+    });
+
+    it("partially missing path returns unknown", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place", value: "test" }],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns false when fact does not match", async () => {
-    const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
-    ];
+  // ── == operator ─────────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("false");
-    expect(missingFacts).toHaveLength(0);
+  describe("== operator", () => {
+    it("returns true when values match", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when values don't match", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "DE" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("unknown == value → unknown", () => {
+      const { result } = eval_(
+        { "==": [{ var: "missing" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("value == unknown → unknown", () => {
+      const { result } = eval_(
+        { "==": ["LU", { var: "missing" }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns unknown when fact is missing", async () => {
-    const facts: Fact[] = [];
+  // ── != operator ─────────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("unknown");
-    expect(missingFacts).toContain("intake_fact.lu.bereavement.jurisdiction_of_death");
+  describe("!= operator", () => {
+    it("returns true when values differ", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "DE" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when values match", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("unknown != value → unknown", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "missing" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("handles nested expressions", async () => {
-    const andExpression = {
-      and: [
-        { "==": [{ var: "a" }, 1] },
-        { "==": [{ var: "b" }, 2] },
-      ],
-    };
+  // ── and operator — three-valued truth table ─────────────────────
 
-    const facts: Fact[] = [
-      { fact_type: "a", value: 1 },
-      { fact_type: "b", value: 2 },
-    ];
+  describe("and operator — three-valued", () => {
+    it("and(true, true) → true", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
 
-    const { result } = await evaluateCondition(andExpression, facts);
-    expect(result).toBe("true");
+    it("and(true, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(false, true) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(false, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(true, unknown) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }], // b is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("and(unknown, true) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 2 }], // a is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("and(false, unknown) → false (short-circuit!)", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }], // a is false, b is missing
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(unknown, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 999 }], // a is missing, b is false
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(unknown, unknown) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns unknown when one nested var is missing", async () => {
-    const andExpression = {
-      and: [
-        { "==": [{ var: "a" }, 1] },
-        { "==": [{ var: "b" }, 2] },
-      ],
-    };
+  // ── or operator — three-valued truth table ──────────────────────
 
-    const facts: Fact[] = [{ fact_type: "a", value: 1 }];
+  describe("or operator — three-valued", () => {
+    it("or(true, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
 
-    const { result, missingFacts } = await evaluateCondition(andExpression, facts);
-    expect(result).toBe("unknown");
-    expect(missingFacts).toContain("b");
+    it("or(true, false) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, false) → false", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("or(true, unknown) → true (short-circuit!)", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }], // b is missing
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(unknown, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 2 }], // a is missing
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, unknown) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }], // a is false, b is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("or(unknown, false) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 999 }], // a is missing, b is false
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("or(unknown, unknown) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── ! (not) operator ────────────────────────────────────────────
+
+  describe("! (not) operator", () => {
+    it("!(true) → false", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [{ fact_type: "a", value: 1 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("!(false) → true", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [{ fact_type: "a", value: 999 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("!(unknown) → unknown", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [], // a is missing
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── exists operator ─────────────────────────────────────────────
+
+  describe("exists operator", () => {
+    it("exists(present) → true", () => {
+      const { result } = eval_(
+        { exists: "death.date" },
+        [{ fact_type: "death.date", value: "2026-05-20" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("exists(missing) → false", () => {
+      const { result } = eval_(
+        { exists: "death.date" },
+        [],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("exists does not contribute to missingFacts", () => {
+      const { missingFacts } = eval_(
+        { exists: "death.date" },
+        [],
+      );
+      expect(missingFacts).toHaveLength(0);
+    });
+  });
+
+  // ── in operator ─────────────────────────────────────────────────
+
+  describe("in operator", () => {
+    it("in(value, array) → true when found", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [{ fact_type: "country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("in(value, array) → false when not found", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [{ fact_type: "country", value: "US" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("in(missing, array) → unknown", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── Comparison operators ────────────────────────────────────────
+
+  describe("comparison operators", () => {
+    it("> returns true when left > right", () => {
+      const { result } = eval_(
+        { ">": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 70 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("> returns false when left <= right", () => {
+      const { result } = eval_(
+        { ">": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 30 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it(">= returns true when equal", () => {
+      const { result } = eval_(
+        { ">=": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 50 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("< returns true when left < right", () => {
+      const { result } = eval_(
+        { "<": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 30 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("<= returns true when equal", () => {
+      const { result } = eval_(
+        { "<=": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 50 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("comparison with missing var → unknown", () => {
+      const { result } = eval_(
+        { ">": [{ var: "missing" }, 50] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── Nested expressions ──────────────────────────────────────────
+
+  describe("nested expressions", () => {
+    it("and(== country LU, exists date) — both present", () => {
+      const { result } = eval_(
+        {
+          and: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { exists: "death.date" },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "LU" },
+          { fact_type: "death.date", value: "2026-05-20" },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("and(== country LU, exists date) — date missing", () => {
+      const { result } = eval_(
+        {
+          and: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { exists: "death.date" },
+          ],
+        },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      // exists(missing) → false, so and(true, false) → false
+      expect(result).toBe(false);
+    });
+
+    it("or(== country LU, == residence LU) — first matches", () => {
+      const { result } = eval_(
+        {
+          or: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+          ],
+        },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(== country LU, == residence LU) — neither matches", () => {
+      const { result } = eval_(
+        {
+          or: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "DE" },
+          { fact_type: "deceased.habitual_residence.country", value: "DE" },
+        ],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("deeply nested: and(or(...), ==, exists)", () => {
+      const { result } = eval_(
+        {
+          and: [
+            {
+              or: [
+                { "==": [{ var: "death.place.country" }, "LU"] },
+                { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+              ],
+            },
+            { "==": [{ var: "relationship.to_deceased" }, "surviving_spouse"] },
+            { exists: "death.date" },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "DE" },
+          { fact_type: "deceased.habitual_residence.country", value: "LU" },
+          { fact_type: "relationship.to_deceased", value: "surviving_spouse" },
+          { fact_type: "death.date", value: "2026-05-20" },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── Backward compatibility ──────────────────────────────────────
+
+  describe("backward compatibility with old-style fact paths", () => {
+    it("still works with long intake_fact paths (pre-migration)", () => {
+      const { result } = eval_(
+        {
+          "==": [
+            { var: "intake_fact.lu.bereavement.jurisdiction_of_death" },
+            "LU",
+          ],
+        },
+        [
+          {
+            fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death",
+            value: "LU",
+          },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── missingFacts reporting ──────────────────────────────────────
+
+  describe("missingFacts reporting", () => {
+    it("reports all missing vars", () => {
+      const { missingFacts } = eval_(
+        {
+          and: [
+            { "==": [{ var: "a.b" }, 1] },
+            { "==": [{ var: "c.d" }, 2] },
+          ],
+        },
+        [],
+      );
+      expect(missingFacts).toContain("a.b");
+      expect(missingFacts).toContain("c.d");
+    });
+
+    it("does not report present vars", () => {
+      const { missingFacts } = eval_(
+        {
+          and: [
+            { "==": [{ var: "a" }, 1] },
+            { "==": [{ var: "b" }, 2] },
+          ],
+        },
+        [{ fact_type: "a", value: 1 }],
+      );
+      expect(missingFacts).toContain("b");
+      expect(missingFacts).not.toContain("a");
+    });
   });
 });

--- a/packages/generator/src/evaluator.ts
+++ b/packages/generator/src/evaluator.ts
@@ -1,34 +1,30 @@
 /**
- * Three-valued condition evaluator.
+ * Clarvia native three-valued condition evaluator.
  *
- * Evaluates JsonLogic expressions against intake facts.
- * Returns "true", "false", or "unknown" (when a required fact is missing).
+ * Evaluates a JsonLogic-subset expression against scenario facts.
+ * Returns true, false, or "unknown" — unknown is NEVER collapsed to false.
  *
- * Per spec §6: missing_fact_behavior is always "unknown".
+ * Supported operators (v0.1 alpha):
+ *   var, ==, !=, and, or, !, exists, in, >, >=, <, <=
+ *
+ * Three-valued truth table:
+ *   missing var                   → "unknown"
+ *   unknown == value              → "unknown"
+ *   unknown != value              → "unknown"
+ *   and(false, anything)          → false   (short-circuit)
+ *   and(true, unknown)            → "unknown"
+ *   or(true, anything)            → true    (short-circuit)
+ *   or(false, unknown)            → "unknown"
+ *   !(unknown)                    → "unknown"
+ *   exists(missing)               → false
+ *   exists(present)               → true
+ *
+ * Per spec §6.2: missing_fact_behavior is always "unknown".
  */
 
-// json-logic-js is CJS-only — handle interop carefully
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _cachedJL: any = null;
+// ── Types ────────────────────────────────────────────────────────────
 
-async function getJsonLogic() {
-  if (_cachedJL) return _cachedJL;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mod: any = await import("json-logic-js");
-  // CJS interop: check for is_logic (a json-logic-specific method)
-  if (mod.default?.is_logic) {
-    _cachedJL = mod.default;
-  } else if (mod.is_logic) {
-    _cachedJL = mod;
-  } else {
-    // Fallback: try module.exports key from Node CJS interop
-    const me = mod["module.exports"];
-    _cachedJL = me?.is_logic ? me : mod.default ?? mod;
-  }
-  return _cachedJL;
-}
-
-export type TriValue = "true" | "false" | "unknown";
+export type TriValue = true | false | "unknown";
 
 export interface Fact {
   fact_type: string;
@@ -36,14 +32,48 @@ export interface Fact {
   confidence?: string;
 }
 
+// Sentinel value for missing/unresolved variables
+const MISSING = Symbol("MISSING");
+
+// ── Var resolution ───────────────────────────────────────────────────
+
 /**
- * Build a nested data object for JsonLogic evaluation from user facts.
- *
- * json-logic-js uses dots for nested property access, so we convert
- * flat fact_type IDs like "intake_fact.lu.bereavement.jurisdiction_of_death"
- * into nested objects: { intake_fact: { lu: { bereavement: { jurisdiction_of_death: "LU" } } } }
+ * Resolve a dot-path variable from nested data.
+ * Returns MISSING if the path cannot be resolved.
  */
-function buildFactData(facts: Fact[]): Record<string, unknown> {
+function resolveVar(
+  varName: string,
+  data: Record<string, unknown>,
+): unknown {
+  const parts = varName.split(".");
+  let current: unknown = data;
+  for (const part of parts) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object"
+    ) {
+      return MISSING;
+    }
+    if (!(part in (current as Record<string, unknown>))) {
+      return MISSING;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current === undefined ? MISSING : current;
+}
+
+// ── Build fact data ──────────────────────────────────────────────────
+
+/**
+ * Build a nested data object from flat fact entries.
+ *
+ * Converts:
+ *   [{ fact_type: "death.place.country", value: "LU" }]
+ * Into:
+ *   { death: { place: { country: "LU" } } }
+ */
+export function buildFactData(facts: Fact[]): Record<string, unknown> {
   const data: Record<string, unknown> = {};
   for (const f of facts) {
     const parts = f.fact_type.split(".");
@@ -60,29 +90,167 @@ function buildFactData(facts: Fact[]): Record<string, unknown> {
   return data;
 }
 
+// ── Core recursive evaluator ─────────────────────────────────────────
+
 /**
- * Check if all "var" references in a JsonLogic expression have values.
- * If any var resolves to undefined, the fact is missing.
+ * Evaluate a JsonLogic-subset expression against nested data.
+ *
+ * Returns:
+ *   - A concrete value (string, number, boolean, array, etc.)
+ *   - MISSING sentinel if a variable cannot be resolved
+ *
+ * The top-level evaluateCondition() converts this to a TriValue.
  */
-function findMissingVars(
+function evaluate(
+  expression: unknown,
+  data: Record<string, unknown>,
+): unknown {
+  // Primitives pass through
+  if (expression === null || expression === undefined) return expression;
+  if (typeof expression !== "object") return expression;
+  if (Array.isArray(expression)) return expression;
+
+  const obj = expression as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length !== 1) return expression;
+
+  const op = keys[0];
+  const rawArgs = obj[op];
+
+  // ── var ────────────────────────────────────────────────────────
+  if (op === "var") {
+    const varName = rawArgs as string;
+    return resolveVar(varName, data);
+  }
+
+  // ── exists ─────────────────────────────────────────────────────
+  if (op === "exists") {
+    const varName = rawArgs as string;
+    const resolved = resolveVar(varName, data);
+    return resolved !== MISSING;
+  }
+
+  // Ensure args is an array
+  const args = Array.isArray(rawArgs) ? rawArgs : [rawArgs];
+
+  // ── ! (not) ────────────────────────────────────────────────────
+  if (op === "!" || op === "not") {
+    const val = evaluate(args[0], data);
+    if (val === MISSING) return MISSING;
+    return !val;
+  }
+
+  // ── and ────────────────────────────────────────────────────────
+  // Three-valued: and(false, anything) → false (short-circuit)
+  //               and(true, unknown) → unknown
+  if (op === "and") {
+    let hasMissing = false;
+    for (const arg of args) {
+      const val = evaluate(arg, data);
+      if (val === MISSING) {
+        hasMissing = true;
+        continue; // don't short-circuit — keep checking for false
+      }
+      if (!val) return false; // false short-circuits
+    }
+    if (hasMissing) return MISSING;
+    return true;
+  }
+
+  // ── or ─────────────────────────────────────────────────────────
+  // Three-valued: or(true, anything) → true (short-circuit)
+  //               or(false, unknown) → unknown
+  if (op === "or") {
+    let hasMissing = false;
+    for (const arg of args) {
+      const val = evaluate(arg, data);
+      if (val === MISSING) {
+        hasMissing = true;
+        continue;
+      }
+      if (val) return true; // true short-circuits
+    }
+    if (hasMissing) return MISSING;
+    return false;
+  }
+
+  // ── == ─────────────────────────────────────────────────────────
+  if (op === "==" || op === "===") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    // Use loose equality for "==" per JsonLogic convention
+    return left == right;
+  }
+
+  // ── != ─────────────────────────────────────────────────────────
+  if (op === "!=" || op === "!==") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return left != right;
+  }
+
+  // ── > ──────────────────────────────────────────────────────────
+  if (op === ">") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) > (right as number);
+  }
+
+  // ── >= ─────────────────────────────────────────────────────────
+  if (op === ">=") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) >= (right as number);
+  }
+
+  // ── < ──────────────────────────────────────────────────────────
+  if (op === "<") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) < (right as number);
+  }
+
+  // ── <= ─────────────────────────────────────────────────────────
+  if (op === "<=") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) <= (right as number);
+  }
+
+  // ── in ─────────────────────────────────────────────────────────
+  if (op === "in") {
+    const needle = evaluate(args[0], data);
+    const haystack = evaluate(args[1], data);
+    if (needle === MISSING || haystack === MISSING) return MISSING;
+    if (Array.isArray(haystack)) {
+      return haystack.includes(needle);
+    }
+    if (typeof haystack === "string" && typeof needle === "string") {
+      return haystack.includes(needle);
+    }
+    return false;
+  }
+
+  // Unknown operator — treat as unknown
+  return MISSING;
+}
+
+// ── Find missing vars ────────────────────────────────────────────────
+
+/**
+ * Walk the expression tree and collect all var paths that don't resolve.
+ */
+export function findMissingVars(
   expression: unknown,
   data: Record<string, unknown>,
 ): string[] {
   const missing: string[] = [];
-
-  function resolveVar(varName: string): boolean {
-    const parts = varName.split(".");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let current: any = data;
-    for (const part of parts) {
-      if (current === null || current === undefined || typeof current !== "object") {
-        return false;
-      }
-      if (!(part in current)) return false;
-      current = current[part];
-    }
-    return current !== undefined;
-  }
 
   function walk(node: unknown): void {
     if (node === null || node === undefined) return;
@@ -95,13 +263,29 @@ function findMissingVars(
 
     const obj = node as Record<string, unknown>;
     const keys = Object.keys(obj);
-    if (keys.length === 1 && keys[0] === "var") {
-      const varName = obj["var"] as string;
-      if (!resolveVar(varName)) {
+    if (keys.length !== 1) return;
+
+    const op = keys[0];
+    const rawArgs = obj[op];
+
+    if (op === "var") {
+      const varName = rawArgs as string;
+      if (resolveVar(varName, data) === MISSING) {
         missing.push(varName);
       }
-    } else {
-      for (const v of Object.values(obj)) walk(v);
+      return;
+    }
+
+    if (op === "exists") {
+      // exists doesn't contribute to "missing" — it explicitly tests presence
+      return;
+    }
+
+    // Walk children
+    if (Array.isArray(rawArgs)) {
+      for (const item of rawArgs) walk(item);
+    } else if (rawArgs && typeof rawArgs === "object") {
+      walk(rawArgs);
     }
   }
 
@@ -109,34 +293,33 @@ function findMissingVars(
   return missing;
 }
 
+// ── Public API ───────────────────────────────────────────────────────
+
 /**
  * Evaluate a condition's JsonLogic expression against user facts.
  *
  * Returns:
- * - "true" if the expression evaluates to truthy and all vars are present
- * - "false" if the expression evaluates to falsy and all vars are present
- * - "unknown" if any required var is missing
+ *   - result: true if the expression evaluates to truthy and all vars are present
+ *   - result: false if the expression evaluates to falsy and all vars are present
+ *   - result: "unknown" if any required var is missing
+ *   - missingFacts: list of var paths that could not be resolved
+ *
+ * This function is synchronous — no external library dependency.
  */
-export async function evaluateCondition(
+export function evaluateCondition(
   expression: object,
   facts: Fact[],
-): Promise<{ result: TriValue; missingFacts: string[] }> {
+): { result: TriValue; missingFacts: string[] } {
   const data = buildFactData(facts);
   const missingFacts = findMissingVars(expression, data);
+  const rawResult = evaluate(expression, data);
 
-  if (missingFacts.length > 0) {
+  if (rawResult === MISSING) {
     return { result: "unknown", missingFacts };
   }
 
-  try {
-    const jsonLogic = await getJsonLogic();
-    const result = jsonLogic.apply(expression, data);
-    return {
-      result: result ? "true" : "false",
-      missingFacts: [],
-    };
-  } catch {
-    // If JsonLogic evaluation fails, treat as unknown
-    return { result: "unknown", missingFacts: [] };
-  }
+  return {
+    result: rawResult ? true : false,
+    missingFacts: [],
+  };
 }

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -7,7 +7,7 @@ import type { Fact } from "./evaluator.js";
 const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..");
 
 describe("generateChecklist", () => {
-  it("generates a checklist for LU core bereavement — all facts present", async () => {
+  it("generates a checklist for LU core bereavement — all facts present", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
@@ -15,7 +15,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -44,7 +44,7 @@ describe("generateChecklist", () => {
     );
   });
 
-  it("handles missing facts — death jurisdiction unknown", async () => {
+  it("handles missing facts — death jurisdiction unknown", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       // No jurisdiction fact provided
@@ -52,7 +52,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -73,13 +73,13 @@ describe("generateChecklist", () => {
     expect(pensionItem?.status).toBe("applies");
   });
 
-  it("filters out consequences for non-matching life events", async () => {
+  it("filters out consequences for non-matching life events", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "marriage", // no records for this
@@ -88,7 +88,7 @@ describe("generateChecklist", () => {
     expect(output.items.length).toBe(0);
   });
 
-  it("returns does_not_apply when condition is false (death in DE, not LU)", async () => {
+  it("returns does_not_apply when condition is false (death in DE, not LU)", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
@@ -96,7 +96,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "DE" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -106,14 +106,14 @@ describe("generateChecklist", () => {
     expect(output.items.length).toBe(0);
   });
 
-  it("output has correct structure", async () => {
+  it("output has correct structure", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -128,15 +128,15 @@ describe("generateChecklist", () => {
     expect(output.sections.length).toBeGreaterThan(0);
   });
 
-  it("produces deterministic item IDs for same consequence+task pair", async () => {
+  it("produces deterministic item IDs for same consequence+task pair", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output1 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
-    const output2 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
 
     // Item IDs should be deterministic (same inputs → same IDs)
     expect(output1.items.map((i) => i.id)).toEqual(

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -21,6 +21,9 @@ import type {
 } from "./loader.js";
 import { evaluateCondition, type Fact, type TriValue } from "./evaluator.js";
 
+// Re-export types for convenience
+export type { Fact } from "./evaluator.js";
+
 // ── Output types ─────────────────────────────────────────────────────
 
 export type ItemStatus =
@@ -129,14 +132,9 @@ function conditionResultToStatus(
   result: TriValue,
   missingFacts: string[],
 ): ItemStatus {
-  switch (result) {
-    case "true":
-      return "applies";
-    case "false":
-      return "does_not_apply";
-    case "unknown":
-      return missingFacts.length > 0 ? "needs_fact" : "maybe_applies";
-  }
+  if (result === true) return "applies";
+  if (result === false) return "does_not_apply";
+  return missingFacts.length > 0 ? "needs_fact" : "maybe_applies";
 }
 
 // ── Generate options ─────────────────────────────────────────────────
@@ -152,7 +150,7 @@ export interface GenerateOptions {
 
 // ── The 6-step algorithm ─────────────────────────────────────────────
 
-export async function generateChecklist(opts: GenerateOptions): Promise<ChecklistOutput> {
+export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
   const {
     graph,
     facts,
@@ -181,7 +179,7 @@ export async function generateChecklist(opts: GenerateOptions): Promise<Checklis
 
     // Evaluate all trigger conditions (AND logic)
     const conditionRefs = consequence.trigger?.condition_refs ?? [];
-    let overallResult: TriValue = "true";
+    let overallResult: TriValue = true;
     const allMissingFacts: string[] = [];
 
     for (const condRef of conditionRefs) {
@@ -192,26 +190,26 @@ export async function generateChecklist(opts: GenerateOptions): Promise<Checklis
         continue;
       }
 
-      const { result, missingFacts } = await evaluateCondition(
+      const { result, missingFacts } = evaluateCondition(
         condition.expression,
         facts,
       );
 
       allMissingFacts.push(...missingFacts);
 
-      if (result === "false") {
-        overallResult = "false";
+      if (result === false) {
+        overallResult = false;
         break; // short-circuit: one false → whole trigger is false
       }
       if (result === "unknown") {
         overallResult = "unknown";
-        // don't break — keep checking for explicit "false"
+        // don't break — keep checking for explicit false
       }
     }
 
     // If no conditions at all, consequence always applies
     if (conditionRefs.length === 0) {
-      overallResult = "true";
+      overallResult = true;
     }
 
     // Step 4: Expand into checklist items via task templates

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -5,6 +5,7 @@
  * - loadGraph(rootDir)  — load all YAML records from disk
  * - generateChecklist() — run the 6-step algorithm
  * - evaluateCondition() — three-valued condition evaluation
+ * - buildFactData()     — convert facts to nested data object
  */
 
 export { loadGraph } from "./loader.js";
@@ -13,5 +14,5 @@ export type { LoadedGraph, Consequence, TaskTemplate, Condition } from "./loader
 export { generateChecklist } from "./generator.js";
 export type { ChecklistOutput, ChecklistItem, GenerateOptions, ItemStatus } from "./generator.js";
 
-export { evaluateCondition } from "./evaluator.js";
+export { evaluateCondition, buildFactData } from "./evaluator.js";
 export type { Fact, TriValue } from "./evaluator.js";

--- a/packages/generator/src/json-logic-js.d.ts
+++ b/packages/generator/src/json-logic-js.d.ts
@@ -1,8 +1,0 @@
-declare module "json-logic-js" {
-  interface JsonLogic {
-    apply(logic: object, data?: Record<string, unknown>): unknown;
-    add_operation(name: string, fn: (...args: unknown[]) => unknown): void;
-  }
-  const jsonLogic: JsonLogic;
-  export default jsonLogic;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       glob:
         specifier: ^11.0.2
         version: 11.1.0
-      json-logic-js:
-        specifier: ^2.0.5
-        version: 2.0.5
       yaml:
         specifier: ^2.7.1
         version: 2.9.0
@@ -594,9 +591,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-logic-js@2.0.5:
-    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1496,8 +1490,6 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   json-buffer@3.0.1: {}
-
-  json-logic-js@2.0.5: {}
 
   json-schema-traverse@0.4.1: {}
 


### PR DESCRIPTION
## C1: Evaluator Correctness

### What
Replace json-logic-js dependency with a native recursive three-valued evaluator.

### Why
json-logic-js collapses truthy/falsy values and cannot properly propagate 'unknown' through nested expressions. Per spec para 6.2, missing_fact_behavior must be 'unknown' - unknown is NEVER collapsed to false.

### Changes
- **evaluator.ts**: Complete rewrite with native recursive evaluator supporting: var, ==, !=, and, or, !, exists, in, >, >=, <, <=
- Three-valued logic: true, false, 'unknown'. Proper short-circuit semantics.
- **evaluator.test.ts**: 51 tests covering full truth tables
- **generator.ts**: Updated for sync evaluator and boolean TriValue
- **generator.test.ts**: Updated for sync API
- **package.json**: Removed json-logic-js dependency
- **json-logic-js.d.ts**: Deleted

### Acceptance Criteria
- [x] Unknown is never collapsed to false
- [x] All truth table rows covered by tests
- [x] Short-circuit: and(false, unknown) -> false
- [x] Short-circuit: or(true, unknown) -> true
- [x] 97 tests pass, typecheck passes, lint passes