### PR TITLE
feat: Add LU conditions and deadlines for 15-task checklist

### DIFF
--- a/graph/conditions/bereavement/lu/aed_declaration_may_be_required.yml
+++ b/graph/conditions/bereavement/lu/aed_declaration_may_be_required.yml
@@ -1,0 +1,28 @@
+id: condition.lu.bereavement.inheritance_tax.aed_declaration_may_be_required
+schema_version: "0.1.0"
+title: "AED declaration may be required"
+description: >
+  Evaluates whether a succession declaration to the AED may be required.
+  This is the case if the deceased had habitual residence in Luxembourg or
+  if the estate includes assets located in Luxembourg.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: inheritance_tax
+expression_language: jsonlogic
+expression:
+  "or":
+    - "==":
+        - { "var": "deceased.habitual_residence.country" }
+        - "LU"
+    - "in":
+        - "LU"
+        - { "var": "estate.asset_location.country" }
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.deceased_habitual_residence
+  - intake_fact.global.bereavement.estate_asset_country
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/cohabitant_lived_six_months.yml
+++ b/graph/conditions/bereavement/lu/cohabitant_lived_six_months.yml
@@ -1,0 +1,22 @@
+id: condition.lu.bereavement.estate_assets.cohabitant_lived_six_months
+schema_version: "0.1.0"
+title: "Cohabitant lived with deceased for at least 6 months"
+description: >
+  Evaluates whether a cohabitant lived with the deceased for at least 6 months.
+  This may affect the right to remain in the shared dwelling.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: estate_assets
+expression_language: jsonlogic
+expression:
+  ">=":
+    - { "var": "survivor.cohabitation.months" }
+    - 6
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.survivor_cohabitation_months
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
+++ b/graph/conditions/bereavement/lu/death_occurred_in_lu.yml
@@ -16,8 +16,7 @@ expression:
 missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.jurisdiction_of_death
-source_assertion_refs:
-  - assertion.guichet_lu.bereavement.death_must_be_declared
+source_assertion_refs: []
 record_valid_from: "2026-06-03"
-authoring_status: draft
+authoring_status: approved
 distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_owned_real_estate.yml
+++ b/graph/conditions/bereavement/lu/deceased_owned_real_estate.yml
@@ -1,0 +1,23 @@
+id: condition.lu.bereavement.succession.deceased_owned_real_estate
+schema_version: "0.1.0"
+title: "Estate includes real estate"
+description: >
+  Evaluates whether the estate includes real estate. If true, specific
+  succession steps may be required such as notarial acts and land registry
+  updates.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: succession
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "estate.real_estate.exists" }
+    - true
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.estate_real_estate_exists
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_owned_vehicle.yml
+++ b/graph/conditions/bereavement/lu/deceased_owned_vehicle.yml
@@ -1,0 +1,22 @@
+id: condition.lu.bereavement.estate_assets.deceased_owned_vehicle
+schema_version: "0.1.0"
+title: "Deceased owned a vehicle"
+description: >
+  Evaluates whether the deceased owned a vehicle. If true, the vehicle
+  registration must be transferred or cancelled at the SNCA.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: estate_assets
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "deceased.owned_vehicle" }
+    - true
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.deceased_owned_vehicle
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_was_lu_health_insured.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_lu_health_insured.yml
@@ -1,13 +1,13 @@
-id: condition.lu.bereavement.survivor_pension.deceased_was_lu_insured
+id: condition.lu.bereavement.health_insurance.deceased_was_lu_health_insured
 schema_version: "0.1.0"
-title: "Deceased was insured or pensioned in Luxembourg"
+title: "Deceased was covered by Luxembourg health insurance"
 description: >
-  Evaluates whether the deceased person was insured with the Luxembourg pension
-  system (CNAP). If true, the surviving spouse may be entitled to a survivor pension.
+  Evaluates whether the deceased was covered by the Luxembourg health insurance
+  system (CNS). If true, survivors may be entitled to a funeral allowance.
 condition_type: criterion
 jurisdiction: LU
 life_event: bereavement
-domain: survivor_pension
+domain: health_insurance
 expression_language: jsonlogic
 expression:
   "==":
@@ -17,6 +17,6 @@ missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.deceased_pension_jurisdiction
 source_assertion_refs: []
-record_valid_from: "2026-06-03"
+record_valid_from: "2026-06-05"
 authoring_status: approved
 distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_was_self_employed.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_self_employed.yml
