### PR TITLE
docs: add foundation spec, repo structure, and spec banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,34 @@ This repository contains:
 - **Validation** — CLI tooling to validate, build, and test the graph
 - **Exports** — Generated JSON for web consumers ([example](exports/example-bereavement-lu.json)), plus JSON-LD, CPSV-AP, and web runtime bundles
 
+## Repository structure
+
+```
+clarvia-graph/
+├── schemas/          # JSON Schema definitions (v0.1)
+├── vocab/            # Controlled vocabularies
+├── graph/            # Consequence graph data (YAML)
+│   ├── authorities/
+│   ├── conditions/
+│   ├── consequences/
+│   ├── task_templates/
+│   └── …
+├── sources/          # Source registry, snapshots, and assertions
+├── translations/     # Locale overlay files
+├── tests/            # Scenario tests and unit tests
+├── exports/          # Generated output (JSON, JSON-LD, web bundles)
+├── packages/         # Workspace packages
+│   ├── cli/          #   @clarvia/cli — validation, build, and export tooling
+│   └── generator/    #   @clarvia/generator — checklist generation engine
+├── docs/             # Foundation specification and guides
+└── build/            # Build output (git-ignored)
+```
+
+The root `package.json` is a [pnpm workspace](https://pnpm.io/workspaces) that orchestrates the packages above. Run `pnpm install` from the root to set up all dependencies.
+
 ## Status
 
-🔒 **Foundation specification locked** — The [foundation spec](https://github.com/clarvia-org/clarvia-graph/wiki) defines the complete data architecture, standards alignment, editorial governance, and extensibility model.
+🔒 **Foundation specification locked** — The [foundation spec](docs/FOUNDATION.md) defines the complete data architecture, standards alignment, editorial governance, and extensibility model.
 
 🚧 **Early implementation in progress** — Proof-of-concept, alpha, and beta work is proceeding with internal resources to validate the foundation before funded hardening, validation, and scale-up phases.
 

--- a/docs/ADDING_A_JURISDICTION.md
+++ b/docs/ADDING_A_JURISDICTION.md
@@ -1,5 +1,7 @@
 # Adding a Jurisdiction
 
+> Part of the [Clarvia Graph Foundation Specification](FOUNDATION.md).
+
 This guide walks through adding a new country to the Clarvia consequence graph. We use **Belgium (BE)** as the running example, but the steps apply to any jurisdiction.
 
 > **Non-negotiable:** Adding a jurisdiction must not change existing records, weaken publication gates, or break scenario tests for other jurisdictions (spec §21.1).

--- a/docs/ADDING_A_LIFE_EVENT.md
+++ b/docs/ADDING_A_LIFE_EVENT.md
@@ -1,5 +1,7 @@
 # Adding a Life Event
 
+> Part of the [Clarvia Graph Foundation Specification](FOUNDATION.md).
+
 This guide walks through adding a new life event to the Clarvia consequence graph. We use **marriage** as the running example, but the steps apply to any life event.
 
 > **Extension principle (spec §21.1):** Life events extend vertically — a new life event creates its own namespace using the same infrastructure. Adding one must not change existing records, weaken publication gates, or break scenario tests for other life events.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,5 +1,7 @@
 # Clarvia Conventions
 
+> Part of the [Clarvia Graph Foundation Specification](FOUNDATION.md).
+
 ## Source snapshot content hashes
 
 `source_snapshot.content_hash` verifies the archived source content saved by Clarvia.

--- a/docs/FOUNDATION.md
+++ b/docs/FOUNDATION.md
@@ -1,0 +1,71 @@
+# Foundation Specification
+
+This document defines the overall architecture, governance model, and design standards for the Clarvia consequence graph.
+
+The foundation specification is the authoritative reference for how the graph is structured, how content is reviewed and published, and how the system extends to new jurisdictions and life events. Individual spec documents live alongside this overview in the [`docs/`](.) directory.
+
+---
+
+## Core Architecture
+
+The graph follows a single provenance chain:
+
+```
+source → snapshot → assertion → consequence → task_template → checklist_item
+```
+
+Every user-facing checklist item traces back to a captured official source. Nothing publishes without an approved source assertion.
+
+For the full data model, see the [JSON Schema definitions](../schemas/v0.1).
+
+---
+
+## Specification Documents
+
+| Document | Scope |
+|---|---|
+| [Editorial conventions](CONVENTIONS.md) | Content hashing, file format norms, and editorial rules |
+| [Review and governance policy](REVIEW_POLICY.md) | Review lifecycle, publication gates, AI boundaries, and contributor model |
+| [Translations](TRANSLATIONS.md) | Multilingual content model, overlay format, and fallback rules |
+| [Adding a jurisdiction](ADDING_A_JURISDICTION.md) | Step-by-step guide for extending the graph to a new country |
+| [Adding a life event](ADDING_A_LIFE_EVENT.md) | Step-by-step guide for extending the graph to a new life event |
+
+---
+
+## Key Design Decisions
+
+- **Source-backed** — every published claim traces to a captured official source
+- **Three-valued logic** — conditions evaluate to `true`, `false`, or `unknown`; uncertainty is never hidden
+- **Cross-border composition** — jurisdiction roles (death place, habitual residence, work state, asset situs) compose layered checklists
+- **Static exports** — consumer apps load generated JSON at build time with no runtime API dependency
+- **Privacy-first** — condition evaluation happens client-side; no user data is sent to servers
+
+---
+
+## Standards Alignment
+
+The graph maintains Clarvia-native schemas and generates compatibility views for:
+
+- **CPSV-AP** — Core Public Service Vocabulary Application Profile
+- **CCCEV** — Core Criterion and Core Evidence Vocabulary
+- **ELI** — European Legislation Identifier
+- **PROV-O** — W3C Provenance Ontology
+
+---
+
+## Extensibility Model
+
+The graph extends along two axes without schema changes:
+
+| Axis | Mechanism | Isolation guarantee |
+|---|---|---|
+| **New jurisdiction** | Add vocab entry, sources, and graph records under `<jurisdiction>/` directories | CI verifies no existing jurisdiction outputs change |
+| **New life event** | Add vocab entries, intake facts, and graph records under `<life_event>/` namespaces | Generator filters by `life_event`; events cannot affect each other |
+
+See [Adding a jurisdiction](ADDING_A_JURISDICTION.md) and [Adding a life event](ADDING_A_LIFE_EVENT.md) for complete walkthroughs.
+
+---
+
+## Versioning
+
+The foundation specification is versioned alongside the schema (`v0.1`). Breaking changes to the data model, review policy, or extensibility guarantees require a version bump and migration path.

--- a/docs/REVIEW_POLICY.md
+++ b/docs/REVIEW_POLICY.md
@@ -1,5 +1,7 @@
 # Review Policy
 
+> Part of the [Clarvia Graph Foundation Specification](FOUNDATION.md).
+
 This document defines how content is reviewed, approved, and published in the Clarvia consequence graph. It covers the review lifecycle, roles, AI boundaries, and publication gates.
 
 ---

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -1,5 +1,7 @@
 # Translations
 
+> Part of the [Clarvia Graph Foundation Specification](FOUNDATION.md).
+
 This document explains how multilingual content works in the Clarvia consequence graph — what gets translated, what doesn't, and how to contribute translations.
 
 ---

--- a/packages/generator/src/normalize.ts
+++ b/packages/generator/src/normalize.ts
@@ -43,14 +43,21 @@ export function normalizeFacts(facts: Fact[]): Fact[] {
   const normalized: Fact[] = [];
 
   for (const fact of facts) {
-    const val = String(fact.value ?? "");
     // Handle array facts (e.g., work_history.country with multiple values)
     if (COUNTRY_ARRAY_PATHS.has(fact.fact_type)) {
-      // Uppercase and deduplicate
-      const values = val.split(",").map((v: string) => v.trim().toUpperCase());
+      // Uppercase and deduplicate — arrays are always string-based country codes
+      const rawArr = Array.isArray(fact.value) ? fact.value : String(fact.value ?? "").split(",");
+      const values = rawArr.map((v: unknown) => String(v).trim().toUpperCase());
       const unique = [...new Set(values)].sort();
       normalized.push({ fact_type: fact.fact_type, value: unique.join(",") });
+    } else if (typeof fact.value === "boolean" || typeof fact.value === "number") {
+      // Preserve boolean and numeric types — conditions use typed JsonLogic comparisons
+      normalized.push({ fact_type: fact.fact_type, value: fact.value });
+    } else if (Array.isArray(fact.value)) {
+      // Preserve arrays (e.g., employment_status: [self_employed, business_owner])
+      normalized.push({ fact_type: fact.fact_type, value: fact.value });
     } else {
+      const val = String(fact.value ?? "");
       normalized.push({
         fact_type: fact.fact_type,
         value: normalizeValue(fact.fact_type, val),

--- a/tests/scenarios/lu/core_married_employed_vehicle.yml
+++ b/tests/scenarios/lu/core_married_employed_vehicle.yml
@@ -1,0 +1,76 @@
+# Scenario Test: Luxembourg Core — Married employed survivor, vehicle owned
+# Full 15-task test with all facts provided.
+# Based on blueprint section K.1.
+
+id: scenario_test.lu.core_married_employed_vehicle
+schema_version: "0.1.0"
+title: "Core LU married employed survivor, vehicle owned"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+  - fact_type: deceased.habitual_residence.country
+    value: LU
+  - fact_type: relationship.to_deceased
+    value: surviving_spouse
+  - fact_type: marriage_or_partnership.status
+    value: married
+  - fact_type: deceased.last_social_security_affiliation.country
+    value: LU
+  - fact_type: survivor.employment_status
+    value: employee
+  - fact_type: deceased.employment_status
+    value:
+      - retired
+  - fact_type: deceased.owned_vehicle
+    value: true
+  - fact_type: deceased.housing.was_tenant
+    value: true
+  - fact_type: survivor.cohabitation.months
+    value: 24
+  - fact_type: estate.asset_location.country
+    value:
+      - LU
+
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: applies
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: applies
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: applies
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: does_not_apply
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: applies
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.succession.file_inheritance_declaration: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: applies
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+
+expected_checklist_groups:
+  immediate_formalities:
+    - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
+    - task_template.lu.bereavement.death_registration.file_death_declaration
+    - task_template.lu.bereavement.funeral.arrange_funeral_or_cremation
+  money_and_benefits:
+    - task_template.lu.bereavement.health_insurance.claim_funeral_allowance
+    - task_template.lu.bereavement.survivor_pension.file_cnap_claim
+  estate_and_inheritance:
+    - task_template.lu.bereavement.estate_assets.notify_banks_trace_assets
+    - task_template.lu.bereavement.succession.engage_notary
+    - task_template.lu.bereavement.succession.decide_accept_renounce
+    - task_template.lu.bereavement.inheritance_tax.file_aed_declaration
+    - task_template.lu.bereavement.estate_assets.understand_housing_rights
+    - task_template.lu.bereavement.estate_assets.transfer_vehicle_registration
+  employment_and_tax:
+    - task_template.lu.bereavement.employment.claim_bereavement_leave
+    - task_template.lu.bereavement.inheritance_tax.file_final_income_tax_return
+  cross_border_issues:
+    - task_template.lu.bereavement.succession.understand_applicable_succession_law

--- a/tests/scenarios/lu/minimal_unknown.yml
+++ b/tests/scenarios/lu/minimal_unknown.yml
@@ -1,0 +1,35 @@
+# Scenario Test: Minimal LU death with most facts unknown
+# Only death location known — conditional consequences should be needs_fact.
+# Based on blueprint section K.3.
+
+id: scenario_test.lu.minimal_unknown
+schema_version: "0.1.0"
+title: "Minimal LU death with most facts unknown"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+
+# Unconditional consequences: applies
+# Conditional consequences with missing facts: needs_fact
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: needs_fact
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: needs_fact
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: needs_fact
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: needs_fact
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: needs_fact
+  consequence.lu.bereavement.succession.file_inheritance_declaration: needs_fact
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: needs_fact

--- a/tests/scenarios/lu/self_employed_property.yml
+++ b/tests/scenarios/lu/self_employed_property.yml
@@ -1,0 +1,75 @@
+# Scenario Test: Self-employed deceased with property, child survivor
+# Tests CCSS/business trigger, no bereavement leave, no vehicle.
+# Based on blueprint section K.2.
+
+id: scenario_test.lu.self_employed_property_not_married
+schema_version: "0.1.0"
+title: "Self-employed deceased with Luxembourg property, not married"
+scenario_type: single_jurisdiction
+life_event: bereavement
+countries: [LU]
+
+facts:
+  - fact_type: death.date
+    value: "2026-06-05"
+  - fact_type: death.place.country
+    value: LU
+  - fact_type: deceased.habitual_residence.country
+    value: LU
+  - fact_type: relationship.to_deceased
+    value: child
+  - fact_type: marriage_or_partnership.status
+    value: not_married_or_partnered
+  - fact_type: deceased.last_social_security_affiliation.country
+    value: LU
+  - fact_type: survivor.employment_status
+    value: not_employed
+  - fact_type: deceased.employment_status
+    value:
+      - self_employed
+      - business_owner
+  - fact_type: deceased.owned_vehicle
+    value: false
+  - fact_type: deceased.housing.was_tenant
+    value: false
+  - fact_type: estate.real_estate.exists
+    value: true
+  - fact_type: estate.asset_location.country
+    value:
+      - LU
+
+expected_consequence_statuses:
+  consequence.lu.bereavement.death_registration.obtain_medical_death_certificate: applies
+  consequence.lu.bereavement.death_registration.declare_death: applies
+  consequence.lu.bereavement.funeral.arrange_funeral_or_cremation: applies
+  consequence.lu.bereavement.employment.claim_bereavement_leave: does_not_apply
+  consequence.lu.bereavement.estate_assets.notify_banks_trace_assets: applies
+  consequence.lu.bereavement.health_insurance.claim_funeral_allowance: applies
+  consequence.lu.bereavement.survivor_pension.claim_survivor_pension: applies
+  consequence.lu.bereavement.employment.notify_ccss_business_matters: applies
+  consequence.lu.bereavement.estate_assets.understand_housing_rights: does_not_apply
+  consequence.lu.bereavement.succession.engage_notary: applies
+  consequence.lu.bereavement.succession.decide_accept_or_renounce: applies
+  consequence.lu.bereavement.succession.file_inheritance_declaration: applies
+  consequence.lu.bereavement.inheritance_tax.file_final_income_tax_return: applies
+  consequence.lu.bereavement.estate_assets.transfer_vehicle_registration: does_not_apply
+  consequence.lu.bereavement.succession.understand_applicable_succession_law: applies
+
+expected_checklist_groups:
+  immediate_formalities:
+    - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
+    - task_template.lu.bereavement.death_registration.file_death_declaration
+    - task_template.lu.bereavement.funeral.arrange_funeral_or_cremation
+  money_and_benefits:
+    - task_template.lu.bereavement.health_insurance.claim_funeral_allowance
+    - task_template.lu.bereavement.survivor_pension.file_cnap_claim
+  estate_and_inheritance:
+    - task_template.lu.bereavement.estate_assets.notify_banks_trace_assets
+    - task_template.lu.bereavement.succession.engage_notary
+    - task_template.lu.bereavement.succession.decide_accept_renounce
+    - task_template.lu.bereavement.inheritance_tax.file_aed_declaration
+  employment_and_tax:
+    - task_template.lu.bereavement.employment.notify_ccss_business_matters
+    - task_template.lu.bereavement.inheritance_tax.file_final_income_tax_return
+  cross_border_issues:
+    - task_template.lu.bereavement.succession.understand_applicable_succession_law


### PR DESCRIPTION
Addresses feedback that the wiki link in the README was empty and the repo structure wasn't obvious.

## Changes

- **New `docs/FOUNDATION.md`** - central foundation specification hub covering architecture, design decisions, standards alignment, extensibility model, and linking to all spec documents
- **README** - replaced dead wiki link with `docs/FOUNDATION.md`, added repository structure tree diagram with pnpm workspace explanation
- **All 5 docs/** - added *Part of the Clarvia Graph Foundation Specification* banner linking back to the hub