### PR TITLE
docs: document and standardize snapshot hash normalization convention

### DIFF
--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,13 @@
+# Clarvia Conventions
+
+## Source snapshot content hashes
+
+`source_snapshot.content_hash` verifies the archived source content saved by Clarvia.
+
+For text archive files (`.html`, `.txt`), Clarvia computes `content_hash` as SHA-256 over UTF-8 bytes after normalizing line endings from CRLF (`\r\n`) to LF (`\n`).
+
+For binary archive files, including PDFs, Clarvia computes `content_hash` as SHA-256 over the exact raw file bytes.
+
+This means text archive hashes are stable across operating systems and Git checkout settings, but external verifiers must apply the same LF normalization before comparing hashes.
+
+The capture pipeline should save text archives with LF line endings so the stored file bytes and canonical hash convention remain easy to reason about.

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -229,6 +229,136 @@ http_status: 200
     expect(snapshotResult!.errors!.join(" ")).toContain("Hash mismatch for archive file");
   });
 
+  it("validates .html with LF line endings", async () => {
+    const htmlContent = "<html>\n<body>\nsome text\n</body>\n</html>\n";
+    const computedHash = createHash("sha256").update(htmlContent).digest("hex");
+
+    mkdirSync(join(tempDir, "sources", "snapshots", "html"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "html", "lf_test.html"),
+      htmlContent,
+    );
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "lf_test.yml"),
+      `id: snapshot.test.lf_test.20250101
+schema_version: "0.1.0"
+source_id: source.test.lf_test
+captured_at: "2025-01-01T12:00:00Z"
+capture_method: http_get
+content_hash: "sha256:${computedHash}"
+archive_uri: "sources/snapshots/html/lf_test.html"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2025-01-01"
+http_status: 200
+`,
+    );
+
+    const { results, ok } = await runValidate({ rootDir: tempDir });
+    const snapshotResult = results.find(r => r.file.includes("lf_test.yml"));
+    expect(snapshotResult?.valid ?? true).toBe(true);
+    expect(ok).toBe(true);
+  });
+
+  it(".html with CRLF produces same canonical hash as LF", async () => {
+    const lfContent = "<html>\n<body>\nsome text\n</body>\n</html>\n";
+    const crlfContent = "<html>\r\n<body>\r\nsome text\r\n</body>\r\n</html>\r\n";
+    const lfHash = createHash("sha256").update(lfContent).digest("hex");
+
+    mkdirSync(join(tempDir, "sources", "snapshots", "html"), { recursive: true });
+    // Write file with CRLF line endings
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "html", "crlf_test.html"),
+      crlfContent,
+    );
+    // Use the LF hash — validator should normalize CRLF to LF before hashing
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "crlf_test.yml"),
+      `id: snapshot.test.crlf_test.20250101
+schema_version: "0.1.0"
+source_id: source.test.crlf_test
+captured_at: "2025-01-01T12:00:00Z"
+capture_method: http_get
+content_hash: "sha256:${lfHash}"
+archive_uri: "sources/snapshots/html/crlf_test.html"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2025-01-01"
+http_status: 200
+`,
+    );
+
+    const { results, ok } = await runValidate({ rootDir: tempDir });
+    const snapshotResult = results.find(r => r.file.includes("crlf_test.yml"));
+    expect(snapshotResult?.valid ?? true).toBe(true);
+    expect(ok).toBe(true);
+  });
+
+  it(".txt with CRLF produces same canonical hash as LF", async () => {
+    const lfContent = "line one\nline two\nline three\n";
+    const crlfContent = "line one\r\nline two\r\nline three\r\n";
+    const lfHash = createHash("sha256").update(lfContent).digest("hex");
+
+    mkdirSync(join(tempDir, "sources", "snapshots", "html"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "html", "crlf_test.txt"),
+      crlfContent,
+    );
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "crlf_test_txt.yml"),
+      `id: snapshot.test.crlf_txt.20250101
+schema_version: "0.1.0"
+source_id: source.test.crlf_txt
+captured_at: "2025-01-01T12:00:00Z"
+capture_method: http_get
+content_hash: "sha256:${lfHash}"
+archive_uri: "sources/snapshots/html/crlf_test.txt"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2025-01-01"
+http_status: 200
+`,
+    );
+
+    const { results, ok } = await runValidate({ rootDir: tempDir });
+    const snapshotResult = results.find(r => r.file.includes("crlf_test_txt.yml"));
+    expect(snapshotResult?.valid ?? true).toBe(true);
+    expect(ok).toBe(true);
+  });
+
+  it("binary files are hashed as raw bytes without line-ending normalization", async () => {
+    // Create a fake PDF with CRLF bytes — these should NOT be normalized
+    const binaryContent = Buffer.from("%PDF-1.4\r\nfake binary content\r\nwith CRLF\r\n");
+    const rawHash = createHash("sha256").update(binaryContent).digest("hex");
+
+    mkdirSync(join(tempDir, "sources", "snapshots", "pdf"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "pdf", "test_binary.pdf"),
+      binaryContent,
+    );
+    // Use the raw-byte hash — validator must NOT normalize CRLF for .pdf files
+    writeFileSync(
+      join(tempDir, "sources", "snapshots", "binary_test.yml"),
+      `id: snapshot.test.binary.20250101
+schema_version: "0.1.0"
+source_id: source.test.binary
+captured_at: "2025-01-01T12:00:00Z"
+capture_method: http_get
+content_hash: "sha256:${rawHash}"
+archive_uri: "sources/snapshots/pdf/test_binary.pdf"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2025-01-01"
+http_status: 200
+`,
+    );
+
+    const { results, ok } = await runValidate({ rootDir: tempDir });
+    const snapshotResult = results.find(r => r.file.includes("binary_test.yml"));
+    expect(snapshotResult?.valid ?? true).toBe(true);
+    expect(ok).toBe(true);
+  });
+
   it("fails when http_status is missing", async () => {
     mkdirSync(join(tempDir, "sources", "snapshots"), { recursive: true });
     // http_status is missing in YAML, but notice that source_snapshot.schema.json doesn't list it as required.

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -276,13 +276,17 @@ function validateSnapshotsAndAnchors(
           try {
             const expectedHash = contentHash.substring(7).toLowerCase();
             let fileBytes = readFileSync(archivePath);
-            // Normalize CRLF to LF for consistent cross-platform hashing
-            if (archivePath.endsWith(".html") || archivePath.endsWith(".txt")) {
+            // Clarvia convention: text archive content_hash values are computed
+            // over LF-normalized UTF-8 content. Binary archive hashes use raw bytes.
+            // See docs/CONVENTIONS.md.
+            const isTextArchive = archivePath.endsWith(".html") || archivePath.endsWith(".txt");
+            if (isTextArchive) {
               fileBytes = Buffer.from(fileBytes.toString("utf-8").replace(/\r\n/g, "\n"));
             }
             const actualHash = createHash("sha256").update(fileBytes).digest("hex").toLowerCase();
             if (actualHash !== expectedHash) {
-              errors.push(`Hash mismatch for archive file. Expected sha256:${expectedHash}, computed sha256:${actualHash}`);
+              const method = isTextArchive ? " using Clarvia LF-normalized text hashing" : "";
+              errors.push(`Hash mismatch for archive file. Expected sha256:${expectedHash}, computed sha256:${actualHash}${method}`);
             }
           } catch (err: unknown) {
             errors.push(`Error reading archive file: ${(err as Error).message}`);


### PR DESCRIPTION
## Summary

Documents and standardizes the LF normalization convention for text archive content hashes.

### Changes

- **\docs/CONVENTIONS.md\** — Documents the hash convention:
  - Text archives (\.html\, \.txt\): SHA-256 over LF-normalized UTF-8 bytes
  - Binary archives (\.pdf\): SHA-256 over exact raw bytes
- **\alidate.ts\** — Adds Clarvia convention comment referencing \docs/CONVENTIONS.md\ and improves hash mismatch error message
- **\alidate.test.ts\** — Adds 4 tests:
  - \.html\ with LF validates ✅
  - \.html\ with CRLF produces same canonical hash as LF ✅
  - \.txt\ with CRLF produces same canonical hash as LF ✅
  - Binary \.pdf\ hashed as raw bytes without normalization ✅
- **Issue #34** — Capture pipeline centralization

### Verification
- \	sc --noEmit\: ✅
- \eslint\: ✅ 0 errors
- 130/130 tests: ✅