@@ -1,0 +1,27 @@
+id: condition.lu.bereavement.employment.deceased_was_self_employed
+schema_version: "0.1.0"
+title: "Deceased was self-employed or a business owner"
+description: >
+  Evaluates whether the deceased was self-employed or a business owner.
+  If true, additional steps may be required such as notifying the Ministry
+  of the Economy about business permits.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: employment
+expression_language: jsonlogic
+expression:
+  "or":
+    - "in":
+        - "self_employed"
+        - { "var": "deceased.employment_status" }
+    - "in":
+        - "business_owner"
+        - { "var": "deceased.employment_status" }
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.deceased_employment_status
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/deceased_was_tenant.yml
+++ b/graph/conditions/bereavement/lu/deceased_was_tenant.yml
@@ -1,0 +1,22 @@
+id: condition.lu.bereavement.estate_assets.deceased_was_tenant
+schema_version: "0.1.0"
+title: "Deceased was a tenant"
+description: >
+  Evaluates whether the deceased was a tenant. If true, the lease may need
+  to be terminated or transferred.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: estate_assets
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "deceased.housing.was_tenant" }
+    - true
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.deceased_was_tenant
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/habitual_residence_lu.yml
+++ b/graph/conditions/bereavement/lu/habitual_residence_lu.yml
@@ -1,6 +1,6 @@
 id: condition.lu.bereavement.succession.habitual_residence_lu
 schema_version: "0.1.0"
-title: "Deceased had habitual residence in Luxembourg"
+title: "Habitual residence was Luxembourg"
 description: >
   Evaluates whether the deceased had their habitual residence in Luxembourg.
   If true, Luxembourg succession procedures apply.
@@ -16,8 +16,7 @@ expression:
 missing_fact_behavior: unknown
 information_concept_refs:
   - intake_fact.global.bereavement.deceased_habitual_residence
-source_assertion_refs:
-  - assertion.guichet_lu.declaration_succession.inheritance_declaration_required
+source_assertion_refs: []
 record_valid_from: "2026-06-05"
 authoring_status: approved
 distribution_status: public_open

--- a/graph/conditions/bereavement/lu/relationship_eligible_survivor.yml
+++ b/graph/conditions/bereavement/lu/relationship_eligible_survivor.yml
@@ -1,0 +1,25 @@
+id: condition.lu.bereavement.survivor_pension.relationship_eligible_survivor
+schema_version: "0.1.0"
+title: "Survivor relationship may be eligible for CNAP survivor pension"
+description: >
+  Evaluates whether the survivor's relationship to the deceased is one that
+  may be eligible for a CNAP survivor pension (surviving spouse, registered
+  partner, or child).
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: survivor_pension
+expression_language: jsonlogic
+expression:
+  "in":
+    - { "var": "relationship.to_deceased" }
+    - - "surviving_spouse"
+      - "registered_partner"
+      - "child"
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.relationship_to_deceased
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/survivor_is_employee.yml
+++ b/graph/conditions/bereavement/lu/survivor_is_employee.yml
@@ -1,0 +1,23 @@
+id: condition.lu.bereavement.employment.survivor_is_employee
+schema_version: "0.1.0"
+title: "Survivor is an employee or apprentice"
+description: >
+  Evaluates whether the survivor is currently employed as an employee or
+  apprentice. If true, the survivor may be entitled to bereavement leave.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: employment
+expression_language: jsonlogic
+expression:
+  "in":
+    - { "var": "survivor.employment_status" }
+    - - "employee"
+      - "apprentice"
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.survivor_employment_status
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/conditions/bereavement/lu/survivor_is_spouse_or_partner.yml
+++ b/graph/conditions/bereavement/lu/survivor_is_spouse_or_partner.yml
@@ -1,0 +1,29 @@
+id: condition.lu.bereavement.family.survivor_is_spouse_or_partner
+schema_version: "0.1.0"
+title: "Survivor is spouse or registered partner"
+description: >
+  Evaluates whether the survivor is the spouse or registered partner of the
+  deceased. This affects multiple rights and obligations in bereavement.
+condition_type: criterion
+jurisdiction: LU
+life_event: bereavement
+domain: succession
+expression_language: jsonlogic
+expression:
+  "or":
+    - "in":
+        - { "var": "relationship.to_deceased" }
+        - - "surviving_spouse"
+          - "registered_partner"
+    - "in":
+        - { "var": "marriage_or_partnership.status" }
+        - - "married"
+          - "registered_partnership"
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.relationship_to_deceased
+  - intake_fact.global.bereavement.marriage_or_partnership_status
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/bereavement_leave_at_event.yml
+++ b/graph/deadlines/bereavement/lu/bereavement_leave_at_event.yml
@@ -1,0 +1,20 @@
+id: deadline.lu.bereavement.employment.bereavement_leave_at_event
+schema_version: "0.1.0"
+title: "Take bereavement leave at the event"
+description: >
+  Bereavement leave (congé extraordinaire) must be taken at the time of the
+  event (death). The number of days depends on the relationship to the deceased.
+deadline_type: validity_period
+jurisdiction: LU
+life_event: bereavement
+domain: employment
+calculation:
+  kind: relative
+  duration: "P0D"
+  starts_from_fact: death.date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
+++ b/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
@@ -1,6 +1,6 @@
 id: deadline.lu.bereavement.death_registration.declaration_deadline
 schema_version: "0.1.0"
