### PR TITLE
feat: Add LU foundation records — authorities, evidence types, forms, intake facts

### DIFF
--- a/graph/authorities/eu/ejustice_portal.yml
+++ b/graph/authorities/eu/ejustice_portal.yml
@@ -1,0 +1,19 @@
+id: authority.eu.ejustice_portal
+schema_version: "0.1.0"
+name: Portail européen e-Justice
+name_en: European e-Justice Portal
+name_de: Europäisches Justizportal
+description: EU portal explaining succession law, jurisdiction, and European Certificate of Succession.
+jurisdiction: EU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/EUR
+function: eu_justice_information
+official_site: https://e-justice.europa.eu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/acd.yml
+++ b/graph/authorities/lu/acd.yml
@@ -1,13 +1,13 @@
-id: authority.lu.bureau_etat_civil
+id: authority.lu.acd
 schema_version: "0.1.0"
-name: Bureau de l'état civil
-name_en: Civil registrar's office
-name_de: Standesamt
-description: Civil registration office of the commune where the death occurred.
+name: Administration des contributions directes
+name_en: Luxembourg Inland Revenue
+name_de: Verwaltung der direkten Steuern
+description: Direct tax authority for income tax return Form 100.
 jurisdiction: LU
 jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
-function: civil_registration
-official_site: https://guichet.public.lu/
+function: direct_tax
+official_site: https://impotsdirects.public.lu/
 contact_channels: []
 languages:
 - fr

--- a/graph/authorities/lu/aed.yml
+++ b/graph/authorities/lu/aed.yml
@@ -1,17 +1,19 @@
 id: authority.lu.aed
 schema_version: "0.1.0"
-name: "Administration de l'enregistrement, des domaines et de la TVA (AED)"
-name_en: "Registration Duties, Estates and VAT Authority"
-description: >
-  The Administration de l'enregistrement, des domaines et de la TVA (AED) is
-  responsible for inheritance declarations, succession duties, and VAT
-  administration in Luxembourg.
+name: Administration de l'enregistrement, des domaines et de la TVA
+name_en: Registration Duties, Estates and VAT Authority
+name_de: Einregistrierungs-, Domänen- und Mehrwertsteuerverwaltung
+description: Authority for succession declarations, wills-register searches, and inheritance/transfer duties.
 jurisdiction: LU
-jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/LUX"
-function: "Succession duties, inheritance declarations, VAT"
-official_site: "https://pfi.public.lu/fr/aed.html"
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: registration_estates_tax
+official_site: https://pfi.public.lu/
 contact_channels: []
-languages: [fr, de, lb]
+languages:
+- fr
+- de
+- en
 authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-05"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/ccss.yml
+++ b/graph/authorities/lu/ccss.yml
@@ -1,0 +1,19 @@
+id: authority.lu.ccss
+schema_version: "0.1.0"
+name: Centre commun de la sécurité sociale
+name_en: Joint Social Security Centre
+name_de: Gemeinsames Zentrum der Sozialversicherung
+description: Social-security registration and affiliation centre, including self-employed affiliation changes.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: social_security
+official_site: https://www.ccss.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/chambre_notaires.yml
+++ b/graph/authorities/lu/chambre_notaires.yml
@@ -1,0 +1,19 @@
+id: authority.lu.chambre_notaires
+schema_version: "0.1.0"
+name: Chambre des Notaires du Grand-Duché de Luxembourg
+name_en: Chamber of Notaries of Luxembourg
+name_de: Notarkammer Luxemburg
+description: Official professional chamber for Luxembourg notaries.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: notarial_professional_body
+official_site: https://www.notariat.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/cnap.yml
+++ b/graph/authorities/lu/cnap.yml
@@ -1,17 +1,19 @@
 id: authority.lu.cnap
 schema_version: "0.1.0"
-name: "Caisse Nationale d'Assurance Pension"
-name_en: "National Pension Insurance Fund"
-name_de: "Nationale Pensionsversicherungskasse"
-description: >
-  The CNAP manages old-age, invalidity, and survivor pensions in Luxembourg.
-  Survivor pension claims must be filed with CNAP within set deadlines.
+name: Caisse nationale d'assurance pension
+name_en: National Pension Insurance Fund
+name_de: Nationale Pensionsversicherungsanstalt
+description: Luxembourg pension authority for survivor-pension applications.
 jurisdiction: LU
-jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/LUX"
-function: "Pension insurance — old-age, invalidity, survivor pensions"
-official_site: "https://www.cnap.lu"
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: pension_authority
+official_site: https://cnap.public.lu/
 contact_channels: []
