### PR TITLE
fix(sources): rename IDs to portal/publisher origin, create snapshot

### DIFF
--- a/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
+++ b/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
@@ -11,9 +11,11 @@ domain: death_registration
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "intake_fact.lu.bereavement.jurisdiction_of_death" }
+    - { "var": "death.place.country" }
     - "LU"
 missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.jurisdiction_of_death
 source_assertion_refs:
   - assertion.lu.guichet_bereavement.death_must_be_declared
 record_valid_from: "2026-06-03"

--- a/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
+++ b/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
@@ -17,7 +17,7 @@ missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.jurisdiction_of_death
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.death_must_be_declared
+  - assertion.guichet_lu.bereavement.death_must_be_declared
 record_valid_from: "2026-06-03"
 authoring_status: draft
 distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
@@ -11,9 +11,11 @@ domain: survivor_pension
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "intake_fact.lu.bereavement.deceased_pension_jurisdiction" }
+    - { "var": "deceased.pension.jurisdiction" }
     - "LU"
 missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.deceased_pension_jurisdiction
 source_assertion_refs:
   - assertion.lu.guichet_bereavement.survivor_pension_available
 record_valid_from: "2026-06-03"

--- a/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
@@ -17,7 +17,7 @@ missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.deceased_pension_jurisdiction
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.survivor_pension_available
+  - assertion.guichet_lu.bereavement.survivor_pension_available
 record_valid_from: "2026-06-03"
 authoring_status: draft
 distribution_status: public_open

--- a/graph/consequences/bereavement/lu/claim_survivor_pension.yml
+++ b/graph/consequences/bereavement/lu/claim_survivor_pension.yml
@@ -16,7 +16,7 @@ trigger:
 task_template_refs:
   - task_template.lu.bereavement.survivor_pension.file_cnap_claim
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.survivor_pension_available
+  - assertion.guichet_lu.bereavement.survivor_pension_available
 authoring_status: draft
 distribution_status: public_open
 confidence: medium

--- a/graph/consequences/bereavement/lu/declare_death.yml
+++ b/graph/consequences/bereavement/lu/declare_death.yml
@@ -16,7 +16,7 @@ trigger:
 task_template_refs:
   - task_template.lu.bereavement.death_registration.file_death_declaration
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.death_must_be_declared
+  - assertion.guichet_lu.bereavement.death_must_be_declared
 authoring_status: draft
 distribution_status: public_open
 confidence: medium

--- a/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
+++ b/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
@@ -16,7 +16,7 @@ calculation:
   calendar: civil
   if_weekend_or_holiday: unknown
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.declaration_within_24h
+  - assertion.guichet_lu.bereavement.declaration_within_24h
 record_valid_from: "2026-06-03"
 authoring_status: draft
 distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
+++ b/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
@@ -12,7 +12,7 @@ domain: death_registration
 calculation:
   kind: relative
   duration: "PT24H"
-  starts_from_fact: intake_fact.lu.bereavement.date_of_death
+  starts_from_fact: intake_fact.global.bereavement.date_of_death
   calendar: civil
   if_weekend_or_holiday: unknown
 source_assertion_refs:

--- a/graph/intake_fact_types/bereavement/date_of_death.yml
+++ b/graph/intake_fact_types/bereavement/date_of_death.yml
@@ -1,6 +1,6 @@
-id: intake_fact.lu.bereavement.date_of_death
+id: intake_fact.global.bereavement.date_of_death
 schema_version: "0.1.0"
-path: date_of_death
+path: death.date
 label: "Date of death"
 description: "The date when the death occurred. Used for deadline calculations."
 value_type: date

--- a/graph/intake_fact_types/bereavement/deceased_pension_jurisdiction.yml
+++ b/graph/intake_fact_types/bereavement/deceased_pension_jurisdiction.yml
@@ -1,6 +1,6 @@
-id: intake_fact.lu.bereavement.deceased_pension_jurisdiction
+id: intake_fact.global.bereavement.deceased_pension_jurisdiction
 schema_version: "0.1.0"
-path: deceased_pension_jurisdiction
+path: deceased.pension.jurisdiction
 label: "Pension jurisdiction of the deceased"
 description: "Which country's pension system the deceased was insured under."
 value_type: jurisdiction_code

--- a/graph/intake_fact_types/bereavement/jurisdiction_of_death.yml
+++ b/graph/intake_fact_types/bereavement/jurisdiction_of_death.yml
@@ -1,6 +1,6 @@
-id: intake_fact.lu.bereavement.jurisdiction_of_death
+id: intake_fact.global.bereavement.jurisdiction_of_death
 schema_version: "0.1.0"
-path: jurisdiction_of_death
+path: death.place.country
 label: "Country where the death occurred"
 description: "ISO 3166-1 alpha-2 code for the jurisdiction where the death took place."
 value_type: jurisdiction_code

--- a/graph/task_templates/bereavement/lu/file_cnap_claim.yml
+++ b/graph/task_templates/bereavement/lu/file_cnap_claim.yml
@@ -24,7 +24,7 @@ evidence_requirements:
         - evidence_type.lu.death_certificate
         - evidence_type.lu.marriage_certificate
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.survivor_pension_available
+  - assertion.guichet_lu.bereavement.survivor_pension_available
 rendering:
   checklist_group: money_and_benefits
   urgency_score: 70

--- a/graph/task_templates/bereavement/lu/file_death_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_death_declaration.yml
@@ -27,7 +27,7 @@ evidence_requirements:
         - evidence_type.lu.medical_death_certificate
         - evidence_type.lu.identity_document_deceased
 source_assertion_refs:
-  - assertion.lu.guichet_bereavement.death_must_be_declared
+  - assertion.guichet_lu.bereavement.death_must_be_declared
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 95

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,12 +10,12 @@
   },
   "scripts": {
     "build": "tsc",
-    "validate": "node --loader ts-node/esm src/index.ts validate",
-    "lint-ids": "node --loader ts-node/esm src/index.ts lint-ids",
-    "check-references": "node --loader ts-node/esm src/index.ts check-references",
-    "build-checklist": "node --loader ts-node/esm src/index.ts build-checklist",
-    "export-json": "node --loader ts-node/esm src/index.ts export-json",
-    "export-web": "node --loader ts-node/esm src/index.ts export-web"
+    "validate": "tsx src/index.ts validate",
+    "lint-ids": "tsx src/index.ts lint-ids",
+    "check-references": "tsx src/index.ts check-references",
+    "build-checklist": "tsx src/index.ts build-checklist",
+    "export-json": "tsx src/index.ts export-json",
+    "export-web": "tsx src/index.ts export-web"
   },
   "dependencies": {
     "ajv": "^8.17.1",
@@ -25,6 +25,6 @@
     "@clarvia/generator": "workspace:*"
   },
   "devDependencies": {
-    "ts-node": "^10.9.2"
+    "tsx": "^4.19.4"
   }
 }

