### PR TITLE
fix(ci): exclude companion metadata from snapshot schema validation

### DIFF
--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -82,7 +82,7 @@ export async function runValidate(
   const patterns = [
     "graph/**/*.{yml,yaml}",
     "sources/assertions/**/*.{yml,yaml}",
-    "sources/snapshots/**/*.{yml,yaml}",
+    "sources/snapshots/*.{yml,yaml}",
   ];
   const files = patterns.flatMap((p: string) =>
     globSync(p, { cwd: rootDir, absolute: true }),
@@ -221,7 +221,7 @@ function validateSnapshotsAndAnchors(
   rootDir: string,
   results: ValidateResult[],
 ): void {
-  const snapshotFiles = globSync("sources/snapshots/**/*.{yml,yaml}", {
+  const snapshotFiles = globSync("sources/snapshots/*.{yml,yaml}", {
     cwd: rootDir,
     absolute: true,
   });


### PR DESCRIPTION
The validator's recursive glob (sources/snapshots/**/*.yml) was picking up lightweight contributor metadata files (e.g. declaration-deces_fr.yml) under sources/snapshots/html/ and validating them against the full source_snapshot.schema.json. These companion files don't have required fields like id, schema_version, content_hash, etc. — they're capture metadata, not snapshot records.

**Fix:** Change the glob to sources/snapshots/*.yml (non-recursive) so only top-level snapshot records are validated. Companion metadata files under html/ subdirectories are excluded.

**Local validation:** 142/142 files pass.

Fixes the 4 failing CI runs caused by PR #62 (Talizdo's contribution).