-languages: [fr, de]
-authoring_status: draft
+languages:
+- fr
+- de
+- en
+authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-03"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/cns.yml
+++ b/graph/authorities/lu/cns.yml
@@ -1,0 +1,19 @@
+id: authority.lu.cns
+schema_version: "0.1.0"
+name: Caisse nationale de santé
+name_en: National Health Fund
+name_de: Nationale Gesundheitskasse
+description: Health insurance authority for funeral allowance and health-insurance death procedures.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: health_insurance
+official_site: https://cns.public.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/cssf.yml
+++ b/graph/authorities/lu/cssf.yml
@@ -1,0 +1,19 @@
+id: authority.lu.cssf
+schema_version: "0.1.0"
+name: Commission de Surveillance du Secteur Financier
+name_en: Financial Sector Supervisory Commission
+name_de: Finanzaufsichtskommission
+description: Financial regulator providing guidance on tracing bank and financial assets.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: financial_regulator
+official_site: https://www.cssf.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/district_court_registry.yml
+++ b/graph/authorities/lu/district_court_registry.yml
@@ -1,0 +1,19 @@
+id: authority.lu.district_court_registry
+schema_version: "0.1.0"
+name: Greffe du tribunal d'arrondissement
+name_en: District court registry
+name_de: Geschäftsstelle des Bezirksgerichts
+description: Court registry relevant for formal inheritance options where applicable.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: court_registry
+official_site: https://justice.public.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/employer.yml
+++ b/graph/authorities/lu/employer.yml
@@ -1,12 +1,12 @@
-id: authority.lu.bureau_etat_civil
+id: authority.lu.employer
 schema_version: "0.1.0"
-name: Bureau de l'état civil
-name_en: Civil registrar's office
-name_de: Standesamt
-description: Civil registration office of the commune where the death occurred.
+name: Employeur
+name_en: Employer
+name_de: Arbeitgeber
+description: Employer who grants statutory special leave for personal reasons.
 jurisdiction: LU
 jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
-function: civil_registration
+function: employment_relationship
 official_site: https://guichet.public.lu/
 contact_channels: []
 languages:

