### PR TITLE
feat: add alpha resolved_subject_id to checklist item identity

### DIFF
--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -172,6 +172,125 @@ describe("generateChecklist", () => {
     expect(output1.id).toBe(output2.id);
   });
 
+  it("same scenario + same subject produces same checklist item ID", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    // All items should have resolved_subject_id
+    for (const item of output1.items) {
+      expect(item.resolved_subject_id).toBeDefined();
+      expect(typeof item.resolved_subject_id).toBe("string");
+    }
+
+    // Same inputs produce same IDs
+    expect(output1.items.map(i => i.id)).toEqual(output2.items.map(i => i.id));
+  });
+
+  it("same task but different resolved_subject_id produces different checklist item ID", () => {
+    const graph = loadGraph(ROOT_DIR);
+
+    const facts: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+
+    // Generate with default subject role (person.deceased)
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    expect(output1.items.length).toBeGreaterThan(0);
+
+    // Find a template that was actually used — match by title
+    const firstItemTitle = output1.items[0].title;
+    let matchedTemplateKey: string | undefined;
+    for (const [key, tmpl] of graph.taskTemplates.entries()) {
+      if (tmpl.title === firstItemTitle) {
+        matchedTemplateKey = key;
+        break;
+      }
+    }
+    expect(matchedTemplateKey).toBeDefined();
+    const template = graph.taskTemplates.get(matchedTemplateKey!)!;
+
+    // Now change the template's subject_role to survivor
+    const originalRole = template.target?.subject_role;
+    if (!template.target) {
+      template.target = {};
+    }
+    template.target.subject_role = "survivor";
+
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    // Restore original
+    if (template.target) {
+      template.target.subject_role = originalRole ?? undefined;
+    }
+
+    // Find items with person.survivor — these should exist
+    const items2ForTemplate = output2.items.filter(i => i.resolved_subject_id === "person.survivor");
+    expect(items2ForTemplate.length).toBeGreaterThan(0);
+
+    // The same-titled item should have a different ID
+    const item1 = output1.items.find(i => i.title === firstItemTitle)!;
+    const item2 = output2.items.find(i => i.title === firstItemTitle)!;
+    expect(item1.id).not.toBe(item2.id);
+    expect(item1.resolved_subject_id).toBe("person.deceased");
+    expect(item2.resolved_subject_id).toBe("person.survivor");
+  });
+
+  it("missing subject role uses person.deceased fallback", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+
+    const output = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    // All current templates have no subject_role, so all items should use person.deceased fallback
+    for (const item of output.items) {
+      expect(item.resolved_subject_id).toBe("person.deceased");
+    }
+  });
+
+  it("item ID does not include generated_at or consequenceId", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+
+    // Generate at two different wall-clock times — same asOfDate
+    const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+    const output2 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    // Item IDs should be identical (no timestamp/generated_at in hash)
+    expect(output1.items.map(i => i.id)).toEqual(output2.items.map(i => i.id));
+
+    // No item ID should contain a consequence ID prefix
+    for (const item of output1.items) {
+      expect(item.id).not.toContain("consequence.");
+    }
+  });
+
+  it("item ID format remains checklist_item.<scenario_hash>.<task_or_group_hash>", () => {
+    const graph = loadGraph(ROOT_DIR);
+    const facts: Fact[] = [
+      { fact_type: "death.place.country", value: "LU" },
+      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+    ];
+
+    const output = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
+
+    for (const item of output.items) {
+      expect(item.id).toMatch(/^checklist_item\.[a-f0-9]+\.[a-f0-9]+$/);
+    }
+  });
+
   it("cross-border: LU death + DE pension produces items from both jurisdictions", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -47,6 +47,7 @@ export type ItemStatus =
 
 export interface ChecklistItem {
   id: string;
+  resolved_subject_id: string;
   status: ItemStatus;
   title: string;
   description: string | null;
@@ -121,20 +122,22 @@ const GROUP_ORDER: Record<string, { order: number; label: string }> = {
 };
 
 // ── Deterministic item ID ────────────────────────────────────────────
-// Per spec §14.1: hash includes task_template_id, jurisdiction,
-// authority_id, dedupe_group_key, and generator_version.
+// Per spec §14.1: hash includes task_template_id, resolved_subject_id,
+// jurisdiction, authority_id, dedupe_group_key, and generator_version.
 
 const GENERATOR_VERSION = "0.1";
 
 function makeItemId(
   scenarioHash: string,
   taskTemplateId: string,
+  resolvedSubjectId: string,
   jurisdiction: string,
   authorityId: string | null,
   dedupeGroupKey: string | null,
 ): string {
   const identity = [
     taskTemplateId,
+    resolvedSubjectId,
     jurisdiction,
     authorityId ?? "",
     dedupeGroupKey ?? "",
@@ -145,6 +148,31 @@ function makeItemId(
     .digest("hex")
     .slice(0, 12);
   return `checklist_item.${scenarioHash}.${hash}`;
+}
+
+// ── Resolved subject ID ─────────────────────────────────────────────
+// Alpha deterministic mapping from task_template.target.subject_role.
+// Fallback for bereavement: person.deceased.
+
+const SUBJECT_ROLE_MAP: Record<string, string> = {
+  deceased: "person.deceased",
+  survivor: "person.survivor",
+  surviving_spouse: "person.survivor",
+  surviving_partner: "person.survivor",
+  child: "person.child",
+  dependant: "person.dependant",
+  estate: "estate.primary",
+};
+
+function resolveSubjectId(
+  template: TaskTemplate | null,
+): string {
+  const role = template?.target?.subject_role;
+  if (role && SUBJECT_ROLE_MAP[role]) {
+    return SUBJECT_ROLE_MAP[role];
+  }
+  // Bereavement alpha fallback
+  return "person.deceased";
 }
 
 // ── Deduplication and Merging helpers ────────────────────────────────
@@ -690,14 +718,18 @@ function makeItem(
     return true;
   });
 
+  const resolvedSubjectId = resolveSubjectId(template);
+
   return {
     id: makeItemId(
       scenarioHash,
       template?.id ?? consequence.id,
+      resolvedSubjectId,
       consequence.jurisdiction,
       template?.authority_refs?.[0] ?? null,
       null,
     ),
+    resolved_subject_id: resolvedSubjectId,
     status,
     title: template?.title ?? consequence.title,
     description: (template as Record<string, unknown>)?.description as string | null ?? null,


### PR DESCRIPTION
## Summary

Adds deterministic \esolved_subject_id\ to checklist item hash inputs and output per spec §14.1.

### Changes

- **\generator.ts\** — Adds \esolveSubjectId()\ with alpha subject-role mapping:
  | Role | Resolved ID |
  |------|-------------|
  | \deceased\ | \person.deceased\ |
  | \survivor\ / \surviving_spouse\ / \surviving_partner\ | \person.survivor\ |
  | \child\ | \person.child\ |
  | \dependant\ | \person.dependant\ |
  | \estate\ | \estate.primary\ |
  | missing/unknown | \person.deceased\ (bereavement fallback) |

- Includes \esolved_subject_id\ in \makeItemId\ hash inputs
- Adds \esolved_subject_id\ field to \ChecklistItem\ output
- \consequenceId\ is **not** reintroduced into item hash identity

### Tests (5 new)
- same scenario + same subject → same ID ✅
- same task + different subject → different ID ✅
- missing subject role → \person.deceased\ fallback ✅
- no \generated_at\/\consequenceId\ in hash ✅
- ID format: \checklist_item.<scenario_hash>.<task_or_group_hash>\ ✅

### Issue
- #36 — Full multi-subject resolution follow-up

### Verification
- \	sc --noEmit\: ✅
- \eslint\: ✅ 0 errors
- 131/131 tests: ✅