### PR TITLE
fix: use linguist-vendored/generated for language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,7 @@
 sources/snapshots/pdf/** filter=lfs diff=lfs merge=lfs -text
 sources/snapshots/html/** -diff -merge binary
 
-# GitHub language detection — show TypeScript/YAML, not HTML/JSON
-sources/snapshots/html/** linguist-detectable=false
-*.json linguist-detectable=false
-exports/** linguist-detectable=false
+# GitHub language detection — exclude archived HTML, data files, and exports
+sources/snapshots/html/** linguist-vendored=true
+exports/** linguist-generated=true
+*.json linguist-generated=true


### PR DESCRIPTION
The previous `linguist-detectable=false` attribute controls whether a *language* appears at all, not whether individual files are excluded. This had no effect on the stats.

Fix: use `linguist-vendored=true` for archived HTML snapshots and `linguist-generated=true` for JSON data/exports, which properly excludes specific files from GitHub language statistics.