--- a/graph/authorities/lu/medecin_inspecteur_sante.yml
+++ b/graph/authorities/lu/medecin_inspecteur_sante.yml
@@ -1,0 +1,19 @@
+id: authority.lu.medecin_inspecteur_sante
+schema_version: "0.1.0"
+name: Médecin-inspecteur — Direction de la santé
+name_en: Medical inspector — Health Directorate
+name_de: Amtsarzt — Gesundheitsdirektion
+description: Health authority medical inspector competent for extensions beyond the ordinary burial/cremation window.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: public_health_authorisation
+official_site: https://sante.public.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/ministry_economy_business_permits.yml
+++ b/graph/authorities/lu/ministry_economy_business_permits.yml
@@ -1,0 +1,19 @@
+id: authority.lu.ministry_economy_business_permits
+schema_version: "0.1.0"
+name: Ministère de l'Économie — autorisations d'établissement
+name_en: Ministry of the Economy — business permits
+name_de: Wirtschaftsministerium — Niederlassungsgenehmigungen
+description: Authority for business-permit matters after the death of a business owner.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: business_permits
+official_site: https://meco.gouvernement.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/snca.yml
+++ b/graph/authorities/lu/snca.yml
@@ -1,0 +1,19 @@
+id: authority.lu.snca
+schema_version: "0.1.0"
+name: Société nationale de circulation automobile
+name_en: National Society of Automotive Traffic
+name_de: Nationale Gesellschaft für Kraftfahrzeugverkehr
+description: Vehicle registration authority.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: vehicle_registration
+official_site: https://snca.public.lu/
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/authorities/lu/vdl_bierger_center.yml
+++ b/graph/authorities/lu/vdl_bierger_center.yml
@@ -1,0 +1,19 @@
+id: authority.lu.vdl_bierger_center
+schema_version: "0.1.0"
+name: Bierger-Center — Ville de Luxembourg
+name_en: Bierger-Center — City of Luxembourg
+name_de: Bierger-Center — Stadt Luxemburg
+description: Luxembourg City municipal front office for civil-status matters.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+function: municipal_civil_status
+official_site: https://www.vdl.lu/fr/la-ville/administration-communale/bierger-center
+contact_channels: []
+languages:
+- fr
+- de
+- en
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/eu/european_certificate_succession.yml
+++ b/graph/evidence_types/eu/european_certificate_succession.yml
@@ -1,0 +1,15 @@
+id: evidence_type.eu.european_certificate_succession
+schema_version: "0.1.0"
+canonical_name: European Certificate of Succession
+synonyms:
+- certificat successoral européen
+- Europäisches Nachlasszeugnis
+- ECS
+description: EU certificate used to prove succession status or powers in cross-border succession cases.
+jurisdiction: EU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/death_certificate.yml
+++ b/graph/evidence_types/global/death_certificate.yml
@@ -1,0 +1,16 @@
+id: evidence_type.global.death_certificate
+schema_version: "0.1.0"
+canonical_name: Death certificate
+synonyms:
+- acte de décès
+- Sterbeurkunde
+- death-certificate extract
+description: Official civil-status document certifying death.
+jurisdiction: global
+broader: null
+jurisdictional_variants:
+- evidence_type.lu.death_certificate
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/identity_document.yml
+++ b/graph/evidence_types/global/identity_document.yml
@@ -1,0 +1,17 @@
+id: evidence_type.global.identity_document
+schema_version: "0.1.0"
+canonical_name: Identity document
+synonyms:
+- document d'identité
+- pièce d'identité
+- Ausweisdokument
+- passport
+- ID card
+description: Official identity document.
+jurisdiction: global
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/marriage_certificate.yml
+++ b/graph/evidence_types/global/marriage_certificate.yml
@@ -1,0 +1,15 @@
+id: evidence_type.global.marriage_certificate
+schema_version: "0.1.0"
+canonical_name: Marriage certificate
+synonyms:
+- acte de mariage
+- Heiratsurkunde
+description: Official proof of marriage.
+jurisdiction: global
+broader: null
+jurisdictional_variants:
+- evidence_type.lu.marriage_certificate
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/proof_of_payment.yml
+++ b/graph/evidence_types/global/proof_of_payment.yml
@@ -1,0 +1,15 @@
+id: evidence_type.global.proof_of_payment
+schema_version: "0.1.0"
+canonical_name: Proof of payment
+synonyms:
+- preuve de paiement
+- payment proof
+- Zahlungsnachweis
+description: Proof that the applicant paid or advanced an invoice.
+jurisdiction: global
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/rib.yml
+++ b/graph/evidence_types/global/rib.yml
@@ -1,0 +1,15 @@
+id: evidence_type.global.rib
+schema_version: "0.1.0"
+canonical_name: Bank-account details / RIB
+synonyms:
+- relevé d'identité bancaire
+- RIB
+- IBAN statement
+description: Bank account details for receiving payments.
+jurisdiction: global
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/global/school_certificate.yml
+++ b/graph/evidence_types/global/school_certificate.yml
@@ -1,0 +1,14 @@
+id: evidence_type.global.school_certificate
+schema_version: "0.1.0"
+canonical_name: School certificate
+synonyms:
+- certificat scolaire
+- Schulbescheinigung
+description: School certificate, commonly relevant to orphan or child-benefit-related claims.
+jurisdiction: global
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/acte_de_notoriete.yml
+++ b/graph/evidence_types/lu/acte_de_notoriete.yml
@@ -1,0 +1,15 @@
+id: evidence_type.lu.acte_de_notoriete
+schema_version: "0.1.0"
+canonical_name: Acte de notoriété
+synonyms:
+- certificate of inheritance
+- Erbschein / Erbnachweis
+- notarial certificate of inheritance
+description: Notarial certificate establishing heirs and inheritance rights.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/aed_attestation_succession.yml
+++ b/graph/evidence_types/lu/aed_attestation_succession.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.aed_attestation_succession
+schema_version: "0.1.0"
+canonical_name: Attestation de succession AED
+synonyms:
+- AED certificate of succession
+- attestation of succession
+description: Succession attestation issued by AED, notably used for inherited-vehicle formalities.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/burial_or_cremation_authorisation.yml
+++ b/graph/evidence_types/lu/burial_or_cremation_authorisation.yml
@@ -1,0 +1,15 @@
+id: evidence_type.lu.burial_or_cremation_authorisation
+schema_version: "0.1.0"
+canonical_name: Autorisation d'inhumation ou de dépôt des cendres
+synonyms:
+- burial permit
+- cremation/burial authorisation
+- Bestattungsgenehmigung
+description: Written authorisation for burial, cremation, or deposit of ashes.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/cnap_survivor_pension_form.yml
+++ b/graph/evidence_types/lu/cnap_survivor_pension_form.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.cnap_survivor_pension_form
+schema_version: "0.1.0"
+canonical_name: Demande de pension de survie
+synonyms:
+- survivor pension application form
+- formulaire pension de survie
+description: CNAP survivor-pension application form.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/cremation_intent_proof.yml
+++ b/graph/evidence_types/lu/cremation_intent_proof.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.cremation_intent_proof
+schema_version: "0.1.0"
+canonical_name: Preuve de la volonté d'être incinéré
+synonyms:
+- written proof of intent to be cremated
+- crémation volonté défunt
+description: Document or family declaration proving the deceased's wish for cremation.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/death_certificate.yml
+++ b/graph/evidence_types/lu/death_certificate.yml
@@ -1,14 +1,15 @@
 id: evidence_type.lu.death_certificate
 schema_version: "0.1.0"
