### PR TITLE
docs: add 4 onboarding documents

### DIFF
--- a/docs/ADDING_A_JURISDICTION.md
+++ b/docs/ADDING_A_JURISDICTION.md
@@ -1,0 +1,360 @@
+# Adding a Jurisdiction
+
+This guide walks through adding a new country to the Clarvia consequence graph. We use **Belgium (BE)** as the running example, but the steps apply to any jurisdiction.
+
+> **Non-negotiable:** Adding a jurisdiction must not change existing records, weaken publication gates, or break scenario tests for other jurisdictions (spec §21.1).
+
+---
+
+## Coverage Stages
+
+A jurisdiction progresses through five stages:
+
+| Stage | What exists | User-visible? |
+|---|---|---|
+| `metadata_only` | Vocab entry + coverage entry, no content | No |
+| `source_backed` | Official sources, snapshots, and assertions | No |
+| `checklist_draft` | Consequences and task templates exist, not fully reviewed | No |
+| `published` | Approved assertions + `public_open` consequences generate checklist items | **Yes** |
+| `monitored` | Published + gold-layer monitoring/freshness tracking | **Yes** |
+
+A jurisdiction may be partially published — e.g. death registration is `published` while succession is still `checklist_draft`.
+
+---
+
+## Prerequisites
+
+- Node.js ≥ 20, pnpm
+- The CLI: `pnpm install` from the repo root
+- A government source URL for the jurisdiction (e.g. `https://www.belgium.be/...`)
+
+---
+
+## Step 1: Verify the Jurisdiction Exists in Vocabularies
+
+Check `vocab/jurisdictions.yml`. Belgium is already registered:
+
+```yaml
+- id: BE
+  label: Belgium
+  label_fr: Belgique
+  label_de: Belgien
+  uri: "http://publications.europa.eu/resource/authority/country/BEL"
+  languages: [fr, nl, de]
+```
+
+If your jurisdiction is missing, add it here with at minimum `id`, `label`, `label_fr`, `label_de`, and `uri` (EU Publications Office URI).
+
+---
+
+## Step 2: Add a Coverage Entry
+
+Add an entry to `coverage/jurisdictions.yml`:
+
+```yaml
+- jurisdiction: BE
+  life_events:
+    bereavement:
+      stage: metadata_only
+      notes: "Skeleton created, no sources yet."
+```
+
+Update the `stage` as you progress through the steps below.
+
+---
+
+## Step 3: Create the Directory Skeleton
+
+Create these directories (with `.gitkeep` files where empty):
+
+```
+graph/
+  authorities/be/
+  conditions/bereavement/be/
+  consequences/bereavement/be/
+  task_templates/bereavement/be/
+  deadlines/bereavement/be/
+sources/
+  assertions/be/
+tests/
+  scenarios/be/
+```
+
+> **Note:** `evidence_types/`, `forms/`, and `intake_fact_types/` are not jurisdiction-scoped — they live under `graph/<type>/<jurisdiction>/` or `graph/intake_fact_types/<life_event>/` respectively.
+
+---
+
+## Step 4: Register an Official Source
+
+Add a source record to `sources/register.yml`. Follow the existing pattern:
+
+```yaml
+- id: source.belgium_gov.bereavement
+  title: "Décès - démarches administratives"
+  title_en: "Death - administrative procedures"
+  url: "https://www.belgium.be/fr/famille/deces"
+  source_type: government_portal
+  jurisdiction: BE
+  publisher: "Service public fédéral Intérieur"
+  languages: [fr]
+  domain: death_registration
+  life_event: bereavement
+  source_role: primary_guidance
+  monitoring:
+    active: false
+  verified_at: null
+```
+
+**ID convention:** `source.<origin_slug>.<topic_slug>`
+
+---
+
+## Step 5: Capture the Source
+
+```bash
+pnpm capture source.belgium_gov.bereavement
+```
+
+This creates:
+- `sources/snapshots/belgium_gov_bereavement_YYYY_MM_DD.yml` — metadata + SHA-256 hash
+- `sources/snapshots/html/belgium_gov_bereavement_YYYY_MM_DD.html` — archived HTML
+
+---
+
+## Step 6: Extract Assertions
+
+```bash
+pnpm extract snapshot.belgium_gov.bereavement.YYYY_MM_DD
+```
+
+This scaffolds an assertion batch file at `sources/assertions/be/belgium_gov/bereavement.yml`. Edit the scaffolded file to add real assertions extracted from the captured HTML:
+
+```yaml
+source_id: source.belgium_gov.bereavement
+source_snapshot_id: snapshot.belgium_gov.bereavement.2026_06_10
+assertions:
+  - id: assertion.belgium_gov.bereavement.death_declaration_required
+    schema_version: "0.1.0"
+    claim_type: legal_scope
+    claim_text: >
+      En Belgique, le décès doit être déclaré à l'officier de l'état
+      civil de la commune où le décès a eu lieu.
+    claim_scope:
+      jurisdiction: BE
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "déclaré à l'officier de l'état civil"
+    source_tier: official_guidance
+    record_valid_from: "2026-06-10"
+    review_status: draft        # Always starts as draft
+    confidence: unassessed      # Until reviewed
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-06-10T10:00:00Z"
+```
+
+**Key rules:**
+- `anchor.text_quote` must exist verbatim in the captured HTML (verified by `check-anchors`)
+- `claim_text` stays in the source's original language
+- `review_status` starts as `draft` — only a founder/reviewer can set `approved`
+- `extraction_method: ai_assisted` stays even after human approval (provenance honesty)
+
+---
+
+## Step 7: Add Reusable Objects
+
+### Authority
+
+```yaml
+# graph/authorities/be/etat_civil.yml
+id: authority.be.etat_civil
+schema_version: "0.1.0"
+name: "Officier de l'état civil"
+name_en: "Civil Registrar"
+name_de: "Standesbeamter"
+jurisdiction: BE
+function: "Civil status registration — births, marriages, deaths"
+official_site: null
+contact_channels: []
+languages: [fr, nl, de]
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-10"
+```
+
+### Evidence types, forms
+
+Add to `graph/evidence_types/be/` and `graph/forms/be/` as needed. These are jurisdiction-scoped but not life-event-scoped.
+
+---
+
+## Step 8: Add Graph Records
+
+### Condition
+
+```yaml
+# graph/conditions/bereavement/be/death_occurred_in_be.yml
+id: condition.be.bereavement.death_registration.death_occurred_in_be
+schema_version: "0.1.0"
+title: "Death occurred in Belgium"
+description: >
+  Evaluates whether the death occurred on Belgian territory.
+condition_type: criterion
+jurisdiction: BE
+life_event: bereavement
+domain: death_registration
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "death.place.country" }
+    - "BE"
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.jurisdiction_of_death
+source_assertion_refs:
+  - assertion.belgium_gov.bereavement.death_declaration_required
+record_valid_from: "2026-06-10"
+authoring_status: draft
+distribution_status: public_open
+```
+
+### Consequence
+
+```yaml
+# graph/consequences/bereavement/be/declare_death.yml
+id: consequence.be.bereavement.death_registration.declare_death
+schema_version: "0.1.0"
+title: "Declare death to the civil registrar"
+description: >
+  When a death occurs in Belgium, it must be declared to the civil
+  registrar of the municipality where the death took place.
+consequence_type: obligation
+jurisdiction: BE
+life_event: bereavement
+domain: death_registration
+trigger:
+  condition_refs:
+    - condition.be.bereavement.death_registration.death_occurred_in_be
+task_template_refs:
+  - task_template.be.bereavement.death_registration.file_death_declaration
+source_assertion_refs:
+  - assertion.belgium_gov.bereavement.death_declaration_required
+authoring_status: draft              # Start as draft
+distribution_status: restricted_source  # Until assertions are approved
+confidence: unassessed
+record_valid_from: "2026-06-10"
+```
+
+### Task template
+
+```yaml
+# graph/task_templates/bereavement/be/file_death_declaration.yml
+id: task_template.be.bereavement.death_registration.file_death_declaration
+schema_version: "0.1.0"
+title: "File death declaration at the municipality"
+description: >
+  Declare the death to the civil registrar of the municipality
+  where the death occurred.
+action_type: file_declaration
+jurisdiction: BE
+life_event: bereavement
+domain: death_registration
+authority_refs:
+  - authority.be.etat_civil
+deadline_refs: []
+rendering:
+  checklist_group: immediate_formalities
+  urgency_score: 95
+  dependency_rank: 1
+  user_visible_caveat: null
+authoring_status: draft
+distribution_status: restricted_source
+record_valid_from: "2026-06-10"
+```
+
+> **Publication gate:** Consequences and task templates should start as `distribution_status: restricted_source` and `authoring_status: draft`. They can only move to `public_open` + `approved` once their linked source assertions are `review_status: approved`.
+
+---
+
+## Step 9: Add a Scenario Test
+
+```yaml
+# tests/scenarios/be/core_bereavement.yml
+id: scenario_test.be.core_bereavement
+schema_version: "0.1.0"
+title: "Belgium core — death occurred in Belgium"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [BE]
+
+facts:
+  - fact_type: death.place.country
+    value: BE
+
+expected_consequence_statuses:
+  consequence.be.bereavement.death_registration.declare_death: applies
+```
+
+---
+
+## Step 10: Validate
+
+Run the full CI pipeline locally:
+
+```bash
+pnpm validate              # Schema validation (all files)
+pnpm lint-ids              # ID grammar checks
+pnpm check-references      # All refs point to existing records
+pnpm check-anchors         # Anchor text found in snapshots
+pnpm check-publication-gate  # No unapproved assertions in public records
+pnpm test-scenarios        # Scenario regression tests
+pnpm test                  # Unit tests
+pnpm typecheck             # TypeScript type checking
+```
+
+All must pass before opening a PR.
+
+---
+
+## Step 11: Open a PR
+
+Push your branch and open a PR. The PR should:
+
+- Target `main`
+- Reference the jurisdiction being added
+- Note the coverage stage being achieved
+- Include the CI results
+
+> **Extension regression rule:** CI verifies that adding BE does not change existing LU/DE/FR scenario outputs.
+
+---
+
+## Promoting to Published
+
+Once assertions are reviewed and approved:
+
+1. Set `review_status: approved` and `confidence: medium` (or `high`) on assertions
+2. Set `authoring_status: approved` on graph records
+3. Set `distribution_status: public_open` on consequences and task templates
+4. Update `coverage/jurisdictions.yml` stage to `published`
+5. The generator will now include these items in public checklist output
+
+---
+
+## ID Conventions Reference
+
+| Record type | ID format |
+|---|---|
+| Source | `source.<origin>.<topic>` |
+| Snapshot | `snapshot.<origin>.<topic>.<date>` |
+| Assertion | `assertion.<origin>.<topic>.<claim_slug>` |
+| Authority | `authority.<jurisdiction>.<slug>` |
+| Condition | `condition.<jurisdiction>.<life_event>.<domain>.<slug>` |
+| Consequence | `consequence.<jurisdiction>.<life_event>.<domain>.<slug>` |
+| Task template | `task_template.<jurisdiction>.<life_event>.<domain>.<slug>` |
+| Intake fact | `intake_fact.global.<life_event>.<slug>` |
+| Scenario test | `scenario_test.<scope>.<slug>` |
+
+All ID segments are lowercase with underscores. Jurisdiction fields use uppercase (`BE`), ID paths use lowercase (`be`).

