### PR TITLE
docs: add workflow-data migration candidates tracking list

### DIFF
--- a/docs/migration-candidates.md
+++ b/docs/migration-candidates.md
@@ -1,0 +1,112 @@
+# workflow-data Migration Candidates
+
+Tracking list of `workflow-data` records and their migration status into `clarvia-graph`.
+Generated from inventory of `workflow-data` as of 2026-06-03.
+
+---
+
+## Legend
+
+| Status | Meaning |
+|--------|---------|
+| ✅ Migrated | Record exists in clarvia-graph |
+| 🔄 Partial | Partially covered by existing graph records |
+| 🎯 Candidate | High-quality migration candidate, not yet migrated |
+| ⚠️ Low priority | Exists in workflow-data but needs further verification before migration |
+
+---
+
+## Sources (`data/sources/lu/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `guichet-death-life-event.yaml` | `source:lu:guichet:death-life-event` | ✅ Migrated | `source.guichet_lu.bereavement` | URL verified, title updated in PR #39 |
+| `guichet-death-certificate.yaml` | `source:lu:guichet:death-certificate` | 🎯 Candidate | `source.guichet_lu.death_certificate` | URL verified 2026-05-27. Needs source + assertion batch + consequence chain |
+| `cnap-survivor-pension.yaml` | `source:lu:cnap:survivor-pension` | 🔄 Partial | `source.cnap_lu.survivor_pension` | Survivor pension consequence already exists via guichet source. Needs standalone CNAP source record + CNAP-specific assertions |
+| `cns-death-notification.yaml` | `source:lu:cns:death-notification` | 🎯 Candidate | `source.cns_lu.death_notification` | CNS funeral allowance. No equivalent in graph yet. Needs source + assertions |
+
+---
+
+## Institutions (`data/institutions/lu/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `bureau-etat-civil.yaml` | `institution:lu:bureau-etat-civil` | ✅ Migrated | `authority.lu.bureau_etat_civil` | In `graph/authorities/lu/bureau_etat_civil.yml` |
+| `guichet.yaml` | `institution:lu:guichet` | ✅ Migrated | Referenced as publisher on source records | Guichet is source publisher, not a standalone authority in the graph model |
+
+---
+
+## Document Requirements (`data/document_requirements/lu/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `death-certificate.yaml` | `document:lu:death-certificate` | 🎯 Candidate | `evidence_type.lu.death_certificate` | Accepted forms (certified_copy, copy) and issuing authority verified in PR #34 and #38. Maps to evidence_type schema |
+
+---
+
+## Deadlines (`data/deadlines/lu/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `death-declaration-deadline.yaml` | `deadline:lu:death-declaration` | ✅ Migrated | `deadline.lu.bereavement.death_registration.declaration_deadline` | 24-hour deadline verified from Guichet in PR #35. Referenced in `file_death_declaration` task template |
+
+---
+
+## Conditions (`data/conditions/common/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `death-in-jurisdiction.yaml` | `condition:death-in-jurisdiction` | ✅ Migrated | `condition.lu.bereavement.death_registration.death_occurred_in_lu` | JsonLogic expression in graph |
+| `deceased-is-foreign-national.yaml` | `condition:deceased-is-foreign-national` | 🎯 Candidate | `condition.xborder.bereavement.succession.deceased_is_foreign_national` | Cross-border condition. No equivalent yet |
+| `deceased-is-frontalier.yaml` | `condition:deceased-is-frontalier` | 🔄 Partial | `condition.xborder.bereavement.survivor_pension.cross_border_pension_applies` | Partially covered. Frontalier-specific condition not yet explicit |
+| `survivor-resides-abroad.yaml` | `condition:survivor-resides-abroad` | 🎯 Candidate | `condition.xborder.bereavement.survivor_pension.survivor_resides_abroad` | No equivalent yet |
+| `assets-in-multiple-jurisdictions.yaml` | `condition:assets-in-multiple-jurisdictions` | 🎯 Candidate | `condition.xborder.bereavement.succession.assets_in_multiple_jurisdictions` | No equivalent yet |
+| `repatriation-of-remains.yaml` | `condition:repatriation-of-remains` | 🎯 Candidate | `condition.xborder.bereavement.death_registration.repatriation_requested` | No equivalent yet |
+
+---
+
+## Scenarios (`data/scenarios/`)
+
+| File | ID | Status | clarvia-graph target | Notes |
+|------|----|--------|---------------------|-------|
+| `luxembourg-core.yaml` | `scenario:luxembourg-core` | ✅ Migrated | Covered by LU consequence chain | Core LU death declaration + survivor pension chain live in graph |
+| `corridor-lu-fr.yaml` | `scenario:corridor-lu-fr` | 🎯 Candidate | `scenario_test.xborder.bereavement.lu_fr_corridor` | France side completely missing from graph (#13) |
+| `corridor-lu-de.yaml` | `scenario:corridor-lu-de` | 🔄 Partial | DE authorities (DRV, Standesamt) in graph. DE consequences missing | |
+| `corridor-lu-be.yaml` | `scenario:corridor-lu-be` | ⚠️ Low priority | No BE records in graph yet | |
+| `corridor-lu-pt.yaml` | `scenario:corridor-lu-pt` | ⚠️ Low priority | No PT records in graph yet. Sources marked discovered in workflow-data | |
+
+---
+
+## Migration Priority Queue
+
+Based on source quality and graph completeness, recommended migration order:
+
+### Priority 1 — High confidence, source-backed, self-contained
+1. `guichet-death-certificate.yaml` → new source + assertion batch + `consequence.lu.bereavement.death_registration.obtain_death_certificate` + task template
+2. `death-certificate.yaml` (document requirement) → `evidence_type.lu.death_certificate`
+3. `cns-death-notification.yaml` → new source + assertion batch (CNS funeral allowance)
+
+### Priority 2 — Cross-border conditions (foundation for corridors)
+4. `deceased-is-foreign-national.yaml` → new cross-border condition
+5. `survivor-resides-abroad.yaml` → new cross-border condition
+6. `assets-in-multiple-jurisdictions.yaml` → new cross-border condition
+7. `repatriation-of-remains.yaml` → new cross-border condition
+
+### Priority 3 — Corridor scenarios (depends on Priority 2)
+8. `corridor-lu-fr.yaml` → FR authorities + consequences + task templates (Issue #13)
+9. `corridor-lu-de.yaml` → DE consequences + task templates (DE authorities already in graph)
+
+### Priority 4 — Deferred pending further source verification
+10. `cnap-survivor-pension.yaml` → standalone CNAP source record (partially covered)
+11. `corridor-lu-be.yaml` — pending BE source verification
+12. `corridor-lu-pt.yaml` — pending PT source verification (sources marked discovered)
+
+---
+
+## Notes
+
+- All migrated records reference `snapshot.guichet_lu.bereavement.2026_06_03` as provenance
+- Cross-border conditions (Priority 2) should use `jurisdiction: EU` or `jurisdiction: xborder` per existing graph conventions
+- `cnap-survivor-pension.yaml` and `cns-death-notification.yaml` both have `verification_status: discovered` in workflow-data — assertions from these sources should carry `confidence: low` until further verified
+- Sources from `data/sources/eu/` (Brussels IV, EC 883/2004) are not listed here — they are EU-level sources that feed the cross-border chain, tracked separately
+


### PR DESCRIPTION
Closes #14

---

## What this is

A structured tracking document at `docs/migration-candidates.md` that inventories every record in the `workflow-data` legacy corpus, maps it against the current `clarvia-graph` state, assigns a migration status, and produces a prioritised migration queue.

This document is the formal output of issue #14 and serves as the single source of truth for migration planning going forward.

---

## How this was produced

### Step 1 — Full inventory of workflow-data

Ran a complete directory inventory of `workflow-data`:

- `data/sources/lu/` — 4 files
- `data/institutions/lu/` — 2 files
- `data/document_requirements/lu/` — 1 file
- `data/deadlines/lu/` — 1 file
- `data/conditions/common/` — 6 files
- `data/scenarios/` — 5 files

### Step 2 — Cross-reference against clarvia-graph

Read every existing graph file to determine what has already been migrated:

- `graph/authorities/lu/` — `bureau_etat_civil.yml`, `cnap.yml`
- `graph/consequences/bereavement/lu/` — `declare_death.yml`, `claim_survivor_pension.yml`
- `graph/conditions/bereavement/lu/` — `death_occurred_in_lu.yml`, `deceased_was_lu_insured.yml`
- `graph/conditions/bereavement/xborder/` — `cross_border_pension.yml`
- `graph/task_templates/bereavement/lu/` — `file_death_declaration.yml`, `file_cnap_claim.yml`
- `sources/guichet_lu/bereavement.yml` — source record
- `sources/assertions/guichet_lu/bereavement.yml` — assertion batch

### Step 3 — Status assignment

Each record was assigned one of four statuses:

- ✅ **Migrated** — equivalent record exists in clarvia-graph with matching semantics
- 🔄 **Partial** — partially covered by existing graph records but not fully modelled
- 🎯 **Candidate** — high-quality migration candidate with verified sources, not yet migrated
- ⚠️ **Low priority** — exists in workflow-data but needs further source verification before migration

### Step 4 — Priority queue

Migration order was determined by three factors:
1. Source quality — records with `source-checked` or `structured-from-source` status in workflow-data are higher priority than `discovered`
2. Graph dependencies — source records and assertion batches must exist before consequences, which must exist before task templates
3. Cross-border ordering — corridor scenarios depend on cross-border conditions being in the graph first

---

## Key findings

### What is already migrated (4 records)

| workflow-data record | clarvia-graph equivalent |
|---|---|
| `guichet-death-life-event.yaml` | `source.guichet_lu.bereavement` |
| `bureau-etat-civil.yaml` | `authority.lu.bureau_etat_civil` |
| `death-declaration-deadline.yaml` | `deadline.lu.bereavement.death_registration.declaration_deadline` |
| `death-in-jurisdiction.yaml` | `condition.lu.bereavement.death_registration.death_occurred_in_lu` |

### What is partially covered (3 records)

- `cnap-survivor-pension.yaml` — survivor pension consequence exists via guichet source, but no standalone CNAP source record or CNAP-specific assertions
- `deceased-is-frontalier.yaml` — covered by `cross_border_pension_applies` condition but frontalier-specific logic not explicitly modelled
- `corridor-lu-de.yaml` — DE authorities (DRV, Standesamt) in graph, DE consequences and task templates missing

### What is not yet migrated (12 records)

Priority 1 — high confidence, source-backed:
- `guichet-death-certificate.yaml` → needs `source.guichet_lu.death_certificate` + assertion batch + consequence chain for obtaining a death certificate. URL and facts verified in workflow-data PRs #34 and #38.
- `death-certificate.yaml` (document requirement) → maps to `evidence_type.lu.death_certificate`. Accepted forms (`certified_copy`, `copy`) and issuing authority verified in PRs #34 and #38.
- `cns-death-notification.yaml` → CNS funeral allowance source. No equivalent in graph yet. URL verified in workflow-data PR #44.

Priority 2 — cross-border conditions:
- `deceased-is-foreign-national.yaml` → `condition.xborder.bereavement.succession.deceased_is_foreign_national`
- `survivor-resides-abroad.yaml` → `condition.xborder.bereavement.survivor_pension.survivor_resides_abroad`
- `assets-in-multiple-jurisdictions.yaml` → `condition.xborder.bereavement.succession.assets_in_multiple_jurisdictions`
- `repatriation-of-remains.yaml` → `condition.xborder.bereavement.death_registration.repatriation_requested`

Priority 3 — corridor scenarios (depends on Priority 2):
- `corridor-lu-fr.yaml` → France side completely missing from graph (no FR authorities, consequences, or task templates). Tracked in issue #13.
- `corridor-lu-de.yaml` → DE authorities exist, consequences and task templates missing.

Priority 4 — deferred:
- `cnap-survivor-pension.yaml` standalone CNAP source — partially covered
- `corridor-lu-be.yaml` — no BE records in graph. Sources verified in workflow-data PR #50.
- `corridor-lu-pt.yaml` — no PT records in graph. Portugal sources marked `discovered` in workflow-data, further verification needed.

---

## Source traceability

All status assignments trace back to specific workflow-data PRs:

| Fact | Verified in |
|---|---|
| Guichet death-life-event URL and title | workflow-data PR #39 |
| Death certificate issuing authority and accepted forms | workflow-data PRs #34, #38 |
| 24-hour death declaration deadline | workflow-data PR #35 |
| CNS death notification URL | workflow-data PR #44 (issue #17) |
| Cross-border conditions research | workflow-data PR #47 (issue #40 PR 1/4) |
| FR corridor sources | workflow-data PR #48 (issue #40 PR 2/4) |
| DE corridor sources | workflow-data PR #49 (issue #40 PR 3/4) |
| BE/PT corridor sources | workflow-data PR #50 (issue #40 PR 4/4) |

---

## Files changed

- `docs/migration-candidates.md` — new file, 112 lines

## Verified

- Trailing newline present
- 1 file, 112 insertions
- DCO sign-off included (`git commit -s`)
- No unintended changes