### PR TITLE
docs: add plain-text badge status for scrapers and AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 [![Try the alpha checklist](https://img.shields.io/badge/🧪_Try_the_alpha_checklist-clarvia.org-blue?style=for-the-badge)](https://clarvia.org/en/checklist)
 
+> **Status:** CI passing · [OpenSSF Best Practices: passing](https://www.bestpractices.dev/projects/13112) · Code: EUPL-1.2 · Data: CC-BY-4.0
+
 Clarvia Graph is the technical engine behind [Clarvia](https://clarvia.org). It stores all the official rules and steps for bereavement paperwork across Europe — structured so that apps, websites, and public services can use them automatically. For the simple, family-friendly version, see [clarvia.org](https://clarvia.org).
 
 <details>


### PR DESCRIPTION
Badge images (shields.io, bestpractices.dev) are invisible to scrapers, LLMs reading READMEs, and most indexing tools. This adds a plain-text status line below the badges so the same information (OpenSSF passing, CI status, licenses) is discoverable as text.

The badge images remain for human readers. The text line serves agents and crawlers.