--- a/docs/ADDING_A_LIFE_EVENT.md
+++ b/docs/ADDING_A_LIFE_EVENT.md
@@ -1,0 +1,320 @@
+# Adding a Life Event
+
+This guide walks through adding a new life event to the Clarvia consequence graph. We use **marriage** as the running example, but the steps apply to any life event.
+
+> **Extension principle (spec §21.1):** Life events extend vertically — a new life event creates its own namespace using the same infrastructure. Adding one must not change existing records, weaken publication gates, or break scenario tests for other life events.
+
+---
+
+## What a Life Event Is
+
+A life event is a significant event in a person's life (bereavement, marriage, job loss, birth) that triggers legal, administrative, and financial consequences across one or more jurisdictions. Each life event has its own:
+
+- **Intake fact types** — the questions we ask users
+- **Conditions** — rules evaluated against user facts
+- **Consequences** — obligations, rights, or steps triggered by conditions
+- **Task templates** — actionable checklist items for users
+- **Deadlines** — time-bound requirements
+- **Scenario tests** — regression fixtures
+
+These objects are **shared** across life events and reused:
+
+- Sources, snapshots, assertions (a government page may cover multiple events)
+- Authorities (the same registry office handles births, deaths, marriages)
+- Evidence types and forms
+- The condition engine, publication gate, export pipeline
+
+---
+
+## Minimum Viable Life Event
+
+To generate a working checklist for a new life event, you need at minimum:
+
+1. A `vocab/life_events.yml` entry
+2. Domain entries in `vocab/domains.yml`
+3. Checklist group entries in `vocab/checklist_groups.yml`
+4. At least one intake fact type
+5. At least one source → snapshot → approved assertion
+6. At least one condition → consequence → task template chain
+7. At least one scenario test
+
+---
+
+## Step 1: Register the Life Event
+
+### vocab/life_events.yml
+
+```yaml
+- id: marriage
+  label: Marriage
+  label_fr: Mariage
+  label_de: Heirat
+```
+
+### vocab/domains.yml
+
+Add domains relevant to this life event:
+
+```yaml
+# Marriage domains
+- id: civil_ceremony
+  label: Civil ceremony
+  label_fr: Cérémonie civile
+  label_de: Standesamtliche Trauung
+  life_events: [marriage]
+
+- id: documents_and_certificates
+  label: Documents and certificates
+  label_fr: Documents et certificats
+  label_de: Dokumente und Bescheinigungen
+  life_events: [marriage]
+
+- id: name_change
+  label: Name change
+  label_fr: Changement de nom
+  label_de: Namensänderung
+  life_events: [marriage]
+```
+
+### vocab/checklist_groups.yml
+
+Add rendering groups for the new event's checklist UI:
+
+```yaml
+- id: pre_ceremony
+  label: Before the ceremony
+  label_fr: Avant la cérémonie
+  label_de: Vor der Zeremonie
+  sort_order: 1
+
+- id: ceremony_and_registration
+  label: Ceremony and registration
+  label_fr: Cérémonie et enregistrement
+  label_de: Zeremonie und Registrierung
+  sort_order: 2
+
+- id: post_ceremony
+  label: After the ceremony
+  label_fr: Nach der Zeremonie
+  label_de: Nach der Zeremonie
+  sort_order: 3
+```
+
+---
+
+## Step 2: Create the Directory Structure
+
+```
+graph/
+  conditions/marriage/lu/
+  consequences/marriage/lu/
+  task_templates/marriage/lu/
+  deadlines/marriage/lu/
+  intake_fact_types/marriage/
+tests/
+  scenarios/lu/
+```
+
+Note that these directories are **not** jurisdiction-scoped:
+- `graph/authorities/<jurisdiction>/` — already exists, shared across life events
+- `graph/evidence_types/<jurisdiction>/` — shared
+- `graph/forms/<jurisdiction>/` — shared
+
+---
+
+## Step 3: Define Intake Fact Types
+
+Intake facts are the questions asked to users. They are global (not jurisdiction-specific) and scoped by life event:
+
+```yaml
+# graph/intake_fact_types/marriage/ceremony_country.yml
+id: intake_fact.global.marriage.ceremony_country
+schema_version: "0.1.0"
+path: marriage.ceremony.country
+label: "Country where the marriage will take place"
+description: "The jurisdiction where the civil ceremony will be held."
+value_type: jurisdiction_code
+allowed_values_ref: vocab/jurisdictions.yml
+cardinality: one
+required_for:
+  - consequence.lu.marriage.civil_ceremony.book_ceremony
+used_by_condition_refs:
+  - condition.lu.marriage.civil_ceremony.ceremony_in_lu
+```
+
+```yaml
+# graph/intake_fact_types/marriage/nationality_partner_a.yml
+id: intake_fact.global.marriage.nationality_partner_a
+schema_version: "0.1.0"
+path: partner_a.nationality
+label: "Nationality of partner A"
+description: "ISO country code for the nationality of the first partner."
+value_type: jurisdiction_code
+allowed_values_ref: vocab/jurisdictions.yml
+cardinality: one
+required_for: []
+used_by_condition_refs: []
+```
+
+> **Progressive intake pattern (spec §20.2):** Start with 5–6 essential questions, generate a first checklist, then ask follow-ups when they unlock additional items.
+
+---
+
+## Step 4: Register Sources and Capture
+
+Follow the same source workflow as for jurisdictions:
+
+1. Add the source to `sources/register.yml`
+2. Capture with `pnpm capture <source_id>`
+3. Extract assertions with `pnpm extract <snapshot_id>`
+
+```yaml
+# In sources/register.yml
+- id: source.guichet_lu.marriage
+  title: "Se marier au Luxembourg"
+  title_en: "Getting married in Luxembourg"
+  url: "https://guichet.public.lu/fr/citoyens/..."
+  source_type: government_portal
+  jurisdiction: LU
+  publisher: "Guichet.lu (Luxembourg Government)"
+  languages: [fr]
+  domain: civil_ceremony
+  life_event: marriage
+  source_role: primary_guidance
+  monitoring:
+    active: false
+  verified_at: null
+```
+
+---
+
+## Step 5: Build the Graph Records
+
+### Condition
+
+```yaml
+# graph/conditions/marriage/lu/ceremony_in_lu.yml
+id: condition.lu.marriage.civil_ceremony.ceremony_in_lu
+schema_version: "0.1.0"
+title: "Marriage ceremony takes place in Luxembourg"
+condition_type: criterion
+jurisdiction: LU
+life_event: marriage
+domain: civil_ceremony
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "marriage.ceremony.country" }
+    - "LU"
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.marriage.ceremony_country
+source_assertion_refs: []
+record_valid_from: "2026-06-10"
+authoring_status: draft
+distribution_status: public_open
+```
+
+### Consequence
+
+```yaml
+# graph/consequences/marriage/lu/book_ceremony.yml
+id: consequence.lu.marriage.civil_ceremony.book_ceremony
+schema_version: "0.1.0"
+title: "Book civil ceremony at the commune"
+description: >
+  Partners must book a civil ceremony at the commune where the
+  marriage will take place, at least one month in advance.
+consequence_type: administrative_step
+jurisdiction: LU
+life_event: marriage
+domain: civil_ceremony
+trigger:
+  condition_refs:
+    - condition.lu.marriage.civil_ceremony.ceremony_in_lu
+task_template_refs:
+  - task_template.lu.marriage.civil_ceremony.book_commune
+source_assertion_refs: []
+authoring_status: draft
+distribution_status: restricted_source
+confidence: unassessed
+record_valid_from: "2026-06-10"
+```
+
+### Task template
+
+```yaml
+# graph/task_templates/marriage/lu/book_commune.yml
+id: task_template.lu.marriage.civil_ceremony.book_commune
+schema_version: "0.1.0"
+title: "Book civil ceremony at the commune"
+description: >
+  Contact the commune where the marriage will take place to reserve
+  a date for the civil ceremony.
+action_type: book_appointment
+jurisdiction: LU
+life_event: marriage
+domain: civil_ceremony
+authority_refs:
+  - authority.lu.bureau_etat_civil
+deadline_refs: []
+rendering:
+  checklist_group: pre_ceremony
+  urgency_score: 80
+  dependency_rank: 1
+  user_visible_caveat: null
+authoring_status: draft
+distribution_status: restricted_source
+record_valid_from: "2026-06-10"
+```
+
+---
+
+## Step 6: Add a Scenario Test
+
+```yaml
+# tests/scenarios/lu/core_marriage.yml
+id: scenario_test.lu.core_marriage
+schema_version: "0.1.0"
+title: "Luxembourg core — marriage ceremony in Luxembourg"
+scenario_type: single_jurisdiction
+life_event: marriage
+countries: [LU]
+
+facts:
+  - fact_type: marriage.ceremony.country
+    value: LU
+
+expected_consequence_statuses:
+  consequence.lu.marriage.civil_ceremony.book_ceremony: applies
+```
+
+---
+
+## Step 7: Validate and Open a PR
+
+```bash
+pnpm validate
+pnpm lint-ids
+pnpm check-references
+pnpm check-anchors
+pnpm check-publication-gate
+pnpm test-scenarios
+pnpm test
+pnpm typecheck
+```
+
+> **Life event isolation rule:** CI verifies that marriage records cannot affect bereavement exports. Each life event is filtered by `life_event` field during generation.
+
+---
+
+## Key Differences from Adding a Jurisdiction
+
+| Aspect | New jurisdiction | New life event |
+|---|---|---|
+| Vocab changes | `jurisdictions.yml` | `life_events.yml` + `domains.yml` + `checklist_groups.yml` |
+| New directories | Under existing life event dirs | New dirs under `conditions/`, `consequences/`, `task_templates/`, `intake_fact_types/` |
+| Authorities | New per-jurisdiction | Reuses existing (same office handles multiple events) |
+| Intake facts | Reuses existing (e.g. `death.place.country`) | New fact types (e.g. `marriage.ceremony.country`) |
+| Generator | Filters by jurisdiction in conditions | Filters by `life_event` field |
+| Scenario tests | New per-jurisdiction dir | New tests under existing jurisdiction dirs |