--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -114,9 +114,10 @@ export async function main(): Promise<void> {
 
   // Also output as YAML
   const yamlOutput = JSON.stringify(output, null, 2);
-  const outputPath = resolve(rootDir, ".clarvia-output", "last-checklist.json");
+  const outputDir = resolve(rootDir, "build", "exports", "checklist");
+  const outputPath = resolve(outputDir, "last-checklist.json");
   const { mkdirSync, writeFileSync } = await import("node:fs");
-  mkdirSync(resolve(rootDir, ".clarvia-output"), { recursive: true });
+  mkdirSync(outputDir, { recursive: true });
   writeFileSync(outputPath, yamlOutput);
   console.log(`Full output saved to: ${outputPath}`);
 }

--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -58,7 +58,7 @@ export async function main(): Promise<void> {
   );
 
   console.log(`\nGenerating checklist for life_event="${lifeEvent}" with ${facts.length} facts...`);
-  const output = await generateChecklist({ graph, facts, lifeEvent });
+  const output = generateChecklist({ graph, facts, lifeEvent });
 
   console.log(`\n${"═".repeat(60)}`);
   console.log(` CHECKLIST: ${lifeEvent}`);

--- a/packages/cli/src/commands/export-json.ts
+++ b/packages/cli/src/commands/export-json.ts
@@ -57,7 +57,7 @@ export async function main(): Promise<void> {
     intake_fact_types: mapToArray(graph.intakeFactTypes),
   };
 
-  const outDir = resolve(rootDir, ".clarvia-output");
+  const outDir = resolve(rootDir, "build", "exports", "json");
   mkdirSync(outDir, { recursive: true });
 
   const outPath = resolve(outDir, "graph-export.json");

--- a/packages/cli/src/commands/export-web.ts
+++ b/packages/cli/src/commands/export-web.ts
@@ -32,7 +32,7 @@ export async function main(): Promise<void> {
   const pkgRaw = readFileSync(resolve(rootDir, "package.json"), "utf-8");
   const pkg = JSON.parse(pkgRaw) as { version: string };
 
-  const webDir = resolve(rootDir, ".clarvia-output", "web");
+  const webDir = resolve(rootDir, "build", "exports", "web");
 
   // Discover life events from consequences
   const lifeEvents = new Set<string>();

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -8,7 +8,6 @@
   "main": "./src/index.ts",
   "dependencies": {
     "yaml": "^2.7.1",
-    "glob": "^11.0.2",
-    "json-logic-js": "^2.0.5"
+    "glob": "^11.0.2"
   }
 }

--- a/packages/generator/src/evaluator.test.ts
+++ b/packages/generator/src/evaluator.test.ts
@@ -1,71 +1,534 @@
 import { describe, it, expect } from "vitest";
-import { evaluateCondition, type Fact } from "./evaluator.js";
+import { evaluateCondition, type Fact, type TriValue } from "./evaluator.js";
 
