### PR TITLE
fix: Set distribution_status to public_metadata_only for unsourced records

### DIFF
--- a/graph/consequences/bereavement/lu/arrange_funeral_or_cremation.yml
+++ b/graph/consequences/bereavement/lu/arrange_funeral_or_cremation.yml
@@ -21,7 +21,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/claim_bereavement_leave.yml
+++ b/graph/consequences/bereavement/lu/claim_bereavement_leave.yml
@@ -20,7 +20,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/claim_funeral_allowance.yml
+++ b/graph/consequences/bereavement/lu/claim_funeral_allowance.yml
@@ -22,7 +22,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/claim_survivor_pension.yml
+++ b/graph/consequences/bereavement/lu/claim_survivor_pension.yml
@@ -21,7 +21,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-03"

--- a/graph/consequences/bereavement/lu/decide_accept_or_renounce.yml
+++ b/graph/consequences/bereavement/lu/decide_accept_or_renounce.yml
@@ -19,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: false
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/declare_death.yml
+++ b/graph/consequences/bereavement/lu/declare_death.yml
@@ -22,7 +22,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-03"

--- a/graph/consequences/bereavement/lu/engage_notary.yml
+++ b/graph/consequences/bereavement/lu/engage_notary.yml
@@ -21,7 +21,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/file_final_income_tax_return.yml
+++ b/graph/consequences/bereavement/lu/file_final_income_tax_return.yml
@@ -19,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/file_inheritance_declaration.yml
+++ b/graph/consequences/bereavement/lu/file_inheritance_declaration.yml
@@ -20,7 +20,7 @@ standards_export:
   cpsv_public_service:
     enabled: false
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/notify_banks_trace_assets.yml
+++ b/graph/consequences/bereavement/lu/notify_banks_trace_assets.yml
@@ -19,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/notify_ccss_business_matters.yml
+++ b/graph/consequences/bereavement/lu/notify_ccss_business_matters.yml
@@ -22,7 +22,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
+++ b/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
@@ -19,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/transfer_vehicle_registration.yml
+++ b/graph/consequences/bereavement/lu/transfer_vehicle_registration.yml
@@ -20,7 +20,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/understand_applicable_succession_law.yml
+++ b/graph/consequences/bereavement/lu/understand_applicable_succession_law.yml
@@ -19,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: false
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/understand_housing_rights.yml
+++ b/graph/consequences/bereavement/lu/understand_housing_rights.yml
@@ -20,7 +20,7 @@ standards_export:
   cpsv_public_service:
     enabled: false
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
+++ b/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
@@ -40,7 +40,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/claim_bereavement_leave.yml
+++ b/graph/task_templates/bereavement/lu/claim_bereavement_leave.yml
@@ -31,7 +31,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
+++ b/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
@@ -38,7 +38,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/decide_accept_renounce.yml
+++ b/graph/task_templates/bereavement/lu/decide_accept_renounce.yml
@@ -31,7 +31,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/engage_notary.yml
+++ b/graph/task_templates/bereavement/lu/engage_notary.yml
@@ -40,7 +40,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/file_aed_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_aed_declaration.yml
@@ -38,7 +38,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/file_cnap_claim.yml
+++ b/graph/task_templates/bereavement/lu/file_cnap_claim.yml
@@ -40,7 +40,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-03"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/file_death_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_death_declaration.yml
@@ -40,7 +40,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-03"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/file_final_income_tax_return.yml
+++ b/graph/task_templates/bereavement/lu/file_final_income_tax_return.yml
@@ -37,7 +37,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
+++ b/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
@@ -36,7 +36,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
+++ b/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
@@ -32,7 +32,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/obtain_medical_death_certificate.yml
+++ b/graph/task_templates/bereavement/lu/obtain_medical_death_certificate.yml
@@ -28,7 +28,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/transfer_vehicle_registration.yml
+++ b/graph/task_templates/bereavement/lu/transfer_vehicle_registration.yml
@@ -42,7 +42,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/understand_applicable_succession_law.yml
+++ b/graph/task_templates/bereavement/lu/understand_applicable_succession_law.yml
@@ -30,7 +30,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/understand_housing_rights.yml
+++ b/graph/task_templates/bereavement/lu/understand_housing_rights.yml
@@ -33,7 +33,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05


### PR DESCRIPTION
The publication gate CI step requires source_assertion_refs to be non-empty for public_open records. Since assertions haven't been created yet (Phase 3 — waiting on volunteer source captures), this sets distribution_status: public_metadata_only on all 30 consequence and task template records.

They'll be promoted back to public_open once source assertions are back-filled.

**All checks pass:** 136/136 validation ✅ | 143/143 tests ✅ | 2/2 scenarios ✅ | publication gate ✅