### PR TITLE
docs: add Zenodo DOI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 [![License: EUPL-1.2](https://img.shields.io/badge/Code-EUPL--1.2-blue.svg)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13112/badge)](https://www.bestpractices.dev/projects/13112)
 [![License: CC-BY-4.0](https://img.shields.io/badge/Data-CC--BY--4.0-green.svg)](LICENSE-DATA)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20572455.svg)](https://doi.org/10.5281/zenodo.20572455)
 
 [![Try the alpha checklist](https://img.shields.io/badge/🧪_Try_the_alpha_checklist-clarvia.org-blue?style=for-the-badge)](https://clarvia.org/en/checklist)
 
-> **Status:** CI passing · [OpenSSF Best Practices: passing](https://www.bestpractices.dev/projects/13112) · Code: EUPL-1.2 · Data: CC-BY-4.0
+> **Status:** CI passing · [OpenSSF Best Practices: passing](https://www.bestpractices.dev/projects/13112) · Code: EUPL-1.2 · Data: CC-BY-4.0 · [DOI: 10.5281/zenodo.20572455](https://doi.org/10.5281/zenodo.20572455)
 
 Clarvia Graph is the technical engine behind [Clarvia](https://clarvia.org). It stores all the official rules and steps for bereavement paperwork across Europe — structured so that apps, websites, and public services can use them automatically. For the simple, family-friendly version, see [clarvia.org](https://clarvia.org).
 


### PR DESCRIPTION
Adds the Zenodo DOI badge and text link to the README.

- **DOI:** [10.5281/zenodo.20572455](https://doi.org/10.5281/zenodo.20572455) (concept DOI — always resolves to latest version)
- **Record:** https://zenodo.org/records/20572456
- Badge added to image row and plain-text status line

The project is now academically citable.