-describe("evaluateCondition", () => {
-  const luDeathExpression = {
-    "==": [
-      { var: "intake_fact.lu.bereavement.jurisdiction_of_death" },
-      "LU",
-    ],
-  };
+describe("evaluateCondition — native three-valued evaluator", () => {
+  // ── Helper ──────────────────────────────────────────────────────
+  function eval_(
+    expression: object,
+    facts: Fact[],
+  ): { result: TriValue; missingFacts: string[] } {
+    return evaluateCondition(expression, facts);
+  }
 
-  it("returns true when fact matches", async () => {
-    const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
-    ];
+  // ── var resolution ──────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("true");
-    expect(missingFacts).toHaveLength(0);
+  describe("var resolution", () => {
+    it("resolves dot-path variables", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("missing var returns unknown", () => {
+      const { result, missingFacts } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+      expect(missingFacts).toContain("death.place.country");
+    });
+
+    it("partially missing path returns unknown", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place", value: "test" }],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns false when fact does not match", async () => {
-    const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
-    ];
+  // ── == operator ─────────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("false");
-    expect(missingFacts).toHaveLength(0);
+  describe("== operator", () => {
+    it("returns true when values match", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when values don't match", () => {
+      const { result } = eval_(
+        { "==": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "DE" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("unknown == value → unknown", () => {
+      const { result } = eval_(
+        { "==": [{ var: "missing" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("value == unknown → unknown", () => {
+      const { result } = eval_(
+        { "==": ["LU", { var: "missing" }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns unknown when fact is missing", async () => {
-    const facts: Fact[] = [];
+  // ── != operator ─────────────────────────────────────────────────
 
-    const { result, missingFacts } = await evaluateCondition(luDeathExpression, facts);
-    expect(result).toBe("unknown");
-    expect(missingFacts).toContain("intake_fact.lu.bereavement.jurisdiction_of_death");
+  describe("!= operator", () => {
+    it("returns true when values differ", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "DE" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("returns false when values match", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "death.place.country" }, "LU"] },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("unknown != value → unknown", () => {
+      const { result } = eval_(
+        { "!=": [{ var: "missing" }, "LU"] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("handles nested expressions", async () => {
-    const andExpression = {
-      and: [
-        { "==": [{ var: "a" }, 1] },
-        { "==": [{ var: "b" }, 2] },
-      ],
-    };
+  // ── and operator — three-valued truth table ─────────────────────
 
-    const facts: Fact[] = [
-      { fact_type: "a", value: 1 },
-      { fact_type: "b", value: 2 },
-    ];
+  describe("and operator — three-valued", () => {
+    it("and(true, true) → true", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
 
-    const { result } = await evaluateCondition(andExpression, facts);
-    expect(result).toBe("true");
+    it("and(true, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(false, true) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(false, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(true, unknown) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }], // b is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("and(unknown, true) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 2 }], // a is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("and(false, unknown) → false (short-circuit!)", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }], // a is false, b is missing
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(unknown, false) → false", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 999 }], // a is missing, b is false
+      );
+      expect(result).toBe(false);
+    });
+
+    it("and(unknown, unknown) → unknown", () => {
+      const { result } = eval_(
+        { and: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
   });
 
-  it("returns unknown when one nested var is missing", async () => {
-    const andExpression = {
-      and: [
-        { "==": [{ var: "a" }, 1] },
-        { "==": [{ var: "b" }, 2] },
-      ],
-    };
+  // ── or operator — three-valued truth table ──────────────────────
 
-    const facts: Fact[] = [{ fact_type: "a", value: 1 }];
+  describe("or operator — three-valued", () => {
+    it("or(true, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
 
-    const { result, missingFacts } = await evaluateCondition(andExpression, facts);
-    expect(result).toBe("unknown");
-    expect(missingFacts).toContain("b");
+    it("or(true, false) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 2 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, false) → false", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }, { fact_type: "b", value: 999 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("or(true, unknown) → true (short-circuit!)", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 1 }], // b is missing
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(unknown, true) → true", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 2 }], // a is missing
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(false, unknown) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "a", value: 999 }], // a is false, b is missing
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("or(unknown, false) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [{ fact_type: "b", value: 999 }], // a is missing, b is false
+      );
+      expect(result).toBe("unknown");
+    });
+
+    it("or(unknown, unknown) → unknown", () => {
+      const { result } = eval_(
+        { or: [{ "==": [{ var: "a" }, 1] }, { "==": [{ var: "b" }, 2] }] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── ! (not) operator ────────────────────────────────────────────
+
+  describe("! (not) operator", () => {
+    it("!(true) → false", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [{ fact_type: "a", value: 1 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("!(false) → true", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [{ fact_type: "a", value: 999 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("!(unknown) → unknown", () => {
+      const { result } = eval_(
+        { "!": [{ "==": [{ var: "a" }, 1] }] },
+        [], // a is missing
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── exists operator ─────────────────────────────────────────────
+
+  describe("exists operator", () => {
+    it("exists(present) → true", () => {
+      const { result } = eval_(
+        { exists: "death.date" },
+        [{ fact_type: "death.date", value: "2026-05-20" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("exists(missing) → false", () => {
+      const { result } = eval_(
+        { exists: "death.date" },
+        [],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("exists does not contribute to missingFacts", () => {
+      const { missingFacts } = eval_(
+        { exists: "death.date" },
+        [],
+      );
+      expect(missingFacts).toHaveLength(0);
+    });
+  });
+
+  // ── in operator ─────────────────────────────────────────────────
+
+  describe("in operator", () => {
+    it("in(value, array) → true when found", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [{ fact_type: "country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("in(value, array) → false when not found", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [{ fact_type: "country", value: "US" }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("in(missing, array) → unknown", () => {
+      const { result } = eval_(
+        { in: [{ var: "country" }, ["LU", "DE", "FR"]] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── Comparison operators ────────────────────────────────────────
+
+  describe("comparison operators", () => {
+    it("> returns true when left > right", () => {
+      const { result } = eval_(
+        { ">": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 70 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("> returns false when left <= right", () => {
+      const { result } = eval_(
+        { ">": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 30 }],
+      );
+      expect(result).toBe(false);
+    });
+
+    it(">= returns true when equal", () => {
+      const { result } = eval_(
+        { ">=": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 50 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("< returns true when left < right", () => {
+      const { result } = eval_(
+        { "<": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 30 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("<= returns true when equal", () => {
+      const { result } = eval_(
+        { "<=": [{ var: "score" }, 50] },
+        [{ fact_type: "score", value: 50 }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("comparison with missing var → unknown", () => {
+      const { result } = eval_(
+        { ">": [{ var: "missing" }, 50] },
+        [],
+      );
+      expect(result).toBe("unknown");
+    });
+  });
+
+  // ── Nested expressions ──────────────────────────────────────────
+
+  describe("nested expressions", () => {
+    it("and(== country LU, exists date) — both present", () => {
+      const { result } = eval_(
+        {
+          and: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { exists: "death.date" },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "LU" },
+          { fact_type: "death.date", value: "2026-05-20" },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("and(== country LU, exists date) — date missing", () => {
+      const { result } = eval_(
+        {
+          and: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { exists: "death.date" },
+          ],
+        },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      // exists(missing) → false, so and(true, false) → false
+      expect(result).toBe(false);
+    });
+
+    it("or(== country LU, == residence LU) — first matches", () => {
+      const { result } = eval_(
+        {
+          or: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+          ],
+        },
+        [{ fact_type: "death.place.country", value: "LU" }],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("or(== country LU, == residence LU) — neither matches", () => {
+      const { result } = eval_(
+        {
+          or: [
+            { "==": [{ var: "death.place.country" }, "LU"] },
+            { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "DE" },
+          { fact_type: "deceased.habitual_residence.country", value: "DE" },
+        ],
+      );
+      expect(result).toBe(false);
+    });
+
+    it("deeply nested: and(or(...), ==, exists)", () => {
+      const { result } = eval_(
+        {
+          and: [
+            {
+              or: [
+                { "==": [{ var: "death.place.country" }, "LU"] },
+                { "==": [{ var: "deceased.habitual_residence.country" }, "LU"] },
+              ],
+            },
+            { "==": [{ var: "relationship.to_deceased" }, "surviving_spouse"] },
+            { exists: "death.date" },
+          ],
+        },
+        [
+          { fact_type: "death.place.country", value: "DE" },
+          { fact_type: "deceased.habitual_residence.country", value: "LU" },
+          { fact_type: "relationship.to_deceased", value: "surviving_spouse" },
+          { fact_type: "death.date", value: "2026-05-20" },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── Backward compatibility ──────────────────────────────────────
+
+  describe("backward compatibility with old-style fact paths", () => {
+    it("still works with long intake_fact paths (pre-migration)", () => {
+      const { result } = eval_(
+        {
+          "==": [
+            { var: "intake_fact.lu.bereavement.jurisdiction_of_death" },
+            "LU",
+          ],
+        },
+        [
+          {
+            fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death",
+            value: "LU",
+          },
+        ],
+      );
+      expect(result).toBe(true);
+    });
+  });
+
+  // ── missingFacts reporting ──────────────────────────────────────
+
+  describe("missingFacts reporting", () => {
+    it("reports all missing vars", () => {
+      const { missingFacts } = eval_(
+        {
+          and: [
+            { "==": [{ var: "a.b" }, 1] },
+            { "==": [{ var: "c.d" }, 2] },
+          ],
+        },
+        [],
+      );
+      expect(missingFacts).toContain("a.b");
+      expect(missingFacts).toContain("c.d");
+    });
+
+    it("does not report present vars", () => {
+      const { missingFacts } = eval_(
+        {
+          and: [
+            { "==": [{ var: "a" }, 1] },
+            { "==": [{ var: "b" }, 2] },
+          ],
+        },
+        [{ fact_type: "a", value: 1 }],
+      );
+      expect(missingFacts).toContain("b");
+      expect(missingFacts).not.toContain("a");
+    });
   });
 });

--- a/packages/generator/src/evaluator.ts
+++ b/packages/generator/src/evaluator.ts
@@ -1,34 +1,30 @@
 /**
- * Three-valued condition evaluator.
+ * Clarvia native three-valued condition evaluator.
  *
- * Evaluates JsonLogic expressions against intake facts.
- * Returns "true", "false", or "unknown" (when a required fact is missing).
+ * Evaluates a JsonLogic-subset expression against scenario facts.
+ * Returns true, false, or "unknown" — unknown is NEVER collapsed to false.
  *
- * Per spec §6: missing_fact_behavior is always "unknown".
+ * Supported operators (v0.1 alpha):
+ *   var, ==, !=, and, or, !, exists, in, >, >=, <, <=
+ *
+ * Three-valued truth table:
+ *   missing var                   → "unknown"
+ *   unknown == value              → "unknown"
+ *   unknown != value              → "unknown"
+ *   and(false, anything)          → false   (short-circuit)
+ *   and(true, unknown)            → "unknown"
+ *   or(true, anything)            → true    (short-circuit)
+ *   or(false, unknown)            → "unknown"
+ *   !(unknown)                    → "unknown"
+ *   exists(missing)               → false
+ *   exists(present)               → true
+ *
+ * Per spec §6.2: missing_fact_behavior is always "unknown".
  */
 
-// json-logic-js is CJS-only — handle interop carefully
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _cachedJL: any = null;
+// ── Types ────────────────────────────────────────────────────────────
 
-async function getJsonLogic() {
-  if (_cachedJL) return _cachedJL;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mod: any = await import("json-logic-js");
-  // CJS interop: check for is_logic (a json-logic-specific method)
-  if (mod.default?.is_logic) {
-    _cachedJL = mod.default;
-  } else if (mod.is_logic) {
-    _cachedJL = mod;
-  } else {
-    // Fallback: try module.exports key from Node CJS interop
-    const me = mod["module.exports"];
-    _cachedJL = me?.is_logic ? me : mod.default ?? mod;
-  }
-  return _cachedJL;
-}
-
-export type TriValue = "true" | "false" | "unknown";
+export type TriValue = true | false | "unknown";
 
 export interface Fact {
   fact_type: string;
@@ -36,14 +32,48 @@ export interface Fact {
   confidence?: string;
 }
 
+// Sentinel value for missing/unresolved variables
+const MISSING = Symbol("MISSING");
+
+// ── Var resolution ───────────────────────────────────────────────────
+
 /**
- * Build a nested data object for JsonLogic evaluation from user facts.
- *
- * json-logic-js uses dots for nested property access, so we convert
- * flat fact_type IDs like "intake_fact.lu.bereavement.jurisdiction_of_death"
- * into nested objects: { intake_fact: { lu: { bereavement: { jurisdiction_of_death: "LU" } } } }
+ * Resolve a dot-path variable from nested data.
+ * Returns MISSING if the path cannot be resolved.
  */
-function buildFactData(facts: Fact[]): Record<string, unknown> {
+function resolveVar(
+  varName: string,
+  data: Record<string, unknown>,
+): unknown {
+  const parts = varName.split(".");
+  let current: unknown = data;
+  for (const part of parts) {
+    if (
+      current === null ||
+      current === undefined ||
+      typeof current !== "object"
+    ) {
+      return MISSING;
+    }
+    if (!(part in (current as Record<string, unknown>))) {
+      return MISSING;
+    }
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current === undefined ? MISSING : current;
+}
+
+// ── Build fact data ──────────────────────────────────────────────────
+
+/**
+ * Build a nested data object from flat fact entries.
+ *
+ * Converts:
+ *   [{ fact_type: "death.place.country", value: "LU" }]
+ * Into:
+ *   { death: { place: { country: "LU" } } }
+ */
+export function buildFactData(facts: Fact[]): Record<string, unknown> {
   const data: Record<string, unknown> = {};
   for (const f of facts) {
     const parts = f.fact_type.split(".");
@@ -60,29 +90,167 @@ function buildFactData(facts: Fact[]): Record<string, unknown> {
   return data;
 }
 
+// ── Core recursive evaluator ─────────────────────────────────────────
+
 /**
- * Check if all "var" references in a JsonLogic expression have values.
- * If any var resolves to undefined, the fact is missing.
+ * Evaluate a JsonLogic-subset expression against nested data.
+ *
+ * Returns:
+ *   - A concrete value (string, number, boolean, array, etc.)
+ *   - MISSING sentinel if a variable cannot be resolved
+ *
+ * The top-level evaluateCondition() converts this to a TriValue.
  */
-function findMissingVars(
+function evaluate(
+  expression: unknown,
+  data: Record<string, unknown>,
+): unknown {
+  // Primitives pass through
+  if (expression === null || expression === undefined) return expression;
+  if (typeof expression !== "object") return expression;
+  if (Array.isArray(expression)) return expression;
+
+  const obj = expression as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length !== 1) return expression;
+
+  const op = keys[0];
+  const rawArgs = obj[op];
+
+  // ── var ────────────────────────────────────────────────────────
+  if (op === "var") {
+    const varName = rawArgs as string;
+    return resolveVar(varName, data);
+  }
+
+  // ── exists ─────────────────────────────────────────────────────
+  if (op === "exists") {
+    const varName = rawArgs as string;
+    const resolved = resolveVar(varName, data);
+    return resolved !== MISSING;
+  }
+
+  // Ensure args is an array
+  const args = Array.isArray(rawArgs) ? rawArgs : [rawArgs];
+
+  // ── ! (not) ────────────────────────────────────────────────────
+  if (op === "!" || op === "not") {
+    const val = evaluate(args[0], data);
+    if (val === MISSING) return MISSING;
+    return !val;
+  }
+
+  // ── and ────────────────────────────────────────────────────────
+  // Three-valued: and(false, anything) → false (short-circuit)
+  //               and(true, unknown) → unknown
+  if (op === "and") {
+    let hasMissing = false;
+    for (const arg of args) {
+      const val = evaluate(arg, data);
+      if (val === MISSING) {
+        hasMissing = true;
+        continue; // don't short-circuit — keep checking for false
+      }
+      if (!val) return false; // false short-circuits
+    }
+    if (hasMissing) return MISSING;
+    return true;
+  }
+
+  // ── or ─────────────────────────────────────────────────────────
+  // Three-valued: or(true, anything) → true (short-circuit)
+  //               or(false, unknown) → unknown
+  if (op === "or") {
+    let hasMissing = false;
+    for (const arg of args) {
+      const val = evaluate(arg, data);
+      if (val === MISSING) {
+        hasMissing = true;
+        continue;
+      }
+      if (val) return true; // true short-circuits
+    }
+    if (hasMissing) return MISSING;
+    return false;
+  }
+
+  // ── == ─────────────────────────────────────────────────────────
+  if (op === "==" || op === "===") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    // Use loose equality for "==" per JsonLogic convention
+    return left == right;
+  }
+
+  // ── != ─────────────────────────────────────────────────────────
+  if (op === "!=" || op === "!==") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return left != right;
+  }
+
+  // ── > ──────────────────────────────────────────────────────────
+  if (op === ">") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) > (right as number);
+  }
+
+  // ── >= ─────────────────────────────────────────────────────────
+  if (op === ">=") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) >= (right as number);
+  }
+
+  // ── < ──────────────────────────────────────────────────────────
+  if (op === "<") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) < (right as number);
+  }
+
+  // ── <= ─────────────────────────────────────────────────────────
+  if (op === "<=") {
+    const left = evaluate(args[0], data);
+    const right = evaluate(args[1], data);
+    if (left === MISSING || right === MISSING) return MISSING;
+    return (left as number) <= (right as number);
+  }
+
+  // ── in ─────────────────────────────────────────────────────────
+  if (op === "in") {
+    const needle = evaluate(args[0], data);
+    const haystack = evaluate(args[1], data);
+    if (needle === MISSING || haystack === MISSING) return MISSING;
+    if (Array.isArray(haystack)) {
+      return haystack.includes(needle);
+    }
+    if (typeof haystack === "string" && typeof needle === "string") {
+      return haystack.includes(needle);
+    }
+    return false;
+  }
+
+  // Unknown operator — treat as unknown
+  return MISSING;
+}
+
+// ── Find missing vars ────────────────────────────────────────────────
+
+/**
+ * Walk the expression tree and collect all var paths that don't resolve.
+ */
+export function findMissingVars(
   expression: unknown,
   data: Record<string, unknown>,
 ): string[] {
   const missing: string[] = [];
-
-  function resolveVar(varName: string): boolean {
-    const parts = varName.split(".");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let current: any = data;
-    for (const part of parts) {
-      if (current === null || current === undefined || typeof current !== "object") {
-        return false;
-      }
-      if (!(part in current)) return false;
-      current = current[part];
-    }
-    return current !== undefined;
-  }
 
   function walk(node: unknown): void {
     if (node === null || node === undefined) return;
@@ -95,13 +263,29 @@ function findMissingVars(
 
     const obj = node as Record<string, unknown>;
     const keys = Object.keys(obj);
-    if (keys.length === 1 && keys[0] === "var") {
-      const varName = obj["var"] as string;
-      if (!resolveVar(varName)) {
+    if (keys.length !== 1) return;
+
+    const op = keys[0];
+    const rawArgs = obj[op];
+
+    if (op === "var") {
+      const varName = rawArgs as string;
+      if (resolveVar(varName, data) === MISSING) {
         missing.push(varName);
       }
-    } else {
-      for (const v of Object.values(obj)) walk(v);
+      return;
+    }
+
+    if (op === "exists") {
+      // exists doesn't contribute to "missing" — it explicitly tests presence
+      return;
+    }
+
+    // Walk children
+    if (Array.isArray(rawArgs)) {
+      for (const item of rawArgs) walk(item);
+    } else if (rawArgs && typeof rawArgs === "object") {
+      walk(rawArgs);
     }
   }
 
@@ -109,34 +293,33 @@ function findMissingVars(
   return missing;
 }
 
+// ── Public API ───────────────────────────────────────────────────────
+
 /**
  * Evaluate a condition's JsonLogic expression against user facts.
  *
  * Returns:
- * - "true" if the expression evaluates to truthy and all vars are present
- * - "false" if the expression evaluates to falsy and all vars are present
- * - "unknown" if any required var is missing
+ *   - result: true if the expression evaluates to truthy and all vars are present
+ *   - result: false if the expression evaluates to falsy and all vars are present
+ *   - result: "unknown" if any required var is missing
+ *   - missingFacts: list of var paths that could not be resolved
+ *
+ * This function is synchronous — no external library dependency.
  */
-export async function evaluateCondition(
+export function evaluateCondition(
   expression: object,
   facts: Fact[],
-): Promise<{ result: TriValue; missingFacts: string[] }> {
+): { result: TriValue; missingFacts: string[] } {
   const data = buildFactData(facts);
   const missingFacts = findMissingVars(expression, data);
+  const rawResult = evaluate(expression, data);
 
-  if (missingFacts.length > 0) {
+  if (rawResult === MISSING) {
     return { result: "unknown", missingFacts };
   }
 
-  try {
-    const jsonLogic = await getJsonLogic();
-    const result = jsonLogic.apply(expression, data);
-    return {
-      result: result ? "true" : "false",
-      missingFacts: [],
-    };
-  } catch {
-    // If JsonLogic evaluation fails, treat as unknown
-    return { result: "unknown", missingFacts: [] };
-  }
+  return {
+    result: rawResult ? true : false,
+    missingFacts: [],
+  };
 }

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -10,9 +10,9 @@ describe("generateChecklist", () => {
   it("generates a checklist for LU core bereavement — all facts present", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
-      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
-      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "death.date", value: "2026-01-15" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -48,8 +48,8 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       // No jurisdiction fact provided
-      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
-      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+      { fact_type: "death.date", value: "2026-01-15" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -68,7 +68,7 @@ describe("generateChecklist", () => {
 
     expect(deathItem?.status).toBe("needs_fact");
     expect(deathItem?.missing_fact_refs).toContain(
-      "intake_fact.lu.bereavement.jurisdiction_of_death",
+      "death.place.country",
     );
     expect(pensionItem?.status).toBe("applies");
   });
@@ -76,7 +76,7 @@ describe("generateChecklist", () => {
   it("filters out consequences for non-matching life events", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -91,9 +91,9 @@ describe("generateChecklist", () => {
   it("returns does_not_apply when condition is false (death in DE, not LU)", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
-      { fact_type: "intake_fact.lu.bereavement.date_of_death", value: "2026-01-15" },
-      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "DE" },
+      { fact_type: "death.place.country", value: "DE" },
+      { fact_type: "death.date", value: "2026-01-15" },
+      { fact_type: "deceased.pension.jurisdiction", value: "DE" },
     ];
 
     const output = generateChecklist({
@@ -109,8 +109,8 @@ describe("generateChecklist", () => {
   it("output has correct structure", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
-      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -131,8 +131,8 @@ describe("generateChecklist", () => {
   it("produces deterministic item IDs for same consequence+task pair", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
-      { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
-      { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
     const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -7,7 +7,7 @@ import type { Fact } from "./evaluator.js";
 const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..");
 
 describe("generateChecklist", () => {
-  it("generates a checklist for LU core bereavement — all facts present", async () => {
+  it("generates a checklist for LU core bereavement — all facts present", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
@@ -15,7 +15,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -44,7 +44,7 @@ describe("generateChecklist", () => {
     );
   });
 
-  it("handles missing facts — death jurisdiction unknown", async () => {
+  it("handles missing facts — death jurisdiction unknown", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       // No jurisdiction fact provided
@@ -52,7 +52,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -73,13 +73,13 @@ describe("generateChecklist", () => {
     expect(pensionItem?.status).toBe("applies");
   });
 
-  it("filters out consequences for non-matching life events", async () => {
+  it("filters out consequences for non-matching life events", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "marriage", // no records for this
@@ -88,7 +88,7 @@ describe("generateChecklist", () => {
     expect(output.items.length).toBe(0);
   });
 
-  it("returns does_not_apply when condition is false (death in DE, not LU)", async () => {
+  it("returns does_not_apply when condition is false (death in DE, not LU)", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "DE" },
@@ -96,7 +96,7 @@ describe("generateChecklist", () => {
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "DE" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -106,14 +106,14 @@ describe("generateChecklist", () => {
     expect(output.items.length).toBe(0);
   });
 
-  it("output has correct structure", async () => {
+  it("output has correct structure", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output = await generateChecklist({
+    const output = generateChecklist({
       graph,
       facts,
       lifeEvent: "bereavement",
@@ -128,15 +128,15 @@ describe("generateChecklist", () => {
     expect(output.sections.length).toBeGreaterThan(0);
   });
 
-  it("produces deterministic item IDs for same consequence+task pair", async () => {
+  it("produces deterministic item IDs for same consequence+task pair", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "intake_fact.lu.bereavement.jurisdiction_of_death", value: "LU" },
       { fact_type: "intake_fact.lu.bereavement.deceased_pension_jurisdiction", value: "LU" },
     ];
 
-    const output1 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
-    const output2 = await generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
 
     // Item IDs should be deterministic (same inputs → same IDs)
     expect(output1.items.map((i) => i.id)).toEqual(

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -119,7 +119,7 @@ describe("generateChecklist", () => {
       lifeEvent: "bereavement",
     });
 
-    expect(output.id).toMatch(/^checklist\./);
+    expect(output.id).toMatch(/^checklist_run\./);
     expect(output.life_event).toBe("bereavement");
     expect(output.generated_at).toBeTruthy();
     expect(output.graph_version).toBe("0.1.0");
@@ -128,19 +128,40 @@ describe("generateChecklist", () => {
     expect(output.sections.length).toBeGreaterThan(0);
   });
 
-  it("produces deterministic item IDs for same consequence+task pair", () => {
+  it("produces fully deterministic checklist + item IDs for same inputs", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
       { fact_type: "deceased.pension.jurisdiction", value: "LU" },
     ];
 
-    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
-    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement" });
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
 
-    // Item IDs should be deterministic (same inputs → same IDs)
+    // Checklist ID should be fully deterministic (no timestamp in hash)
+    expect(output1.id).toBe(output2.id);
+    expect(output1.id).toMatch(/^checklist_run\.20260603\./);
+
+    // Item IDs should also be deterministic
     expect(output1.items.map((i) => i.id)).toEqual(
       output2.items.map((i) => i.id),
     );
+  });
+
+  it("same facts in different order produce same checklist ID", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts1: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+    const facts2: Fact[] = [
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "death.place.country", value: "LU" },
+    ];
+
+    const output1 = generateChecklist({ graph, facts: facts1, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts: facts2, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    expect(output1.id).toBe(output2.id);
   });
 });

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -21,6 +21,9 @@ import type {
 } from "./loader.js";
 import { evaluateCondition, type Fact, type TriValue } from "./evaluator.js";
 
+// Re-export types for convenience
+export type { Fact } from "./evaluator.js";
+
 // ── Output types ─────────────────────────────────────────────────────
 
 export type ItemStatus =
@@ -129,14 +132,9 @@ function conditionResultToStatus(
   result: TriValue,
   missingFacts: string[],
 ): ItemStatus {
-  switch (result) {
-    case "true":
-      return "applies";
-    case "false":
-      return "does_not_apply";
-    case "unknown":
-      return missingFacts.length > 0 ? "needs_fact" : "maybe_applies";
-  }
+  if (result === true) return "applies";
+  if (result === false) return "does_not_apply";
+  return missingFacts.length > 0 ? "needs_fact" : "maybe_applies";
 }
 
 // ── Generate options ─────────────────────────────────────────────────
@@ -152,7 +150,7 @@ export interface GenerateOptions {
 
 // ── The 6-step algorithm ─────────────────────────────────────────────
 
-export async function generateChecklist(opts: GenerateOptions): Promise<ChecklistOutput> {
+export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
   const {
     graph,
     facts,
@@ -181,7 +179,7 @@ export async function generateChecklist(opts: GenerateOptions): Promise<Checklis
 
     // Evaluate all trigger conditions (AND logic)
     const conditionRefs = consequence.trigger?.condition_refs ?? [];
-    let overallResult: TriValue = "true";
+    let overallResult: TriValue = true;
     const allMissingFacts: string[] = [];
 
     for (const condRef of conditionRefs) {
@@ -192,26 +190,26 @@ export async function generateChecklist(opts: GenerateOptions): Promise<Checklis
         continue;
       }
 
-      const { result, missingFacts } = await evaluateCondition(
+      const { result, missingFacts } = evaluateCondition(
         condition.expression,
         facts,
       );
 
       allMissingFacts.push(...missingFacts);
 
-      if (result === "false") {
-        overallResult = "false";
+      if (result === false) {
+        overallResult = false;
         break; // short-circuit: one false → whole trigger is false
       }
       if (result === "unknown") {
         overallResult = "unknown";
-        // don't break — keep checking for explicit "false"
+        // don't break — keep checking for explicit false
       }
     }
 
     // If no conditions at all, consequence always applies
     if (conditionRefs.length === 0) {
-      overallResult = "true";
+      overallResult = true;
     }
 
     // Step 4: Expand into checklist items via task templates

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -157,7 +157,11 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     lifeEvent,
     graphVersion = "0.1.0",
     graphCommit = null,
+    asOfDate,
   } = opts;
+
+  // Determine reference date for temporal filtering
+  const referenceDate = asOfDate ?? new Date().toISOString().slice(0, 10);
 
   const items: ChecklistItem[] = [];
 
@@ -172,7 +176,15 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     // For alpha, skip only explicitly expired records
     if (
       consequence.record_valid_to &&
-      consequence.record_valid_to < new Date().toISOString().slice(0, 10)
+      consequence.record_valid_to < referenceDate
+    ) {
+      continue;
+    }
+
+    // Skip records that haven't started yet
+    if (
+      consequence.record_valid_from &&
+      consequence.record_valid_from > referenceDate
     ) {
       continue;
     }
@@ -290,13 +302,19 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     }
   }
 
-  const checklistId = createHash("sha256")
-    .update(`${lifeEvent}::${JSON.stringify(facts)}::${new Date().toISOString()}`)
+  // Deterministic checklist ID: hash of lifeEvent + canonical facts (no timestamp)
+  const canonicalFacts = JSON.stringify(
+    [...facts].sort((a, b) => a.fact_type.localeCompare(b.fact_type)),
+  );
+  const scenarioHash = createHash("sha256")
+    .update(`${lifeEvent}::${canonicalFacts}`)
     .digest("hex")
-    .slice(0, 16);
+    .slice(0, 12);
+
+  const checklistId = `checklist_run.${referenceDate.replace(/-/g, "")}.${scenarioHash}`;
 
   return {
-    id: `checklist.${checklistId}`,
+    id: checklistId,
     life_event: lifeEvent,
     generated_at: new Date().toISOString(),
     graph_version: graphVersion,

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -5,6 +5,7 @@
  * - loadGraph(rootDir)  — load all YAML records from disk
  * - generateChecklist() — run the 6-step algorithm
  * - evaluateCondition() — three-valued condition evaluation
+ * - buildFactData()     — convert facts to nested data object
  */
 
 export { loadGraph } from "./loader.js";
@@ -13,5 +14,5 @@ export type { LoadedGraph, Consequence, TaskTemplate, Condition } from "./loader
 export { generateChecklist } from "./generator.js";
 export type { ChecklistOutput, ChecklistItem, GenerateOptions, ItemStatus } from "./generator.js";
 
-export { evaluateCondition } from "./evaluator.js";
+export { evaluateCondition, buildFactData } from "./evaluator.js";
 export type { Fact, TriValue } from "./evaluator.js";

--- a/packages/generator/src/json-logic-js.d.ts
+++ b/packages/generator/src/json-logic-js.d.ts
@@ -1,8 +1,0 @@
-declare module "json-logic-js" {
-  interface JsonLogic {
-    apply(logic: object, data?: Record<string, unknown>): unknown;
-    add_operation(name: string, fn: (...args: unknown[]) => unknown): void;
-  }
-  const jsonLogic: JsonLogic;
-  export default jsonLogic;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 8.60.1(eslint@10.4.1)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(yaml@2.9.0))
+        version: 4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/cli:
     dependencies:
@@ -48,9 +48,9 @@ importers:
         specifier: ^2.7.1
         version: 2.9.0
     devDependencies:
-      ts-node:
-        specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.9.1)(typescript@6.0.3)
+      tsx:
+        specifier: ^4.19.4
+        version: 4.22.4
 
   packages/generator:
     dependencies:
@@ -63,10 +63,6 @@ importers:
 
 packages:
 
-  '@cspotcode/source-map-support@0.8.1':
-    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
-    engines: {node: '>=12'}
-
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -75,6 +71,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -139,15 +291,8 @@ packages:
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
     engines: {node: '>=18'}
 
-  '@jridgewell/resolve-uri@3.1.2':
-    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -252,18 +397,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tsconfig/node10@1.0.12':
-    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
-
-  '@tsconfig/node12@1.0.11':
-    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
-
-  '@tsconfig/node14@1.0.3':
-    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
-
-  '@tsconfig/node16@1.0.4':
-    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
@@ -379,10 +512,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -402,9 +531,6 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  arg@4.1.3:
-    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -423,9 +549,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  create-require@1.1.1:
-    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -447,12 +570,13 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
-
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -689,9 +813,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  make-error@1.3.6:
-    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -828,22 +949,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-node@10.9.2:
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -866,9 +978,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  v8-compile-cache-lib@3.0.1:
-    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -973,19 +1082,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  yn@3.1.1:
-    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
-    engines: {node: '>=6'}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
-
-  '@cspotcode/source-map-support@0.8.1':
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.9
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1001,6 +1102,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1)':
@@ -1055,14 +1234,7 @@ snapshots:
 
   '@isaacs/cliui@9.0.0': {}
 
-  '@jridgewell/resolve-uri@3.1.2': {}
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
-
-  '@jridgewell/trace-mapping@0.3.9':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -1125,14 +1297,6 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tsconfig/node10@1.0.12': {}
-
-  '@tsconfig/node12@1.0.11': {}
-
-  '@tsconfig/node14@1.0.3': {}
-
-  '@tsconfig/node16@1.0.4': {}
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -1256,13 +1420,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1292,10 +1456,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
   acorn@8.16.0: {}
 
   ajv-formats@3.0.1(ajv@8.20.0):
@@ -1316,8 +1476,6 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  arg@4.1.3: {}
-
   assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
@@ -1329,8 +1487,6 @@ snapshots:
   chai@6.2.2: {}
 
   convert-source-map@2.0.0: {}
-
-  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1346,9 +1502,36 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  diff@4.0.4: {}
-
   es-module-lexer@2.1.0: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escape-string-regexp@4.0.0: {}
 
@@ -1565,8 +1748,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  make-error@1.3.6: {}
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -1683,26 +1864,14 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  ts-node@10.9.2(@types/node@25.9.1)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.1
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   tslib@2.8.1:
     optional: true
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:
@@ -1727,9 +1896,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  v8-compile-cache-lib@3.0.1: {}
-
-  vite@8.0.16(@types/node@25.9.1)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1738,13 +1905,15 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.1
+      esbuild: 0.28.0
       fsevents: 2.3.3
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(yaml@2.9.0)):
+  vitest@4.1.8(@types/node@25.9.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -1761,7 +1930,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.1)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
@@ -1780,7 +1949,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yaml@2.9.0: {}
-
-  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       glob:
         specifier: ^11.0.2
         version: 11.1.0
-      json-logic-js:
-        specifier: ^2.0.5
-        version: 2.0.5
       yaml:
         specifier: ^2.7.1
         version: 2.9.0
@@ -594,9 +591,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-logic-js@2.0.5:
-    resolution: {integrity: sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -1496,8 +1490,6 @@ snapshots:
       '@isaacs/cliui': 9.0.0
 
   json-buffer@3.0.1: {}
-
-  json-logic-js@2.0.5: {}
 
   json-schema-traverse@0.4.1: {}
 

--- a/sources/assertions/guichet_lu/bereavement.yml
+++ b/sources/assertions/guichet_lu/bereavement.yml
@@ -1,7 +1,7 @@
-source_id: source.lu.guichet_bereavement
-source_snapshot_id: snapshot.lu.guichet_bereavement.20260603
+source_id: source.guichet_lu.bereavement
+source_snapshot_id: snapshot.guichet_lu.bereavement.2026_06_03
 assertions:
-  - id: assertion.lu.guichet_bereavement.death_must_be_declared
+  - id: assertion.guichet_lu.bereavement.death_must_be_declared
     schema_version: "0.1.0"
     claim_type: legal_scope
     claim_text: >
@@ -22,7 +22,7 @@ assertions:
       extraction_method: ai_assisted
       extracted_at: "2026-06-03T12:00:00Z"
 
-  - id: assertion.lu.guichet_bereavement.declaration_within_24h
+  - id: assertion.guichet_lu.bereavement.declaration_within_24h
     schema_version: "0.1.0"
     claim_type: deadline
     claim_text: >
@@ -45,7 +45,7 @@ assertions:
       extraction_method: ai_assisted
       extracted_at: "2026-06-03T12:00:00Z"
 
-  - id: assertion.lu.guichet_bereavement.survivor_pension_available
+  - id: assertion.guichet_lu.bereavement.survivor_pension_available
     schema_version: "0.1.0"
     claim_type: eligibility_condition
     claim_text: >

--- a/sources/guichet_lu/bereavement.yml
+++ b/sources/guichet_lu/bereavement.yml
@@ -1,4 +1,4 @@
-id: source.lu.guichet_bereavement
+id: source.guichet_lu.bereavement
 schema_version: "0.1.0"
 title: "Dealing with the death of a loved one"
 title_en: "Dealing with the death of a loved one"

--- a/sources/register.yml
+++ b/sources/register.yml
@@ -3,7 +3,7 @@
 # See: foundation-spec §18.2
 
 sources:
-  - id: source.lu.guichet_bereavement
+  - id: source.guichet_lu.bereavement
     title: "Dealing with the death of a loved one"
     title_en: "Dealing with the death of a loved one"
     url: "https://guichet.public.lu/en/citoyens/life-event/famille-education/deces-proche.html"

--- a/sources/snapshots/guichet_lu_bereavement_2026_06_03.yml
+++ b/sources/snapshots/guichet_lu_bereavement_2026_06_03.yml
@@ -1,0 +1,13 @@
+id: snapshot.guichet_lu.bereavement.2026_06_03
+schema_version: "0.1.0"
+source_id: source.guichet_lu.bereavement
+captured_at: "2026-06-03T12:00:00Z"
+capture_method: manual
+content_hash:
+  algorithm: sha256
+  value: "pending_capture"
+archive_uri: "sources/snapshots/html/guichet_lu_bereavement_2026_06_03.html"
+page_url: "https://guichet.public.lu/en/citoyens/life-event/famille-education/deces-proche.html"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-03"

--- a/tests/scenarios/lu/core_bereavement.yml
+++ b/tests/scenarios/lu/core_bereavement.yml
@@ -10,11 +10,11 @@ life_event: bereavement
 countries: [LU]
 
 facts:
-  - fact_type: intake_fact.lu.bereavement.jurisdiction_of_death
+  - fact_type: death.place.country
     value: LU
-  - fact_type: intake_fact.lu.bereavement.date_of_death
+  - fact_type: death.date
     value: "2026-01-15"
-  - fact_type: intake_fact.lu.bereavement.deceased_pension_jurisdiction
+  - fact_type: deceased.pension.jurisdiction
     value: LU
 
 expected_consequence_statuses:


### PR DESCRIPTION
## I1 + C5 + I4 + M3 + M4: Source/Provenance Chain Fixes

### What
Rename source/assertion/snapshot IDs from jurisdiction-origin to portal/publisher-origin convention.

### Why
Spec convention expects source IDs to identify the portal/publisher origin, not the jurisdiction. This enables proper disambiguation when multiple sources come from the same jurisdiction.

### Changes
- **Source**: source.lu.guichet_bereavement -> source.guichet_lu.bereavement
- **Assertions**: assertion.lu.guichet_bereavement.* -> assertion.guichet_lu.bereavement.*
- **Snapshot**: Created snapshot.guichet_lu.bereavement.2026_06_03
- Updated all source_assertion_refs in graph YAML files
- Updated source register
- Created structured source record with metadata

### Verification
- [x] No old source.lu.guichet_bereavement references remain (git grep)
- [x] 98 tests pass
- [x] validate, lint-ids, check-references pass