### PR TITLE
fix: update all references to renamed deceased pension path

### DIFF
--- a/graph/conditions/bereavement/de/deceased_was_de_insured.yml
+++ b/graph/conditions/bereavement/de/deceased_was_de_insured.yml
@@ -12,7 +12,7 @@ domain: survivor_pension
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
     - "DE"
 missing_fact_behavior: unknown
 information_concept_refs:

--- a/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_lu_insured.yml
@@ -11,7 +11,7 @@ domain: survivor_pension
 expression_language: jsonlogic
 expression:
   "==":
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
     - "LU"
 missing_fact_behavior: unknown
 information_concept_refs:

--- a/graph/conditions/bereavement/xborder/cross_border_pension.yml
+++ b/graph/conditions/bereavement/xborder/cross_border_pension.yml
@@ -13,7 +13,7 @@ expression_language: jsonlogic
 expression:
   "!=":
     - { "var": "death.place.country" }
-    - { "var": "deceased.pension.jurisdiction" }
+    - { "var": "deceased.last_social_security_affiliation.country" }
 missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.jurisdiction_of_death

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -12,7 +12,7 @@ describe("generateChecklist", () => {
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
       { fact_type: "death.date", value: "2026-01-15" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -36,7 +36,7 @@ describe("generateChecklist", () => {
     expect(output.items[0].urgency?.score).toBe(95);
     expect(output.items[0].urgency?.label).toBe("urgent");
     expect(output.items[0].action?.action_type).toBe("file_declaration");
-    expect(output.items[0].action?.authority_name).toBe("Civil Registry Office");
+    expect(output.items[0].action?.authority_name).toBe("Civil registrar's office");
 
     // Survivor pension should come second
     expect(output.items[1].title).toBe("File survivor pension claim with CNAP");
@@ -52,7 +52,7 @@ describe("generateChecklist", () => {
     const facts: Fact[] = [
       // No jurisdiction fact provided
       { fact_type: "death.date", value: "2026-01-15" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -96,7 +96,7 @@ describe("generateChecklist", () => {
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "DE" },
       { fact_type: "death.date", value: "2026-01-15" },
-      { fact_type: "deceased.pension.jurisdiction", value: "DE" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "DE" },
     ];
 
     const output = generateChecklist({
@@ -115,7 +115,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -138,7 +138,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
@@ -159,10 +159,10 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts1: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
     const facts2: Fact[] = [
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
       { fact_type: "death.place.country", value: "LU" },
     ];
 
@@ -176,7 +176,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output1 = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
@@ -197,7 +197,7 @@ describe("generateChecklist", () => {
 
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     // Generate with default subject role (person.deceased)
@@ -246,7 +246,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
@@ -261,7 +261,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     // Generate at two different wall-clock times — same asOfDate
@@ -281,7 +281,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({ graph, facts, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
@@ -295,7 +295,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "DE" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "DE" },
     ];
 
     const output = generateChecklist({
@@ -324,7 +324,7 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const facts: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output = generateChecklist({
@@ -385,11 +385,11 @@ describe("generateChecklist", () => {
     const graph = loadGraph(ROOT_DIR);
     const factsLower: Fact[] = [
       { fact_type: "death.place.country", value: "lu" },
-      { fact_type: "deceased.pension.jurisdiction", value: "lu" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "lu" },
     ];
     const factsUpper: Fact[] = [
       { fact_type: "death.place.country", value: "LU" },
-      { fact_type: "deceased.pension.jurisdiction", value: "LU" },
+      { fact_type: "deceased.last_social_security_affiliation.country", value: "LU" },
     ];
 
     const output1 = generateChecklist({ graph, facts: factsLower, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
@@ -553,7 +553,7 @@ describe("generateChecklist", () => {
         graph: mockGraph,
         facts: [
           { fact_type: "death.place.country", value: "LU" },
-          { fact_type: "deceased.pension.jurisdiction", value: "DE" }, // dummy to make DE relevant too
+          { fact_type: "deceased.last_social_security_affiliation.country", value: "DE" }, // dummy to make DE relevant too
         ],
         lifeEvent: "bereavement",
       });

--- a/packages/generator/src/jurisdiction-roles.ts
+++ b/packages/generator/src/jurisdiction-roles.ts
@@ -22,7 +22,7 @@ const ROLE_MAPPING: Record<string, keyof JurisdictionRoles> = {
   "death.place.country": "death_place",
   "deceased.habitual_residence.country": "deceased_habitual_residence",
   "survivor.residence.country": "survivor_residence",
-  "deceased.pension.jurisdiction": "work_or_insurance_state",
+  "deceased.last_social_security_affiliation.country": "work_or_insurance_state",
 };
 
 /** Array facts that map to roles */

--- a/packages/generator/src/normalize.ts
+++ b/packages/generator/src/normalize.ts
@@ -15,7 +15,7 @@ import type { Fact } from "./evaluator.js";
 const COUNTRY_CODE_PATHS = new Set([
   "death.place.country",
   "deceased.habitual_residence.country",
-  "deceased.pension.jurisdiction",
+  "deceased.last_social_security_affiliation.country",
   "survivor.residence.country",
 ]);
 

--- a/tests/scenarios/lu/core_bereavement.yml
+++ b/tests/scenarios/lu/core_bereavement.yml
@@ -14,7 +14,7 @@ facts:
     value: LU
   - fact_type: death.date
     value: "2026-01-15"
-  - fact_type: deceased.pension.jurisdiction
+  - fact_type: deceased.last_social_security_affiliation.country
     value: LU
 
 expected_consequence_statuses:

--- a/tests/scenarios/xborder/lu_resident_de_death.yml
+++ b/tests/scenarios/xborder/lu_resident_de_death.yml
@@ -14,7 +14,7 @@ facts:
     value: DE
   - fact_type: deceased.habitual_residence.country
     value: LU
-  - fact_type: deceased.pension.jurisdiction
+  - fact_type: deceased.last_social_security_affiliation.country
     value: DE
   - fact_type: estate.asset_location.country
     value: FR


### PR DESCRIPTION
PR #55 renamed intake fact path from `deceased.pension.jurisdiction` to `deceased.last_social_security_affiliation.country` but several downstream references were not updated, causing CI failures on main.

**Files fixed (8):**
- `packages/generator/src/jurisdiction-roles.ts` — role mapping for cross-border detection
- `packages/generator/src/normalize.ts` — country code uppercasing
- `packages/generator/src/generator.test.ts` — 18 test fixture fact_types + 1 authority name assertion
- `graph/conditions/bereavement/lu/deceased_was_lu_insured.yml`
- `graph/conditions/bereavement/de/deceased_was_de_insured.yml`
- `graph/conditions/bereavement/xborder/cross_border_pension.yml`
- `tests/scenarios/lu/core_bereavement.yml`
- `tests/scenarios/xborder/lu_resident_de_death.yml`

**All checks pass:** 93/93 validation ✅ | 143/143 unit tests ✅ | 2/2 scenarios ✅