### PR TITLE
docs: CI/license badges, linguist fix, PR template, mermaid diagram

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 *.pdf filter=lfs diff=lfs merge=lfs -text
 sources/snapshots/pdf/** filter=lfs diff=lfs merge=lfs -text
 sources/snapshots/html/** -diff -merge binary
+
+# GitHub language detection — show TypeScript/YAML, not HTML/JSON
+sources/snapshots/html/** linguist-detectable=false
+*.json linguist-detectable=false
+exports/** linguist-detectable=false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What does this PR do?
+
+<!-- Brief description of the change and why it's needed. -->
+
+## Checklist
+
+- [ ] CI passes (`pnpm validate`, `pnpm test`, `pnpm typecheck`)
+- [ ] New graph records start as `draft` / `restricted_source`
+- [ ] Source assertions include `text_quote` anchors
+- [ ] Scenario tests cover new consequences
+- [ ] Documentation updated (if applicable)
+
+## Related issues
+
+<!-- Link related issues: Closes #123, Fixes #456 -->

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 **Open consequence graph for source-backed administrative workflows**
 
+[![CI](https://github.com/clarvia-org/clarvia-graph/actions/workflows/ci.yml/badge.svg)](https://github.com/clarvia-org/clarvia-graph/actions/workflows/ci.yml)
+[![License: EUPL-1.2](https://img.shields.io/badge/Code-EUPL--1.2-blue.svg)](LICENSE)
+[![License: CC-BY-4.0](https://img.shields.io/badge/Data-CC--BY--4.0-green.svg)](LICENSE-DATA)
+
 [![Try the alpha checklist](https://img.shields.io/badge/🧪_Try_the_alpha_checklist-clarvia.org-blue?style=for-the-badge)](https://clarvia.org/en/checklist)
 
 Clarvia Graph is the technical engine behind [Clarvia](https://clarvia.org). It stores all the official rules and steps for bereavement paperwork across Europe — structured so that apps, websites, and public services can use them automatically. For the simple, family-friendly version, see [clarvia.org](https://clarvia.org).
@@ -74,8 +78,9 @@ The intended path is to build quickly, learn from real implementation, and then 
 
 ## Architecture
 
-```
-source → snapshot → assertion → consequence → task_template → checklist_item
+```mermaid
+flowchart LR
+    Source --> Snapshot --> Assertion --> Consequence --> Task["Task template"] --> Item["Checklist item"]
 ```
 
 Every checklist item traces back to an official source. No legal consequence publishes without an approved source assertion.


### PR DESCRIPTION
Grant review polish for clarvia-graph:

- **CI badge** — shows build status directly in README
- **License badges** — EUPL-1.2 (code) and CC-BY-4.0 (data)
- **Linguist fix** — .gitattributes overrides so GitHub shows TypeScript/YAML instead of HTML (from source snapshots)
- **PR template** — graph-specific checklist (CI, draft status, anchors, scenarios)
- **Mermaid architecture diagram** — replaces plain-text chain with rendered flowchart