### PR TITLE
docs: add Zenodo metadata for DOI archival

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,69 @@
+{
+  "title": "Clarvia Graph: Open Consequence Graph for Bereavement Administration",
+  "description": "An open, source-backed consequence graph modelling administrative workflows triggered by bereavement across European jurisdictions. Maps official government sources to structured tasks, deadlines, conditions, and evidence requirements. Aligned with CPSV-AP, CCCEV, ELI, and PROV-O.",
+  "upload_type": "software",
+  "creators": [
+    {
+      "name": "Lindfors, Tommi",
+      "affiliation": "CLARVIA ASBL, Luxembourg"
+    }
+  ],
+  "contributors": [
+    {
+      "name": "Gajjar, Hiren",
+      "type": "Researcher",
+      "affiliation": ""
+    },
+    {
+      "name": "Talizdo",
+      "type": "DataCollector",
+      "affiliation": ""
+    }
+  ],
+  "keywords": [
+    "bereavement",
+    "administrative workflows",
+    "knowledge graph",
+    "consequence graph",
+    "legal ontology",
+    "public services",
+    "cross-border",
+    "Luxembourg",
+    "CPSV-AP",
+    "CCCEV",
+    "ELI",
+    "PROV-O",
+    "civic tech",
+    "open data"
+  ],
+  "license": {
+    "id": "EUPL-1.2"
+  },
+  "communities": [
+    {
+      "identifier": "zenodo"
+    }
+  ],
+  "grants": [],
+  "related_identifiers": [
+    {
+      "identifier": "https://github.com/clarvia-org/clarvia-graph",
+      "relation": "isSupplementTo",
+      "scheme": "url"
+    },
+    {
+      "identifier": "https://clarvia.org",
+      "relation": "isDocumentedBy",
+      "scheme": "url"
+    }
+  ],
+  "subjects": [
+    {
+      "term": "Public administration",
+      "identifier": "https://id.loc.gov/authorities/subjects/sh85108611",
+      "scheme": "url"
+    }
+  ],
+  "language": "eng",
+  "access_right": "open"
+}


### PR DESCRIPTION
Adds `.zenodo.json` with project metadata so that when Zenodo archives a GitHub release, it creates a properly indexed DOI record with:

- Project title and description
- Creator/contributor attribution
- Keywords for discoverability (bereavement, knowledge graph, civic tech, etc.)
- Standards alignment (CPSV-AP, CCCEV, ELI, PROV-O)
- Related identifiers (GitHub repo, clarvia.org)
- EUPL-1.2 license

**Note:** The ORCID field for the creator is empty — fill in if you have one.

**Next steps after merge:**
1. Enable the repo at https://zenodo.org/account/settings/github/
2. Create a GitHub release to trigger the first Zenodo archival
3. Add the DOI badge to the README