-canonical_name: "Acte de décès"
+canonical_name: Acte de décès
 synonyms:
-  - "Death certificate"
-  - "Sterbeurkunde"
-description: >
-  Official death certificate (acte de décès) issued by the Bureau de l'état civil
-  after the death declaration. This is the primary document needed for most
-  subsequent administrative steps — pension claims, bank account closure, etc.
+- extrait d'acte de décès
+- copie intégrale d'acte de décès
+- Sterbeurkunde
+description: Luxembourg death certificate or extract issued by the commune.
 jurisdiction: LU
-authoring_status: draft
+broader: evidence_type.global.death_certificate
+jurisdictional_variants: []
+authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-03"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/funeral_invoice_paid.yml
+++ b/graph/evidence_types/lu/funeral_invoice_paid.yml
@@ -1,0 +1,15 @@
+id: evidence_type.lu.funeral_invoice_paid
+schema_version: "0.1.0"
+canonical_name: Factures funéraires acquittées
+synonyms:
+- paid funeral invoices
+- original paid funeral invoices
+- quittierte Bestattungsrechnungen
+description: Paid funeral invoices needed for funeral allowance reimbursement.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/identity_document_deceased.yml
+++ b/graph/evidence_types/lu/identity_document_deceased.yml
@@ -1,13 +1,14 @@
 id: evidence_type.lu.identity_document_deceased
 schema_version: "0.1.0"
-canonical_name: "Document d'identité du défunt"
+canonical_name: Document d'identité du défunt
 synonyms:
-  - "Identity document of the deceased"
-  - "Personalausweis des Verstorbenen"
-description: >
-  Identity document (passport, ID card, or residence permit) of the deceased person.
-  Required for the death declaration.
+- identity document of the deceased
+- Ausweisdokument des Verstorbenen
+description: Identity document of the deceased person.
 jurisdiction: LU
-authoring_status: draft
+broader: evidence_type.global.identity_document
+jurisdictional_variants: []
+authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-03"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/livret_de_famille.yml
+++ b/graph/evidence_types/lu/livret_de_famille.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.livret_de_famille
+schema_version: "0.1.0"
+canonical_name: Livret de famille
+synonyms:
+- family record book
+- Familienstammbuch
+description: Family record book or civil-status record supporting death declaration.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/marriage_certificate.yml
+++ b/graph/evidence_types/lu/marriage_certificate.yml
@@ -1,13 +1,14 @@
 id: evidence_type.lu.marriage_certificate
 schema_version: "0.1.0"
-canonical_name: "Acte de mariage"
+canonical_name: Acte de mariage
 synonyms:
-  - "Marriage certificate"
-  - "Heiratsurkunde"
-description: >
-  Marriage certificate proving the marital status with the deceased.
-  Required for survivor pension claims.
+- marriage certificate
+- Heiratsurkunde
+description: Luxembourg or accepted marriage certificate.
 jurisdiction: LU
-authoring_status: draft
+broader: evidence_type.global.marriage_certificate
+jurisdictional_variants: []
+authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-03"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/medical_death_certificate.yml
+++ b/graph/evidence_types/lu/medical_death_certificate.yml
@@ -1,13 +1,15 @@
 id: evidence_type.lu.medical_death_certificate
 schema_version: "0.1.0"
-canonical_name: "Certificat médical de décès"
+canonical_name: Attestation médicale de décès
 synonyms:
-  - "Medical death certificate"
-  - "Ärztliche Sterbeurkunde"
-description: >
-  Medical certificate of death issued by the attending physician.
-  Required for the death declaration at the civil registry.
+- déclaration de décès
+- certificat médical de décès
+- medical certificate of death
+description: Medical certificate/declaration established by a doctor after death.
 jurisdiction: LU
-authoring_status: draft
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
 distribution_status: public_open