--- a/docs/REVIEW_POLICY.md
+++ b/docs/REVIEW_POLICY.md
@@ -1,0 +1,267 @@
+# Review Policy
+
+This document defines how content is reviewed, approved, and published in the Clarvia consequence graph. It covers the review lifecycle, roles, AI boundaries, and publication gates.
+
+---
+
+## Core Principles
+
+1. **No checklist item without a source assertion.** Every user-facing claim must trace back to a captured government source.
+2. **No AI-written legal consequence can publish without human approval.** AI may draft, but humans approve.
+3. **No source assertion without a captured source snapshot.** Assertions must be anchored to a specific, archived version of a page.
+4. **No source assertion approval without checking the anchor.** The `text_quote` must exist in the captured HTML.
+5. **No external contributor approval rights by default.** Only founders and designated reviewers can approve.
+
+---
+
+## Review Phases
+
+The review model evolves with the size of the team:
+
+### Phase 1: Solo Founder (current)
+
+| What | Who reviews | Rule |
+|---|---|---|
+| Source assertions | Founder | Self-review with **mandatory 24-hour delay** between extraction and approval |
+| Graph records | Founder | Self-review, no delay required |
+| Scenario tests | Founder | Self-review |
+
+The 24-hour delay for assertions ensures the reviewer comes back with fresh eyes. Extraction and approval should not happen in the same session.
+
+### Phase 2: First Reviewer (2–3 people)
+
+| What | Who reviews | Rule |
+|---|---|---|
+| Source assertions | Legal reviewer | Approves assertions. **High-risk assertions** require founder + legal reviewer |
+| Graph records | Founder | Approves modeling decisions |
+| Scenario tests | Any team member | Reviews test logic |
+
+### Phase 3: Mature (5+ people)
+
+| What | Who reviews | Rule |
+|---|---|---|
+| Source assertions | Jurisdiction reviewer | Approved per jurisdiction. Cross-border items require jurisdiction + cross-border reviewer |
+| Graph records | Role-based via CODEOWNERS | Per-directory ownership |
+| Scenario tests | Any contributor | With CI verification |
+
+> **Jurisdiction reviewer rule (spec §18.6):** No jurisdiction can publish public checklist records without an approved jurisdiction reviewer or a documented temporary founder review policy.
+
+---
+
+## Status Lifecycles
+
+### Assertion Review Status
+
+```
+draft → in_review → changes_requested → approved
+                                      → rejected
+                                      → superseded
+```
+
+| Status | Meaning |
+|---|---|
+| `draft` | AI-extracted or contributor-submitted, not yet reviewed |
+| `in_review` | Under active review |
+| `changes_requested` | Reviewer requested changes |
+| `approved` | Verified against source, ready for publication |
+| `rejected` | Claim is incorrect or not supported by source |
+| `superseded` | Replaced by a newer assertion |
+
+### Authoring Status (graph records)
+
+```
+draft → in_review → changes_requested → approved → deprecated
+                                                  → withdrawn
+```
+
+### Confidence Levels
+
+| Level | Meaning |
+|---|---|
+| `high` | Multiple sources agree, clear legal basis |
+| `medium` | Single official source, clear statement |
+| `low` | Inferred or ambiguous source |
+| `unassessed` | AI/contributor draft, not yet reviewed |
+
+---
+
+## High-Risk vs. Lower-Risk Assertions
+
+Not all assertions carry the same risk. **High-risk claim types** require stricter review:
+
+### High-risk (require careful legal review)
+
+- `deadline` — wrong deadlines cause missed obligations
+- `eligibility_condition` — wrong conditions exclude entitled people
+- `exception` — wrong exceptions mislead users
+- `legal_scope` — wrong scope misrepresents the law
+- `fee` — wrong amounts cause financial harm
+- `obligation` — wrong obligations cause unnecessary actions
+- `liability` — wrong liability info causes legal exposure
+
+### Lower-risk (single reviewer sufficient)
+
+- `authority` — which office handles this
+- `form` — which form to file
+- `channel` — online vs. in-person
+- `filing_location` — where to go
+- `document_required` — what to bring
+
+---
+
+## Publication Gate
+
+A consequence can only appear in the public checklist output when all of these are true:
+
+| Gate | Requirement |
+|---|---|
+| **Source present** | Consequence has at least one `source_assertion_ref` |
+| **Assertion approved** | Referenced assertions have `review_status: approved` |
+| **Anchor verified** | Assertion `text_quote` exists in the captured snapshot HTML |
+| **Confidence set** | Assertion `confidence` is not `null` or `unassessed` |
+| **Authoring approved** | Consequence has `authoring_status: approved` |
+| **Distribution public** | Consequence has `distribution_status: public_open` |
+
+Records that don't pass the gate are filtered out by the generator — they exist in the repo but are invisible to users.
+
+### Distribution Status Values
+
+| Status | Meaning |
+|---|---|
+| `public_open` | Visible in public checklist output |
+| `public_metadata_only` | Metadata visible, details hidden |
+| `private_overlay` | Only in private/paid overlays |
+| `restricted_source` | Draft or under review — not in public output |
+
+### Promotion Path
+
+```
+restricted_source → public_open
+```
+
+A record is promoted from `restricted_source` to `public_open` when:
+1. All referenced source assertions are `approved`
+2. The record's `authoring_status` is set to `approved`
+3. The publication gate CI check passes
+
+---
+
+## AI Boundary
+
+AI is used extensively in the workflow but has clear boundaries:
+
+| Stage | AI allowed? | Human checkpoint |
+|---|---|---|
+| Source discovery | ✅ Find candidate URLs | Human confirms the source is official |
+| Snapshot capture | ✅ Deterministic CLI | Automated — no human needed |
+| Assertion extraction | ✅ Draft claims from HTML | Human checks anchor text and claim accuracy before setting `approved` |
+| Consequence drafting | ✅ Draft YAML records | Human reviews modeling before setting `approved` |
+| Review assistance | ✅ Flag potential issues | Human makes the decision |
+| Translation | ✅ Draft translations | Human verifies legal/admin wording |
+| Monitoring diffs | ✅ Summarize source changes | Human classifies severity |
+
+**Provenance honesty:** The `extraction_method` field stays `ai_assisted` even after human approval. This is an honest record of how the content was created, not a quality judgment.
+
+---
+
+## Contributor Model
+
+**Fork-and-PR model.** External contributors may propose content but cannot approve it.
+
+### Contributors CAN
+
+- Discover and suggest official sources
+- Draft assertions (`review_status: draft`)
+- Draft graph records (`authoring_status: draft`)
+- Add scenario tests
+- Report staleness or contradictions
+- Propose translations
+- Fix typos and metadata
+
+### Contributors CANNOT
+
+- Approve assertions (set `review_status: approved`)
+- Approve graph records (set `authoring_status: approved`)
+- Merge PRs
+- Resolve contradictions
+- Publish gold overlays
+
+### Contributed records always start as
+
+```yaml
+# Assertions
+review_status: draft
+confidence: unassessed
+
+# Graph records
+authoring_status: draft
+distribution_status: restricted_source
+```
+
+### Licensing
+
+| Component | License |
+|---|---|
+| Code | EUPL-1.2 |
+| Data (graph records, assertions) | CC-BY-4.0 |
+| Schemas and vocabularies | CC0 or Apache-2.0 |
+| Contributor agreement | Developer Certificate of Origin (DCO) — not a CLA |
+
+---
+
+## Contradiction Handling
+
+When two assertions make conflicting claims, the CI `check-contradictions` command detects and reports them.
+
+### Contradiction Types
+
+- `direct_value_conflict` — two assertions state different values for the same fact
+- `source_tier_conflict` — primary law vs. guidance portal disagree
+- `temporal_conflict` — old vs. new source disagree
+- `scope_conflict` — overlapping jurisdiction scopes
+- `translation_conflict` — translation diverges from source language
+- `jurisdiction_conflict` — cross-border rules conflict
+
+### Publication Rules for Contradictions
+
+| Contradiction status | Can publish? |
+|---|---|
+| `none` | ✅ Yes |
+| `resolved` | ✅ Yes |
+| `accepted_uncertainty` | ✅ Only for non-high-risk items |
+| `suspected` / `in_review` | ❌ No |
+| `quarantined` | ❌ No |
+
+**High-risk contradictions always block publication.**
+
+---
+
+## CI Validation Pipeline
+
+Every PR runs these checks:
+
+```bash
+pnpm validate               # JSON Schema validation for all YAML files
+pnpm lint-ids               # ID grammar and length rules
+pnpm check-references       # All _refs point to existing records
+pnpm check-anchors          # Assertion text_quotes exist in snapshot HTML
+pnpm check-publication-gate # No unapproved assertions in public_open records
+pnpm check-contradictions   # Flag overlapping conflicting claims
+pnpm test-scenarios         # Scenario regression tests pass
+pnpm test                   # Unit tests pass
+pnpm typecheck              # TypeScript type checking
+```
+
+All must pass for the PR to be mergeable.
+
+---
+
+## Monitoring (Future)
+
+Sources will eventually be monitored for changes:
+
+```
+unmonitored → monitored → review_due → source_changed → stale → quarantined
+```
+
+When a source page changes, the monitoring system flags assertions linked to that source for re-review. Assertions linked to `quarantined` sources are automatically hidden from public output.

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -1,0 +1,206 @@
+# Translations
+
+This document explains how multilingual content works in the Clarvia consequence graph — what gets translated, what doesn't, and how to contribute translations.
+
+---
+
+## Supported Locales
+
+The graph currently supports these locales (defined in `vocab/locales.yml`):
+
+| Code | Language |
+|---|---|
+| `en` | English |
+| `fr` | French |
+| `de` | German |
+| `nl` | Dutch |
+| `lb` | Luxembourgish |
+| `pt` | Portuguese |
+
+---
+
+## What Gets Translated
+
+### User-facing record fields
+
+These fields appear in the checklist UI and need translations:
+
+- **Consequence** — `title`, `description`
+- **Task template** — `title`, `description`
+- **Deadline** — `title`
+- **Condition** — `title`, `description`
+- **Authority** — `name`, `name_en`, `name_de`
+- **Checklist group labels** — already multilingual in `vocab/checklist_groups.yml`
+- **Vocab labels** — already multilingual in all vocab files
+
+### Controlled vocabularies (already translated inline)
+
+Vocab files already carry multilingual labels directly. Example from `vocab/jurisdictions.yml`:
+
+```yaml
+- id: LU
+  label: Luxembourg
+  label_fr: Luxembourg
+  label_de: Luxemburg
+```
+
+And `vocab/checklist_groups.yml`:
+
+```yaml
+- id: immediate_formalities
+  label: Immediate formalities
+  label_fr: Formalités immédiates
+  label_de: Sofortige Formalitäten
+  sort_order: 1
+```
+
+### Authority records (already translated inline)
+
+Authority records carry multilingual names directly:
+
+```yaml
+id: authority.lu.bureau_etat_civil
+name: "Bureau de l'état civil"
+name_en: "Civil Registry Office"
+name_de: "Standesamt"
+```
+
+---
+
+## What Does NOT Get Translated
+
+### Source assertion `claim_text`
+
+The `claim_text` stays in the source's original language. This is the canonical legal/administrative statement extracted from the government source. Translations of `claim_text` are non-canonical overlays, not replacements.
+
+```yaml
+# This stays in French — the source is a French government page
+claim_text: >
+  En cas de décès, une déclaration doit être faite dans les 24 heures
+  à l'officier de l'état civil du lieu du décès.
+```
+
+### Anchor text (`anchor.text_quote`)
+
+The anchor must match the captured HTML exactly. It is never translated — it's a content-addressed reference to the source.
+
+---
+
+## Translation Overlay Files
+
+Translations are stored as **overlay files** in the `translations/` directory, mirroring the graph structure:
+
+```
+translations/
+  en/
+    graph/consequences/bereavement/lu/declare_death.yml
+  fr/
+    graph/consequences/bereavement/lu/declare_death.yml
+  de/
+    graph/consequences/bereavement/lu/declare_death.yml
+```
+
+### Overlay format
+
+```yaml
+record_id: consequence.lu.bereavement.death_registration.declare_death
+locale: fr
+fields:
+  title: "Déclarer le décès à l'officier de l'état civil"
+  description: >
+    En cas de décès survenu au Luxembourg, le décès doit être déclaré
+    au bureau de l'état civil de la commune où le décès a eu lieu.
+translation_status: reviewed
+translated_by: translator.fr.001
+```
+
+### Translation status lifecycle
+
+```
+draft → ai_draft → reviewed → approved
+```
+
+| Status | Meaning |
+|---|---|
+| `draft` | Human-written first draft |
+| `ai_draft` | AI-generated translation, not yet reviewed |
+| `reviewed` | Checked by a bilingual reviewer |
+| `approved` | Final, suitable for production |
+
+---
+
+## Locale-Specific Exports
+
+The web export pipeline generates locale-specific bundles:
+
+```
+build/exports/web/runtime/en/bereavement-lu-de-fr.json
+build/exports/web/runtime/fr/bereavement-lu-de-fr.json
+build/exports/web/runtime/de/bereavement-lu-de-fr.json
+```
+
+### Fallback order
+
+When a translation is missing, the system falls back:
+
+```
+fr: [fr, en, source_language]
+de: [de, en, source_language]
+en: [en, source_language]
+```
+
+If an important translation is missing, the UI shows:
+
+> *"Some source excerpts are shown in their original language."*
+
+---
+
+## Contributing Translations
+
+### What you can translate
+
+- Consequence titles and descriptions
+- Task template titles and descriptions
+- Deadline titles
+- Condition titles and descriptions
+- Vocab labels (add `label_<locale>` to vocab entries)
+
+### How to contribute
+
+1. Create a translation overlay file in the appropriate `translations/<locale>/` directory
+2. Set `translation_status: draft` (or `ai_draft` if AI-generated)
+3. Open a PR
+
+### Rules
+
+- **Never modify `claim_text`** in source assertions — that stays in the source language
+- **Never modify `anchor.text_quote`** — that must match the HTML exactly
+- AI-generated translations should use `translation_status: ai_draft`
+- A human must verify legal/administrative wording before `reviewed` or `approved`
+- **Review language rule:** No high-risk assertion may be approved by a reviewer who cannot read the source language, unless a qualified translation review is attached
+
+---
+
+## CI Gates
+
+```yaml
+translation_gate:        # Missing high-priority UI translations fail web export
+                         # for supported locales
+review_language_gate:    # High-risk assertions require reviewer competence
+                         # in the source language, or a reviewed translation
+```
+
+---
+
+## Current Status
+
+The `translations/` directory currently contains only `.gitkeep` placeholder files:
+
+```
+translations/
+  en/   (.gitkeep)
+  fr/   (.gitkeep)
+  de/   (.gitkeep)
+```
+
+Translation overlay files will be added as the graph grows beyond the initial alpha jurisdictions. For alpha, the primary content language is the source language (French for LU/FR sources, German for DE sources), with English `title_en` / `name_en` fields providing basic English coverage directly in the record files.


### PR DESCRIPTION
Adds the 4 core onboarding documents per issue #11:

- **ADDING_A_JURISDICTION.md** — 12-step walkthrough using Belgium (BE) as the worked example. Covers coverage stages, directory skeleton, source capture, assertion extraction, graph records, scenario tests, and the promotion path to published.
- **ADDING_A_LIFE_EVENT.md** — Walkthrough using marriage as the example. Covers vocab entries, directory structure, intake fact types, and the key differences from adding a jurisdiction.
- **REVIEW_POLICY.md** — Covers the 3-phase review model (solo founder → first reviewer → mature team), high-risk vs lower-risk assertions, publication gate requirements, AI boundaries, contributor model, contradiction handling, and the full CI pipeline.
- **TRANSLATIONS.md** — Explains the translation overlay system, what gets translated vs. stays in source language, fallback order, and CI gates.

All documents reference spec v0.1 and use real file patterns from the existing LU/DE/FR records.

Closes #11