### PR TITLE
feat: migrate cross-border records from workflow-data

### DIFF
--- a/docs/corridors.md
+++ b/docs/corridors.md
@@ -1,0 +1,83 @@
+# Cross-Border Bereavement Corridors
+
+Part of the Clarvia Graph Foundation Specification.
+
+This document captures corridor-level knowledge for the four major Luxembourg
+cross-border bereavement corridors. Each corridor represents a distinct
+administrative pathway for families connected to Luxembourg and a neighbouring
+country.
+
+This information was originally authored by HirenGajjar in `clarvia-org/workflow-data`
+and migrated here in June 2026. It informs the design of cross-border
+`consequence`, `condition`, and `composition_rule` records but is not itself a
+graph record type.
+
+---
+
+## Luxembourg — France (~120,000 frontaliers)
+
+France is the largest frontalier corridor for Luxembourg.
+
+| Aspect | Detail |
+|---|---|
+| **Survivor pension** | Filed via Info Retraite (single request covers all French schemes) |
+| **Pension coordination** | CARSAT Alsace-Moselle coordinates with CNAP via form P5000 |
+| **Death certificate** | Luxembourg death certificate requires SCEC transcription for French civil registry |
+| **Succession** | Governed by Brussels IV (habitual residence rule) |
+
+**Sources:** `source.fr_info_retraite.reversion`, `source.fr_service_public.deces`, `source.eur_lex.brussels_iv`, `source.eur_lex.ec_883_2004`
+
+**Authorities:** `authority.fr.carsat`, `authority.fr.scec`
+
+---
+
+## Luxembourg — Germany (~55,000 frontaliers)
+
+Germany is the second largest frontalier corridor for Luxembourg.
+
+| Aspect | Detail |
+|---|---|
+| **Survivor pension** | DRV survivor pension requires marriage/partnership at death and 5-year qualifying period |
+| **Sterbevierteljahr** | 3 months at deceased's full pension rate with no income offset |
+| **Pension coordination** | DRV coordinates with CNAP via EU social security coordination |
+| **Advisory service** | DRV provides international advisory days for frontaliers |
+| **Succession** | Governed by Brussels IV (habitual residence rule) |
+
+**Sources:** `source.de_drv.hinterbliebenenrente`, `source.de_drv.rente_und_ausland`, `source.eur_lex.brussels_iv`, `source.eur_lex.ec_883_2004`
+
+**Authorities:** `authority.de.drv`, `authority.de.standesamt`
+
+---
+
+## Luxembourg — Belgium (~50,000 frontaliers)
+
+Belgium is the third largest frontalier corridor for Luxembourg.
+
+| Aspect | Detail |
+|---|---|
+| **Death declaration** | Declared to municipality where death occurred, usually by undertaker |
+| **Death certificate** | Forwarded to municipality of last residence |
+| **Succession duties** | Regional in Belgium — depend on fiscal residence |
+| **Pension coordination** | SFP handles survivor pension coordination with CNAP via EU social security rules |
+| **Succession** | Governed by Brussels IV (habitual residence rule) |
+
+**Sources:** `source.be_gouv.deces`, `source.eur_lex.brussels_iv`, `source.eur_lex.ec_883_2004`
+
+**Authorities:** `authority.be.sfp`
+
+---
+
+## Luxembourg — Portugal (~100,000 residents)
+
+Portugal represents the largest foreign national community in Luxembourg.
+
+| Aspect | Detail |
+|---|---|
+| **Death registration** | Death of a Portuguese national in Luxembourg must be registered in Portugal via consular services |
+| **Survivor pension** | Pensão de sobrevivência requires 36 months of contributions |
+| **Application** | Form RP 5075 via Segurança Social Direta or online at seg-social.pt |
+| **Succession** | Governed by Brussels IV (habitual residence rule) |
+
+**Sources:** `source.pt_eportugal.obito`, `source.eur_lex.brussels_iv`, `source.eur_lex.ec_883_2004`
+
+**Authorities:** `authority.pt.seguranca_social`

--- a/graph/authorities/be/sfp.yml
+++ b/graph/authorities/be/sfp.yml
@@ -1,0 +1,18 @@
+id: authority.be.sfp
+schema_version: "0.1.0"
+name: "Service fédéral des Pensions"
+name_en: "Federal Pension Service"
+name_de: "Föderaler Pensionsdienst"
+description: >
+  The Belgian Federal Pension Service (SFP/SFPD) administers statutory retirement,
+  survivor, and guaranteed-income pensions. Coordinates with CNAP for cross-border
+  Luxembourg–Belgium survivor pension claims under EU Regulation 883/2004.
+jurisdiction: BE
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/BEL"
+function: "Statutory pension administration — retirement, survivor, and guaranteed-income pensions"
+official_site: "https://www.sfpd.fgov.be"
+contact_channels: []
+languages: [fr, nl, de]
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-28"