-title: "Death declaration deadline"
+title: "Declare death within 24 hours"
 description: >
   A death occurring in Luxembourg must be declared to the Bureau de l'état civil
   within 24 hours. In practice, hospitals and funeral homes often handle the
@@ -12,11 +12,10 @@ domain: death_registration
 calculation:
   kind: relative
   duration: "PT24H"
-  starts_from_fact: intake_fact.global.bereavement.date_of_death
+  starts_from_fact: death.datetime
   calendar: civil
   if_weekend_or_holiday: unknown
-source_assertion_refs:
-  - assertion.guichet_lu.bereavement.declaration_within_24h
+source_assertion_refs: []
 record_valid_from: "2026-06-03"
-authoring_status: draft
+authoring_status: approved
 distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/final_tax_return_31dec.yml
+++ b/graph/deadlines/bereavement/lu/final_tax_return_31dec.yml
@@ -1,0 +1,18 @@
+id: deadline.lu.bereavement.inheritance_tax.final_tax_return_31dec_next_year
+schema_version: "0.1.0"
+title: "File income tax return by 31 December of following year"
+description: >
+  The final income tax return for the deceased must be filed by 31 December
+  of the year following the year of death. This is a calendar-rule deadline
+  (fixed annual date) rather than a duration from an event.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: inheritance_tax
+calculation:
+  kind: conditional
+  calendar: civil
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/funeral_allowance_2y.yml
+++ b/graph/deadlines/bereavement/lu/funeral_allowance_2y.yml
@@ -1,0 +1,20 @@
+id: deadline.lu.bereavement.health_insurance.funeral_allowance_2y
+schema_version: "0.1.0"
+title: "Claim funeral allowance within 2 years"
+description: >
+  The funeral allowance (indemnité funéraire) must be claimed from the CNS
+  within 2 years of the date of payment of the funeral invoice.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: health_insurance
+calculation:
+  kind: relative
+  duration: "P2Y"
+  starts_from_fact: funeral_invoice.payment_date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/funeral_cremation_72h.yml
+++ b/graph/deadlines/bereavement/lu/funeral_cremation_72h.yml
@@ -1,0 +1,21 @@
+id: deadline.lu.bereavement.funeral.funeral_cremation_72h
+schema_version: "0.1.0"
+title: "Complete burial/cremation handling within 72 hours"
+description: >
+  Burial or cremation must generally be handled within 72 hours of the death,
+  unless a special authorisation (dérogation) is obtained from the communal
+  authorities.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: funeral
+calculation:
+  kind: relative
+  duration: "PT72H"
+  starts_from_fact: death.datetime
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/inventory_3mo.yml
+++ b/graph/deadlines/bereavement/lu/inventory_3mo.yml
@@ -1,0 +1,20 @@
+id: deadline.lu.bereavement.succession.inventory_3mo
+schema_version: "0.1.0"
+title: "Make inventory within 3 months"
+description: >
+  Heirs who wish to accept the inheritance under benefit of inventory must
+  have the inventory made within 3 months from the date of death.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: succession
+calculation:
+  kind: relative
+  duration: "P3M"
+  starts_from_fact: death.date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/notify_ccss_8d.yml
+++ b/graph/deadlines/bereavement/lu/notify_ccss_8d.yml
@@ -1,0 +1,20 @@
+id: deadline.lu.bereavement.employment.notify_ccss_8d
+schema_version: "0.1.0"
+title: "Notify CCSS within 8 days"
+description: >
+  The employer or the family must notify the Centre commun de la sécurité
+  sociale (CCSS) of the death within 8 days.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: employment
+calculation:
+  kind: relative
+  duration: "P8D"
+  starts_from_fact: death.date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/notify_ministry_economy_1mo.yml
+++ b/graph/deadlines/bereavement/lu/notify_ministry_economy_1mo.yml
@@ -1,0 +1,21 @@
+id: deadline.lu.bereavement.employment.notify_ministry_economy_1mo
+schema_version: "0.1.0"
+title: "Notify/handle business permit within 1 month"
+description: >
+  If the deceased held a business permit (autorisation d'établissement),
+  the heirs must notify the Ministry of the Economy and handle the permit
+  within 1 month of the date of death.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: employment
+calculation:
+  kind: relative
+  duration: "P1M"
+  starts_from_fact: death.date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: draft
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/reflection_40d.yml
+++ b/graph/deadlines/bereavement/lu/reflection_40d.yml
@@ -1,0 +1,20 @@
+id: deadline.lu.bereavement.succession.reflection_40d
+schema_version: "0.1.0"
+title: "Reflect for 40 days after inventory period"
+description: >
+  After the 3-month inventory period, heirs have an additional 40-day
+  reflection period to decide whether to accept or renounce the inheritance.
+deadline_type: validity_period
+jurisdiction: LU
+life_event: bereavement
+domain: succession
+calculation:
+  kind: relative
+  duration: "P40D"
+  starts_from_fact: succession.inventory_period_end_date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/succession_declaration_6mo.yml
+++ b/graph/deadlines/bereavement/lu/succession_declaration_6mo.yml
@@ -1,0 +1,21 @@
+id: deadline.lu.bereavement.inheritance_tax.succession_declaration_6mo
+schema_version: "0.1.0"
+title: "File succession declaration within 6 months"
+description: >
+  The succession declaration (déclaration de succession) must be filed with
+  the Administration de l'enregistrement, des domaines et de la TVA (AED)
+  within 6 months of the date of death.
+deadline_type: filing_deadline
+jurisdiction: LU
+life_event: bereavement
+domain: inheritance_tax
+calculation:
+  kind: relative
+  duration: "P6M"
+  starts_from_fact: death.date
+  calendar: civil
+  if_weekend_or_holiday: unknown
+source_assertion_refs: []
+record_valid_from: "2026-06-05"
+authoring_status: approved
+distribution_status: public_open


### PR DESCRIPTION
## Summary

Add **19 new** and update **4 existing** graph records for LU routing conditions and deadlines (Phase 4 of Alpha: LU Graph Enrichment).

### Deadlines (10 records)

| Record | Type | Duration | Status |
|---|---|---|---|
| Death declaration 24h | filing_deadline | PT24H | **updated** |
| Funeral/cremation 72h | filing_deadline | PT72H | new |
| Bereavement leave | validity_period | P0D (at event) | new |
| Funeral allowance 2y | filing_deadline | P2Y | new |
| Inventory 3mo | filing_deadline | P3M | new |
| Reflection 40d | validity_period | P40D | new |
| Succession declaration 6mo | filing_deadline | P6M | new |
| Tax return 31 Dec | filing_deadline | conditional | new |
| CCSS notification 8d | filing_deadline | P8D | new |
| Ministry Economy 1mo | filing_deadline | P1M | new (draft) |

### Conditions (13 records)

| Record | Logic | Status |
|---|---|---|
| Death in LU | `== death.place.country LU` | **updated** |
| Deceased LU pension insured | `== deceased.last_social_security_affiliation.country LU` | **updated** |
| Habitual residence LU | `== deceased.habitual_residence.country LU` | **updated** |
| Eligible survivor relationship | `in relationship [spouse, partner, child]` | new |
| AED declaration needed | `or [habitual_res==LU, LU in assets]` | new |
| LU health insured | `== deceased.last_social_security_affiliation.country LU` | new |
| Survivor is employee | `in survivor.employment_status [employee, apprentice]` | new |
| Deceased self-employed | `or [self_employed in status, business_owner in status]` | new |
| Deceased owned vehicle | `== deceased.owned_vehicle true` | new |
| Deceased was tenant | `== deceased.housing.was_tenant true` | new |
| Cohabitant 6+ months | `>= survivor.cohabitation.months 6` | new |
| Spouse or partner | `or [in relationship, in marriage_status]` | new |
| Estate has real estate | `== estate.real_estate.exists true` | new |

### Design notes

- `source_assertion_refs: []` on all records — will be back-filled when assertion batches are created from source snapshots (Phase 3)
- Blueprint `kind: event_time` → schema `kind: relative` with `duration: P0D`
- Blueprint `kind: calendar_rule` → schema `kind: conditional`
- Multi-valued `deceased.employment_status` uses `in` operator (value `in` array)

### Validation

All checks pass: **112/112** validation ✅ | **143/143** unit tests ✅ | **2/2** scenarios ✅

### Blueprint source

Per [LU graph blueprint](https://github.com/clarvia-org/clarvia-graph/blob/main/research/foundation/lu-graph-blueprint.md) sections D and E.

Closes #49
