### PR TITLE
feat: Expand scenario tests for 15-task checklist + fix boolean normalization

### DIFF
--- a/packages/generator/src/normalize.ts
+++ b/packages/generator/src/normalize.ts
@@ -43,14 +43,21 @@ export function normalizeFacts(facts: Fact[]): Fact[] {
   const normalized: Fact[] = [];
 
   for (const fact of facts) {
-    const val = String(fact.value ?? "");
     // Handle array facts (e.g., work_history.country with multiple values)
     if (COUNTRY_ARRAY_PATHS.has(fact.fact_type)) {
-      // Uppercase and deduplicate
-      const values = val.split(",").map((v: string) => v.trim().toUpperCase());
+      // Uppercase and deduplicate — arrays are always string-based country codes
+      const rawArr = Array.isArray(fact.value) ? fact.value : String(fact.value ?? "").split(",");
+      const values = rawArr.map((v: unknown) => String(v).trim().toUpperCase());
       const unique = [...new Set(values)].sort();
       normalized.push({ fact_type: fact.fact_type, value: unique.join(",") });
+    } else if (typeof fact.value === "boolean" || typeof fact.value === "number") {
+      // Preserve boolean and numeric types — conditions use typed JsonLogic comparisons
+      normalized.push({ fact_type: fact.fact_type, value: fact.value });
+    } else if (Array.isArray(fact.value)) {
+      // Preserve arrays (e.g., employment_status: [self_employed, business_owner])
+      normalized.push({ fact_type: fact.fact_type, value: fact.value });
     } else {
+      const val = String(fact.value ?? "");
       normalized.push({
         fact_type: fact.fact_type,
         value: normalizeValue(fact.fact_type, val),

--- a/tests/scenarios/lu/core_married_employed_vehicle.yml
+++ b/tests/scenarios/lu/core_married_employed_vehicle.yml
@@ -1,0 +1,76 @@
+# Scenario Test: Luxembourg Core — Married employed survivor, vehicle owned
+# Full 15-task test with all facts provided.
+# Based on blueprint section K.1.
+
+id: scenario_test.lu.core_married_employed_vehicle
+schema_version: "0.1.0"
+title: "Core LU married employed survivor, vehicle owned"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+  - fact_type: deceased.habitual_residence.country
+    value: LU
+  - fact_type: relationship.to_deceased
+    value: surviving_spouse
+  - fact_type: marriage_or_partnership.status
+    value: married
+  - fact_type: deceased.last_social_security_affiliation.country
+    value: LU
+  - fact_type: survivor.employment_status
+    value: employee
+  - fact_type: deceased.employment_status
+    value:
+      - retired
+  - fact_type: deceased.owned_vehicle
+    value: true
+  - fact_type: deceased.housing.was_tenant
+    value: true
+  - fact_type: survivor.cohabitation.months
+    value: 24
+  - fact_type: estate.asset_location.country
+    value:
+      - LU
+
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: applies
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: applies
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: applies
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: does_not_apply
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: applies
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.succession.file_inheritance_declaration: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: applies
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+
+expected_checklist_groups:
+  immediate_formalities:
+    - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
+    - task_template.lu.bereavement.death_registration.file_death_declaration
+    - task_template.lu.bereavement.funeral.arrange_funeral_or_cremation
+  money_and_benefits:
+    - task_template.lu.bereavement.health_insurance.claim_funeral_allowance
+    - task_template.lu.bereavement.survivor_pension.file_cnap_claim
+  estate_and_inheritance:
+    - task_template.lu.bereavement.estate_assets.notify_banks_trace_assets
+    - task_template.lu.bereavement.succession.engage_notary
+    - task_template.lu.bereavement.succession.decide_accept_renounce
+    - task_template.lu.bereavement.inheritance_tax.file_aed_declaration
+    - task_template.lu.bereavement.estate_assets.understand_housing_rights
+    - task_template.lu.bereavement.estate_assets.transfer_vehicle_registration
+  employment_and_tax:
+    - task_template.lu.bereavement.employment.claim_bereavement_leave
+    - task_template.lu.bereavement.inheritance_tax.file_final_income_tax_return
+  cross_border_issues:
+    - task_template.lu.bereavement.succession.understand_applicable_succession_law

--- a/tests/scenarios/lu/minimal_unknown.yml
+++ b/tests/scenarios/lu/minimal_unknown.yml
@@ -1,0 +1,35 @@
+# Scenario Test: Minimal LU death with most facts unknown
+# Only death location known — conditional consequences should be needs_fact.
+# Based on blueprint section K.3.
+
+id: scenario_test.lu.minimal_unknown
+schema_version: "0.1.0"
+title: "Minimal LU death with most facts unknown"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+
+# Unconditional consequences: applies
+# Conditional consequences with missing facts: needs_fact
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: needs_fact
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: needs_fact
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: needs_fact
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: needs_fact
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: needs_fact
+  consequence.lu.bereavement.succession.file_inheritance_declaration: needs_fact
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: needs_fact

--- a/tests/scenarios/lu/self_employed_property_not_married.yml
+++ b/tests/scenarios/lu/self_employed_property_not_married.yml
@@ -1,0 +1,75 @@
+# Scenario Test: Self-employed deceased with property, child survivor
+# Tests CCSS/business trigger, no bereavement leave, no vehicle.
+# Based on blueprint section K.2.
+
+id: scenario_test.lu.self_employed_property_not_married
+schema_version: "0.1.0"
+title: "Self-employed deceased with Luxembourg property, not married"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+  - fact_type: deceased.habitual_residence.country
+    value: LU
+  - fact_type: relationship.to_deceased
+    value: child
+  - fact_type: marriage_or_partnership.status
+    value: not_married_or_partnered
+  - fact_type: deceased.last_social_security_affiliation.country
+    value: LU
+  - fact_type: survivor.employment_status
+    value: not_employed
+  - fact_type: deceased.employment_status
+    value:
+      - self_employed
+      - business_owner
+  - fact_type: deceased.owned_vehicle
+    value: false
+  - fact_type: deceased.housing.was_tenant
+    value: false
+  - fact_type: estate.real_estate.exists
+    value: true
+  - fact_type: estate.asset_location.country
+    value:
+      - LU
+
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: does_not_apply
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: applies
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: applies
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: applies
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: does_not_apply
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.succession.file_inheritance_declaration: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: does_not_apply
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+
+expected_checklist_groups:
+  immediate_formalities:
+    - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
+    - task_template.lu.bereavement.death_registration.file_death_declaration
+    - task_template.lu.bereavement.funeral.arrange_funeral_or_cremation
+  money_and_benefits:
+    - task_template.lu.bereavement.health_insurance.claim_funeral_allowance
+    - task_template.lu.bereavement.survivor_pension.file_cnap_claim
+  estate_and_inheritance:
+    - task_template.lu.bereavement.estate_assets.notify_banks_trace_assets
+    - task_template.lu.bereavement.succession.engage_notary
+    - task_template.lu.bereavement.succession.decide_accept_renounce
+    - task_template.lu.bereavement.inheritance_tax.file_aed_declaration
+  employment_and_tax:
+    - task_template.lu.bereavement.employment.notify_ccss_business_matters
+    - task_template.lu.bereavement.inheritance_tax.file_final_income_tax_return
+  cross_border_issues:
+    - task_template.lu.bereavement.succession.understand_applicable_succession_law


### PR DESCRIPTION
## Summary

Add 3 new scenario tests covering the full 15-task Luxembourg bereavement checklist per blueprint section K, plus a bug fix in the fact normalizer.

### Scenarios added

| # | Scenario | Key test | Consequence status |
|---|----------|----------|-------------------|
| 1 | Core married employed + vehicle | Full 15-task graph | 14 applies, 1 does_not_apply |
| 2 | Self-employed + property | CCSS trigger, no leave/vehicle/tenant | 12 applies, 3 does_not_apply |
| 3 | Minimal unknown | Only death location | 8 applies, 7 needs_fact |

### Bug fix: Boolean fact normalization

The `normalizeFacts()` function in `normalize.ts` was converting **all** fact values to strings via `String()`. This turned boolean `true` into string `'true'`. The JsonLogic condition expressions compare against boolean `true`, so `'true' == true` evaluated to `false` in JS (NaN coercion during loose equality).

**Fix:** Preserve boolean, number, and array types during normalization. Only stringify string-typed values.

**Impact:** Boolean conditions (`deceased.owned_vehicle`, `deceased.housing.was_tenant`) were always evaluating to `false`, making those consequences invisible.

### Validation

All checks pass: **136/136** validation ✅ | **143/143** tests ✅ | **5/5** scenarios ✅ | publication gate ✅

Closes #53