--- a/graph/authorities/fr/carsat.yml
+++ b/graph/authorities/fr/carsat.yml
@@ -1,0 +1,18 @@
+id: authority.fr.carsat
+schema_version: "0.1.0"
+name: "Caisse d'assurance retraite et de la santé au travail"
+name_en: "Retirement and Occupational Health Insurance Fund"
+name_de: "Rentenversicherungskasse (Frankreich)"
+description: >
+  CARSAT administers statutory retirement and survivor pensions in France.
+  CARSAT Alsace-Moselle coordinates cross-border survivor pension claims
+  with CNAP Luxembourg via form P5000 under EU Regulation 883/2004.
+jurisdiction: FR
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/FRA"
+function: "Statutory pension and occupational health insurance"
+official_site: "https://www.lassuranceretraite.fr"
+contact_channels: []
+languages: [fr]
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/graph/authorities/fr/scec.yml
+++ b/graph/authorities/fr/scec.yml
@@ -1,0 +1,18 @@
+id: authority.fr.scec
+schema_version: "0.1.0"
+name: "Service central d'état civil"
+name_en: "Central Civil Registry Service"
+name_de: "Zentrales Standesamtsregister (Frankreich)"
+description: >
+  The Service central d'état civil (SCEC) in Nantes is the central civil
+  registry for French nationals abroad. A Luxembourg death certificate must
+  be transcribed by the SCEC before it is valid for French administrative purposes.
+jurisdiction: FR
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/FRA"
+function: "Central civil registration for events involving French nationals abroad"
+official_site: "https://www.service-public.fr/particuliers/vosdroits/F1431"
+contact_channels: []
+languages: [fr]
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/graph/authorities/pt/seguranca_social.yml
+++ b/graph/authorities/pt/seguranca_social.yml
@@ -1,0 +1,18 @@
+id: authority.pt.seguranca_social
+schema_version: "0.1.0"
+name: "Segurança Social"
+name_en: "Social Security (Portugal)"
+description: >
+  Portuguese social security authority. Administers survivor pensions
+  (pensão de sobrevivência) requiring minimum 36 months of registered
+  contributions. Application via Segurança Social Direta (form RP 5075)
+  or online at seg-social.pt.
+jurisdiction: PT
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/PRT"
+function: "Social security — pensions, death grants, survivor benefits"
+official_site: "https://www.seg-social.pt"
+contact_channels: []
+languages: [pt]
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-30"

--- a/graph/conditions/bereavement/xborder/repatriation_requested.yml
+++ b/graph/conditions/bereavement/xborder/repatriation_requested.yml
@@ -1,0 +1,26 @@
+id: condition.xborder.bereavement.repatriation.repatriation_requested
+schema_version: "0.1.0"
+title: "The family intends to transport the body or ashes to another country"
+description: >
+  Evaluates whether the family wishes to transport the deceased's body or
+  ashes to a country other than where the death occurred. Requires a
+  laissez-passer mortuaire (mortuary pass) issued by the commune. For EU
+  countries, the 1973 Strasbourg Convention on the Transfer of Mortal
+  Remains applies. Funeral director typically coordinates documentation.
+  Cremated remains have fewer cross-border restrictions than body transport.
+condition_type: criterion
+jurisdiction: EU
+life_event: bereavement
+domain: repatriation
+expression_language: jsonlogic
+expression:
+  "==":
+    - { "var": "repatriation.requested" }
+    - true
+missing_fact_behavior: unknown
+information_concept_refs:
+  - intake_fact.global.bereavement.repatriation_requested
+source_assertion_refs: []
+record_valid_from: "2026-05-28"
+authoring_status: draft
+distribution_status: public_open

--- a/graph/intake_fact_types/bereavement/repatriation_requested.yml
+++ b/graph/intake_fact_types/bereavement/repatriation_requested.yml
@@ -1,0 +1,15 @@
+id: intake_fact.global.bereavement.repatriation_requested
+schema_version: "0.1.0"
+path: repatriation.requested
+label: "Family intends to transport the body or ashes to another country"
+description: >
+  Whether the family wishes to transport the deceased's remains (body or
+  cremated ashes) to a country other than where the death occurred. If true,
+  additional cross-border documentation is required including a laissez-passer
+  mortuaire.
+value_type: boolean
+cardinality: one
+required_for:
+  - repatriation_routing
+used_by_condition_refs:
+  - condition.xborder.bereavement.repatriation.repatriation_requested