-record_valid_from: "2026-06-03"
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/non_violent_death_certificate.yml
+++ b/graph/evidence_types/lu/non_violent_death_certificate.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.non_violent_death_certificate
+schema_version: "0.1.0"
+canonical_name: Attestation médicale de mort non violente
+synonyms:
+- medical certificate of non-violent death
+- Bescheinigung eines nicht gewaltsamen Todes
+description: Medical certificate required for cremation stating no signs or indications of violent death.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/pacemaker_certificate.yml
+++ b/graph/evidence_types/lu/pacemaker_certificate.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.pacemaker_certificate
+schema_version: "0.1.0"
+canonical_name: Certificat pacemaker
+synonyms:
+- pace-maker certificate
+- pacemaker certificate
+description: Certificate for the crematorium about pacemaker status.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/proof_cohabitation.yml
+++ b/graph/evidence_types/lu/proof_cohabitation.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.proof_cohabitation
+schema_version: "0.1.0"
+canonical_name: Preuve de cohabitation
+synonyms:
+- proof of living together
+- domestic community evidence
+description: Proof that a survivor lived with the deceased, relevant to housing transfer rules.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/succession_declaration.yml
+++ b/graph/evidence_types/lu/succession_declaration.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.succession_declaration
+schema_version: "0.1.0"
+canonical_name: Déclaration de succession ou de mutation par décès
+synonyms:
+- inheritance declaration
+- succession declaration
+description: Written declaration filed with AED after death.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/tax_return_form_100.yml
+++ b/graph/evidence_types/lu/tax_return_form_100.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.tax_return_form_100
+schema_version: "0.1.0"
+canonical_name: Déclaration impôt sur le revenu — Modèle 100
+synonyms:
+- Form 100
+- income tax return form
+description: Luxembourg income tax return form for natural persons.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/transfer_agreement_heirs.yml
+++ b/graph/evidence_types/lu/transfer_agreement_heirs.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.transfer_agreement_heirs
+schema_version: "0.1.0"
+canonical_name: Accord de cession signé par les héritiers
+synonyms:
+- signed transfer agreement
+- agreement of heirs
+description: Agreement on vehicle ownership transfer signed by all heirs, where required.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/valid_insurance_certificate.yml
+++ b/graph/evidence_types/lu/valid_insurance_certificate.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.valid_insurance_certificate
+schema_version: "0.1.0"
+canonical_name: Certificat d'assurance valable
+synonyms:
+- valid insurance certificate
+- proof of insurance
+description: Valid motor insurance certificate.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/valid_technical_inspection.yml
+++ b/graph/evidence_types/lu/valid_technical_inspection.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.valid_technical_inspection
+schema_version: "0.1.0"
+canonical_name: Contrôle technique valable
+synonyms:
+- valid MOT
+- valid technical inspection
+description: Valid technical inspection certificate for a vehicle.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/vehicle_registration_certificate_part1.yml
+++ b/graph/evidence_types/lu/vehicle_registration_certificate_part1.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.vehicle_registration_certificate_part1
+schema_version: "0.1.0"
+canonical_name: Certificat d'immatriculation — partie 1
+synonyms:
+- vehicle registration certificate part 1
+- car logbook part 1
+description: Vehicle registration certificate part 1.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/evidence_types/lu/vehicle_registration_certificate_part2.yml
+++ b/graph/evidence_types/lu/vehicle_registration_certificate_part2.yml
@@ -1,0 +1,14 @@
+id: evidence_type.lu.vehicle_registration_certificate_part2
+schema_version: "0.1.0"
+canonical_name: Certificat d'immatriculation — partie 2
+synonyms:
+- vehicle registration certificate part 2
+- car logbook part 2
+description: Vehicle registration certificate part 2.
+jurisdiction: LU
+broader: null
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/forms/lu/model_100.yml
+++ b/graph/forms/lu/model_100.yml
@@ -1,0 +1,19 @@
+id: form.lu.acd.model_100
+schema_version: "0.1.0"
+title: Déclaration pour l'impôt sur le revenu — Modèle 100
+title_en: Income tax return — Form 100
+description: Official income-tax return form for natural persons.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+authority_refs:
+- authority.lu.acd
+url: https://guichet.public.lu/fr/citoyens/fiscalite/declaration-impot-decompte/activite-professionnelle/declaration-revenus/declaration-impot.html
+languages:
+- fr
+- de
+- en
+form_role: blank_template
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/forms/lu/orphan_pension_application.yml
+++ b/graph/forms/lu/orphan_pension_application.yml
@@ -1,0 +1,19 @@
+id: form.lu.cnap.orphan_pension_application
+schema_version: "0.1.0"
+title: Demander une pension d'orphelin
+title_en: Apply for an orphan pension
+description: CNAP form for orphan pension after the death of a parent.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+authority_refs:
+- authority.lu.cnap
+url: https://cnap.public.lu/fr/documentation/formulaires.html
+languages:
+- fr
+- de
+- en
+form_role: blank_template
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/forms/lu/registration_certificate_application.yml
+++ b/graph/forms/lu/registration_certificate_application.yml
@@ -1,0 +1,17 @@
+id: form.lu.snca.registration_certificate_application
+schema_version: "0.1.0"
+title: Demande en obtention d'un certificat d'immatriculation
+title_en: Application for a registration certificate
+description: SNCA form used when registering or changing vehicle-registration certificates.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+authority_refs:
+- authority.lu.snca
+url: https://snca.public.lu/fr/publications.html
+languages:
+- fr
+form_role: blank_template
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/forms/lu/survivor_pension_application.yml
+++ b/graph/forms/lu/survivor_pension_application.yml
@@ -1,0 +1,19 @@
+id: form.lu.cnap.survivor_pension_application
+schema_version: "0.1.0"
+title: Demander une pension de survie
+title_en: Apply for a survival pension
+description: CNAP form for survivor pension in case of spouse or partner death.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+authority_refs:
+- authority.lu.cnap
+url: https://cnap.public.lu/fr/documentation/formulaires.html
+languages:
+- fr
+- de
+- en
+form_role: blank_template
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/forms/lu/wills_register_search.yml
+++ b/graph/forms/lu/wills_register_search.yml
@@ -1,0 +1,17 @@
+id: form.lu.aed.wills_register_search
+schema_version: "0.1.0"
+title: Demande de recherche testamentaire
+title_en: Wills-register search request
+description: AED electronic or paper request for a search in the register of last-will dispositions.
+jurisdiction: LU
+jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
+authority_refs:
+- authority.lu.aed
+url: https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/declaration-succession.html
+languages:
+- fr
+form_role: online_application
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: '2026-06-05'
+record_valid_to: null

