### PR TITLE
feat(generator): deterministic checklist IDs and temporal filtering

### DIFF
--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -119,7 +119,7 @@ describe("generateChecklist", () => {
       lifeEvent: "bereavement",
     });
 
-    expect(output.id).toMatch(/^checklist\./);
+    expect(output.id).toMatch(/^checklist_run\./);
     expect(output.life_event).toBe("bereavement");
     expect(output.generated_at).toBeTruthy();
     expect(output.graph_version).toBe("0.1.0");
@@ -128,19 +128,40 @@ describe("generateChecklist", () => {
     expect(output.sections.length).toBeGreaterThan(0);
   });
 
-  it("produces deterministic item IDs for same consequence+task pair", () => {
+  it("produces fully deterministic checklist + item IDs for same inputs", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
       { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
-    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
-    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
 
-    // Item IDs should be deterministic (same inputs → same IDs)
+    // Checklist ID should be fully deterministic (no timestamp in hash)
+    expect(output1.id).toBe(output2.id);
+    expect(output1.id).toMatch(/^checklist_run\.20260603\./);
+
+    // Item IDs should also be deterministic
     expect(output1.items.map((i) => i.id)).toEqual(
       output2.items.map((i) => i.id),
     );
+  });
+
+  it("same facts in different order produce same checklist ID", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts1: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+    const facts2: Fact[] = [
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
+    ];
+
+    const output1 = generateChecklist({ graph, facts: facts1, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts: facts2, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    expect(output1.id).toBe(output2.id);
   });
 });

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -157,7 +157,11 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     lifeEvent,
     graphVersion = "0.1.0",
     graphCommit = null,
+    asOfDate,
   } = opts;
+
+  // Determine reference date for temporal filtering
+  const referenceDate = asOfDate ?? new Date().toISOString().slice(0, 10);
 
   const items: ChecklistItem[] = [];
 
@@ -172,7 +176,15 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     // For alpha, skip only explicitly expired records
     if (
       consequence.record_valid_to &&
-      consequence.record_valid_to < new Date().toISOString().slice(0, 10)
+      consequence.record_valid_to < referenceDate
+    ) {
+      continue;
+    }
+
+    // Skip records that haven't started yet
+    if (
+      consequence.record_valid_from &&
+      consequence.record_valid_from > referenceDate
     ) {
       continue;
     }
@@ -290,13 +302,19 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     }
   }
 
-  const checklistId = createHash("sha256")
-    .update(`${lifeEvent}::${JSON.stringify(facts)}::${new Date().toISOString()}`)
+  // Deterministic checklist ID: hash of lifeEvent + canonical facts (no timestamp)
+  const canonicalFacts = JSON.stringify(
+    [...facts].sort((a, b) => a.fact_type.localeCompare(b.fact_type)),
+  );
+  const scenarioHash = createHash("sha256")
+    .update(`${lifeEvent}::${canonicalFacts}`)
     .digest("hex")
-    .slice(0, 16);
+    .slice(0, 12);
+
+  const checklistId = `checklist_run.${referenceDate.replace(/-/g, "")}.${scenarioHash}`;
 
   return {
-    id: `checklist.${checklistId}`,
+    id: checklistId,
     life_event: lifeEvent,
     generated_at: new Date().toISOString(),
     graph_version: graphVersion,


### PR DESCRIPTION
## I7 + I6: Deterministic IDs and Temporal Filtering

### What
Make checklist IDs fully deterministic and implement temporal record filtering.

### Why
Previous checklist ID included new Date().toISOString() in hash, making it non-deterministic. Records should be filtered by asOfDate to exclude expired or future records.

### Changes
- **Checklist ID format**: checklist_run.<YYYYMMDD>.<scenario_hash>
- **Scenario hash**: Computed from canonical JSON of sorted facts, no timestamp
- **Temporal filtering**: Uses asOfDate option for record_valid_from/to checks
- **Fact order independence**: Same facts in different order produce same ID

### Verification
- [x] Deterministic ID test (pinned asOfDate produces same ID)
- [x] Fact order independence test
- [x] 98 tests pass