--- a/sources/be_gouv/deces.yml
+++ b/sources/be_gouv/deces.yml
@@ -1,0 +1,20 @@
+id: source.be_gouv.deces
+schema_version: "0.1.0"
+title: "Décès"
+title_en: "Death (Belgium)"
+description: >
+  Official Belgian government portal covering administrative procedures
+  following a death in Belgium. Death is declared to the municipality where
+  it occurred, usually by the undertaker. The death certificate is forwarded
+  to the municipality of last residence.
+source_type: government_portal
+url: "https://www.belgium.be/fr/famille/deces"
+jurisdiction: BE
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/BEL"
+languages: [fr, nl, de]
+publisher: "Belgium.be (Service public fédéral)"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-30"

--- a/sources/de_drv/hinterbliebenenrente.yml
+++ b/sources/de_drv/hinterbliebenenrente.yml
@@ -1,0 +1,20 @@
+id: source.de_drv.hinterbliebenenrente
+schema_version: "0.1.0"
+title: "Hinterbliebenenrente"
+title_en: "Survivor pension (Germany)"
+description: >
+  Official DRV guidance on German survivor pensions (Witwen-/Witwerrente).
+  DRV survivor pension requires marriage/partnership at death and 5-year
+  qualifying period. Sterbevierteljahr provision grants 3 months at the
+  deceased's full pension rate with no income offset.
+source_type: official_guidance
+url: "https://www.deutsche-rentenversicherung.de/SharedDocs/Formulare/DE/_pdf/R0500.html"
+jurisdiction: DE
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/DEU"
+languages: [de]
+publisher: "Deutsche Rentenversicherung"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/sources/de_drv/rente_und_ausland.yml
+++ b/sources/de_drv/rente_und_ausland.yml
@@ -1,0 +1,19 @@
+id: source.de_drv.rente_und_ausland
+schema_version: "0.1.0"
+title: "Rente und Ausland"
+title_en: "Pension and abroad (Germany)"
+description: >
+  Official DRV guidance on pensions for persons living abroad or with
+  international employment histories. Covers cross-border pension
+  coordination and the international advisory service for frontaliers.
+source_type: official_guidance
+url: "https://www.deutsche-rentenversicherung.de/SharedDocs/Formulare/DE/_pdf/R0860.html"
+jurisdiction: DE
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/DEU"
+languages: [de]
+publisher: "Deutsche Rentenversicherung"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/sources/eur_lex/brussels_iv.yml
+++ b/sources/eur_lex/brussels_iv.yml
@@ -1,0 +1,27 @@
+id: source.eur_lex.brussels_iv
+schema_version: "0.1.0"
+title: "Regulation (EU) No 650/2012 — Succession Regulation (Brussels IV)"
+title_en: "EU Succession Regulation (Brussels IV)"
+description: >
+  EU Regulation 650/2012 on jurisdiction, applicable law, recognition and
+  enforcement of decisions and acceptance and enforcement of authentic
+  instruments in matters of succession, and on the creation of a European
+  Certificate of Succession. Key provisions: Art. 21 (habitual residence
+  rule), Art. 22 (choice of nationality law), Art. 62-73 (European
+  Certificate of Succession). Applies in all EU member states except Denmark
+  and Ireland for succession matters.
+source_type: regulation
+url: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32012R0650"
+jurisdiction: EU
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/EUR"
+languages: [en, fr, de]
+publisher: "Official Journal of the European Union"
+legal_identifier:
+  scheme: CELEX
+  celex: "32012R0650"
+  eli_uri: "http://data.europa.eu/eli/reg/2012/650/oj"
+  date_document: "2012-07-04"
+  first_date_entry_in_force: "2015-08-17"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-28"