--- a/graph/intake_fact_types/bereavement/date_of_death.yml
+++ b/graph/intake_fact_types/bereavement/date_of_death.yml
@@ -1,10 +1,12 @@
 id: intake_fact.global.bereavement.date_of_death
 schema_version: "0.1.0"
 path: death.date
-label: "Date of death"
-description: "The date when the death occurred. Used for deadline calculations."
+label: Date of death
+description: Calendar date on which the death occurred.
 value_type: date
 cardinality: one
 required_for:
-  - deadline.lu.bereavement.death_registration.declaration_deadline
+- starter_intake
+- deadline_calculation
+- succession_declaration_deadline
 used_by_condition_refs: []

--- a/graph/intake_fact_types/bereavement/death_datetime.yml
+++ b/graph/intake_fact_types/bereavement/death_datetime.yml
@@ -1,0 +1,12 @@
+id: intake_fact.global.bereavement.death_datetime
+schema_version: "0.1.0"
+path: death.datetime
+label: Date and time of death
+description: Date and time used for 24-hour and 72-hour deadline calculations.
+value_type: string
+cardinality: one
+required_for:
+- starter_intake
+- deadline_calculation
+- death_declaration_and_funeral_deadlines
+used_by_condition_refs: []

--- a/graph/intake_fact_types/bereavement/deceased_employment_status.yml
+++ b/graph/intake_fact_types/bereavement/deceased_employment_status.yml
@@ -1,0 +1,18 @@
+id: intake_fact.global.bereavement.deceased_employment_status
+schema_version: "0.1.0"
+path: deceased.employment_status
+label: Deceased's employment status
+description: Multi-valued status because a person can be employed and self-employed at the same time.
+value_type: enum
+cardinality: many
+required_for:
+- employment_and_business
+used_by_condition_refs:
+- condition.lu.bereavement.employment.deceased_was_self_employed
+allowed_values:
+- employed
+- self_employed
+- business_owner
+- not_employed
+- retired
+- unknown

--- a/graph/intake_fact_types/bereavement/deceased_habitual_residence.yml
+++ b/graph/intake_fact_types/bereavement/deceased_habitual_residence.yml
@@ -1,12 +1,12 @@
 id: intake_fact.global.bereavement.deceased_habitual_residence
 schema_version: "0.1.0"
 path: deceased.habitual_residence.country
-label: "Country of habitual residence of the deceased"
-description: "The country where the deceased had their habitual residence at the time of death."
+label: Deceased's habitual residence
+description: Country of the deceased's habitual residence / last domicile.
 value_type: jurisdiction_code
-allowed_values_ref: vocab/jurisdictions.yml
 cardinality: one
 required_for:
-  - consequence.lu.bereavement.succession.file_inheritance_declaration
+- starter_intake
 used_by_condition_refs:
-  - condition.lu.bereavement.succession.habitual_residence_lu
+- condition.lu.bereavement.succession.habitual_residence_lu
+- condition.lu.bereavement.inheritance_tax.aed_declaration_may_be_required

