### PR TITLE
fix: update condition var paths after intake fact rename

### DIFF
--- a/graph/conditions/bereavement/de/deceased_was_de_insured.yml
+++ b/graph/conditions/bereavement/de/deceased_was_de_insured.yml
@@ -12,7 +12,7 @@ domain: survivor_pension
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
     - "DE"
 missing_fact_behavior: unknown
 information_concept_refs:

--- a/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
@@ -11,7 +11,7 @@ domain: survivor_pension
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
     - "LU"
 missing_fact_behavior: unknown
 information_concept_refs:

--- a/graph/conditions/bereavement/xborder/cross_border_pension.yml
+++ b/graph/conditions/bereavement/xborder/cross_border_pension.yml
@@ -13,7 +13,7 @@ expression_language: jsonlogic
 expression:
   "!=":
     - { "var": "death.place.country" }
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
 missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.jurisdiction_of_death


### PR DESCRIPTION
PR #55 renamed the `deceased_pension_jurisdiction` intake fact path from `deceased.pension.jurisdiction` to `deceased.last_social_security_affiliation.country` but did not update the 3 conditions referencing the old var path, breaking CI validation.

**Files fixed (3):**
- `graph/conditions/bereavement/lu/deceased_was_lu_insured.yml`
- `graph/conditions/bereavement/de/deceased_was_de_insured.yml`
- `graph/conditions/bereavement/xborder/cross_border_pension.yml`

Validation: **93/93 pass** ✅