--- a/sources/eur_lex/ec_883_2004.yml
+++ b/sources/eur_lex/ec_883_2004.yml
@@ -1,0 +1,25 @@
+id: source.eur_lex.ec_883_2004
+schema_version: "0.1.0"
+title: "Regulation (EC) No 883/2004 — Social Security Coordination"
+title_en: "EU Social Security Coordination Regulation"
+description: >
+  EU Regulation 883/2004 coordinating social security systems across member
+  states, including survivor pension routing for cross-border workers and
+  their families. Determines which country's pension authority is responsible
+  when the deceased worked across borders. Current consolidated version:
+  31/07/2019. Applies to EU member states plus EEA and Switzerland.
+source_type: regulation
+url: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32004R0883"
+jurisdiction: EU
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/EUR"
+languages: [en, fr, de]
+publisher: "Official Journal of the European Union"
+legal_identifier:
+  scheme: CELEX
+  celex: "32004R0883"
+  eli_uri: "http://data.europa.eu/eli/reg/2004/883/oj"
+  date_document: "2004-04-29"
+  first_date_entry_in_force: "2010-05-01"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-28"

--- a/sources/fr_info_retraite/reversion.yml
+++ b/sources/fr_info_retraite/reversion.yml
@@ -1,0 +1,20 @@
+id: source.fr_info_retraite.reversion
+schema_version: "0.1.0"
+title: "Pension de réversion"
+title_en: "Survivor pension (France)"
+description: >
+  French inter-regime retirement portal covering survivor pension
+  (pension de réversion) procedures. A single request via Info Retraite
+  covers all French pension schemes. CARSAT Alsace-Moselle coordinates
+  with CNAP Luxembourg via form P5000 for cross-border claims.
+source_type: government_portal
+url: "https://www.info-retraite.fr/portail-info/sites/PortsRef498/"
+jurisdiction: FR
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/FRA"
+languages: [fr]
+publisher: "Info Retraite (GIP Union Retraite)"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/sources/fr_service_public/deces.yml
+++ b/sources/fr_service_public/deces.yml
@@ -1,0 +1,19 @@
+id: source.fr_service_public.deces
+schema_version: "0.1.0"
+title: "Décès"
+title_en: "Death (France)"
+description: >
+  Official French government portal covering administrative steps
+  after a death in France, including death declaration, certificates,
+  succession, and survivor pension procedures.
+source_type: government_portal
+url: "https://www.service-public.fr/particuliers/vosdroits/F16507"
+jurisdiction: FR
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/FRA"
+languages: [fr]
+publisher: "Service-Public.fr (Direction de l'information légale et administrative)"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-29"

--- a/sources/pt_eportugal/obito.yml
+++ b/sources/pt_eportugal/obito.yml
@@ -1,0 +1,21 @@
+id: source.pt_eportugal.obito
+schema_version: "0.1.0"
+title: "Morte"
+title_en: "Death (Portugal)"
+description: >
+  Official Portuguese government portal covering administrative procedures
+  following a death, including death declaration, death certificate, survivor
+  pension, death grant, and procedures for Portuguese nationals who die abroad.
+  The death of a Portuguese citizen abroad must be declared in Portugal via
+  consular services.
+source_type: government_portal
+url: "https://eportugal.gov.pt/en/temas/familia/morte"
+jurisdiction: PT
+jurisdiction_uri: "http://publications.europa.eu/resource/authority/country/PRT"
+languages: [pt, en]
+publisher: "ePortugal (Agência para a Modernização Administrativa)"
+legal_identifier:
+  scheme: url_only
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-05-30"


### PR DESCRIPTION
Migrates all unique, valuable content from `workflow-data` into the graph, completing the data migration and enabling `workflow-data` to be archived.

## Records migrated

| Type | Count | Details |
|---|---|---|
| **Authorities** | 4 | BE/sfp, FR/carsat, FR/scec, PT/seguranca_social |
| **Sources** | 8 | BE(1), DE(2), FR(2), PT(1), EU(2 - Brussels IV + EC 883/2004) |
| **Conditions** | 1 | Cross-border repatriation of remains |
| **Intake facts** | 1 | repatriation.requested |
| **Documentation** | 1 | Corridor reference (FR/DE/BE/PT) |

All records originally authored by @HirenGajjar in workflow-data and converted to clarvia-graph v0.1 schema format.

## Validation

142/142 files passed schema validation.

## What was NOT migrated (already superseded)

- 1 task scaffold, 1 workflow scaffold (graph has 19 consequences + 19 task templates)
- 6 generic conditions (graph has 17 LU-specific ones)
- 1 deadline, 1 document requirement (graph has 10 deadlines + 28 evidence types)
- 4 corridor scenarios (captured as docs/corridors.md - no corridor record type in spec)
- 2 institutions already in graph (drv, bureau_etat_civil)
- 2 sources already in graph (guichet death life event, guichet death certificate)