--- a/graph/intake_fact_types/bereavement/deceased_owned_vehicle.yml
+++ b/graph/intake_fact_types/bereavement/deceased_owned_vehicle.yml
@@ -1,0 +1,11 @@
+id: intake_fact.global.bereavement.deceased_owned_vehicle
+schema_version: "0.1.0"
+path: deceased.owned_vehicle
+label: Did the deceased own a Luxembourg-registered vehicle?
+description: Whether the deceased owned a vehicle requiring inheritance/registration handling.
+value_type: boolean
+cardinality: one
+required_for:
+- estate_and_assets
+used_by_condition_refs:
+- condition.lu.bereavement.estate_assets.deceased_owned_vehicle

--- a/graph/intake_fact_types/bereavement/deceased_pension_jurisdiction.yml
+++ b/graph/intake_fact_types/bereavement/deceased_pension_jurisdiction.yml
@@ -1,12 +1,12 @@
 id: intake_fact.global.bereavement.deceased_pension_jurisdiction
 schema_version: "0.1.0"
-path: deceased.pension.jurisdiction
-label: "Pension jurisdiction of the deceased"
-description: "Which country's pension system the deceased was insured under."
+path: deceased.last_social_security_affiliation.country
+label: Last pension/social-security affiliation country
+description: Country of the deceased's last known pension or social-security affiliation.
 value_type: jurisdiction_code
-allowed_values_ref: vocab/jurisdictions.yml
 cardinality: one
 required_for:
-  - consequence.lu.bereavement.survivor_pension.claim_survivor_pension
+- pension_and_benefits
 used_by_condition_refs:
-  - condition.lu.bereavement.survivor_pension.deceased_was_lu_insured
+- condition.lu.bereavement.survivor_pension.deceased_was_lu_insured
+- condition.lu.bereavement.health_insurance.deceased_was_lu_health_insured

--- a/graph/intake_fact_types/bereavement/deceased_was_tenant.yml
+++ b/graph/intake_fact_types/bereavement/deceased_was_tenant.yml
@@ -1,0 +1,11 @@
+id: intake_fact.global.bereavement.deceased_was_tenant
+schema_version: "0.1.0"
+path: deceased.housing.was_tenant
+label: Was the deceased a tenant?
+description: Whether the deceased held a rental lease at death.
+value_type: boolean
+cardinality: one
+required_for:
+- housing
+used_by_condition_refs:
+- condition.lu.bereavement.estate_assets.deceased_was_tenant

--- a/graph/intake_fact_types/bereavement/estate_asset_country.yml
+++ b/graph/intake_fact_types/bereavement/estate_asset_country.yml
@@ -1,12 +1,11 @@
 id: intake_fact.global.bereavement.estate_asset_country
 schema_version: "0.1.0"
 path: estate.asset_location.country
-label: "Country where estate assets are located"
-description: "A country where the deceased held assets (bank accounts, real estate, investments, etc.)."
+label: Countries where estate assets are located
+description: Countries where the deceased owned assets. This is multi-valued.
 value_type: jurisdiction_code
-allowed_values_ref: vocab/jurisdictions.yml
 cardinality: many
 required_for:
-  - consequence.fr.bereavement.estate_assets.settle_fr_succession
+- estate_and_assets
 used_by_condition_refs:
-  - condition.fr.bereavement.estate_assets.assets_in_fr
+- condition.lu.bereavement.inheritance_tax.aed_declaration_may_be_required

--- a/graph/intake_fact_types/bereavement/estate_real_estate_exists.yml
+++ b/graph/intake_fact_types/bereavement/estate_real_estate_exists.yml
@@ -1,0 +1,11 @@
+id: intake_fact.global.bereavement.estate_real_estate_exists
+schema_version: "0.1.0"
+path: estate.real_estate.exists
+label: Did the deceased own real estate?
+description: Whether the estate includes immovable property.
+value_type: boolean
+cardinality: one
+required_for:
+- estate_and_assets
+used_by_condition_refs:
+- condition.lu.bereavement.succession.deceased_owned_real_estate

--- a/graph/intake_fact_types/bereavement/jurisdiction_of_death.yml
+++ b/graph/intake_fact_types/bereavement/jurisdiction_of_death.yml
@@ -1,12 +1,11 @@
 id: intake_fact.global.bereavement.jurisdiction_of_death
 schema_version: "0.1.0"
 path: death.place.country
-label: "Country where the death occurred"
-description: "ISO 3166-1 alpha-2 code for the jurisdiction where the death took place."
+label: Country where the death occurred
+description: Country in which the death physically occurred.
 value_type: jurisdiction_code
-allowed_values_ref: vocab/jurisdictions.yml
 cardinality: one
 required_for:
-  - consequence.lu.bereavement.death_registration.declare_death
+- starter_intake
 used_by_condition_refs:
-  - condition.lu.bereavement.death_registration.death_occurred_in_lu
+- condition.lu.bereavement.death_registration.death_occurred_in_lu

--- a/graph/intake_fact_types/bereavement/marriage_or_partnership_status.yml
+++ b/graph/intake_fact_types/bereavement/marriage_or_partnership_status.yml
@@ -1,0 +1,18 @@
+id: intake_fact.global.bereavement.marriage_or_partnership_status
+schema_version: "0.1.0"
+path: marriage_or_partnership.status
+label: Marriage or partnership status
+description: Whether the survivor and deceased were married or in a registered partnership.
+value_type: enum
+cardinality: one
+required_for:
+- pension_and_benefits
+used_by_condition_refs:
+- condition.lu.bereavement.family.survivor_is_spouse_or_partner
+allowed_values:
+- married
+- registered_partnership
+- divorced
+- former_partner
+- not_married_or_partnered
+- unknown

--- a/graph/intake_fact_types/bereavement/relationship_to_deceased.yml
+++ b/graph/intake_fact_types/bereavement/relationship_to_deceased.yml
@@ -1,0 +1,21 @@
+id: intake_fact.global.bereavement.relationship_to_deceased
+schema_version: "0.1.0"
+path: relationship.to_deceased
+label: Relationship to the deceased
+description: Relationship of the user/survivor to the deceased.
+value_type: enum
+cardinality: one
+required_for:
+- starter_intake
+used_by_condition_refs:
+- condition.lu.bereavement.survivor_pension.relationship_eligible_survivor
+- condition.lu.bereavement.family.survivor_is_spouse_or_partner
+allowed_values:
+- surviving_spouse
+- registered_partner
+- child
+- parent
+- sibling
+- other_relative
+- unrelated_person
+- unknown

--- a/graph/intake_fact_types/bereavement/survivor_cohabitation_months.yml
+++ b/graph/intake_fact_types/bereavement/survivor_cohabitation_months.yml
@@ -1,0 +1,11 @@
+id: intake_fact.global.bereavement.survivor_cohabitation_months
+schema_version: "0.1.0"
+path: survivor.cohabitation.months
+label: Months the survivor lived with the deceased
+description: Number of months the survivor lived in domestic community with the deceased.
+value_type: integer
+cardinality: one
+required_for:
+- housing
+used_by_condition_refs:
+- condition.lu.bereavement.estate_assets.cohabitant_lived_six_months

--- a/graph/intake_fact_types/bereavement/survivor_employment_status.yml
+++ b/graph/intake_fact_types/bereavement/survivor_employment_status.yml
@@ -1,0 +1,18 @@
+id: intake_fact.global.bereavement.survivor_employment_status
+schema_version: "0.1.0"
+path: survivor.employment_status
+label: Survivor's employment status
+description: Employment status of the user/survivor for bereavement-leave routing.
+value_type: enum
+cardinality: one
+required_for:
+- employment_and_benefits
+used_by_condition_refs:
+- condition.lu.bereavement.employment.survivor_is_employee
+allowed_values:
+- employee
+- apprentice
+- self_employed
+- not_employed
+- retired
+- unknown


### PR DESCRIPTION
## Summary

Add **47 new** and update **14 existing** graph records for the Luxembourg bereavement checklist alpha enrichment (Phase 1 of Alpha: LU Graph Enrichment project).

### Records added/updated

| Category | New | Updated | Total |
|---|---|---|---|
| Authorities | 12 (11 LU + 1 EU) | 3 | 15 |
| Evidence types | 20 (6 global + 13 LU + 1 EU) | 4 | 24 |
| Forms | 5 | 0 | 5 |
| Intake fact types | 9 | 5 | 14 |
| **Total** | **47** | **14** | **58** |

### Key design decisions

- **Multi-valued cardinality** for deceased_employment_status (can be employed AND self-employed) and estate_asset_country (assets in multiple countries)
- **death_datetime** uses alue_type: string (schema doesn't support datetime; stores ISO 8601 datetime strings)
- **Global evidence types** introduced for cross-jurisdictional reuse (death certificate, identity document, marriage certificate, bank details, proof of payment, school certificate)
- **EU records** added for e-Justice portal authority and European Certificate of Succession evidence type

### Validation

All 58 files pass schema validation (`pnpm run validate`). 3 pre-existing failures in DE/xborder conditions (unrelated var path issue) remain unchanged.

### Blueprint source

Per [LU graph blueprint](https://github.com/clarvia-org/clarvia-graph/blob/main/research/foundation/lu-graph-blueprint.md) sections B, C, F.

Closes #47