### PR TITLE
fix: resolve all 6 CodeQL security and quality alerts

### DIFF
--- a/packages/cli/src/commands/check-anchors.ts
+++ b/packages/cli/src/commands/check-anchors.ts
@@ -23,11 +23,10 @@ function toPosixRel(abs: string, root: string): string {
 /** Strip HTML tags from a string, returning text content only. */
 export function stripHtmlTags(html: string): string {
   return html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[^>]*>[\s\S]*?<\/script[^>]*>/gi, " ")
+    .replace(/<style[^>]*>[\s\S]*?<\/style[^>]*>/gi, " ")
     .replace(/<[^>]+>/g, " ")
     .replace(/&nbsp;/gi, " ")
-    .replace(/&amp;/gi, "&")
     .replace(/&lt;/gi, "<")
     .replace(/&gt;/gi, ">")
     .replace(/&quot;/gi, '"')
@@ -39,6 +38,7 @@ export function stripHtmlTags(html: string): string {
     .replace(/&ndash;/gi, "\u2013")
     .replace(/&mdash;/gi, "\u2014")
     .replace(/&#\d+;/gi, " ")
+    .replace(/&amp;/gi, "&")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -563,12 +563,18 @@ function normalizeText(text: string): string {
 }
 
 function getNormalizedTextContent(html: string): string {
-  let text = html.replace(/<!--[\s\S]*?-->/g, "");
+  // Loop to handle crafted/nested comment markers like <!-<!-- -->->
+  let text = html;
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(/<!--[\s\S]*?-->/g, "");
+  } while (text !== prev);
   text = text.replace(/<(script|style)[\s\S]*?>[\s\S]*?<\/\1>/gi, " ");
   text = text.replace(/<[^>]+>/g, " ");
   // Decode common HTML entities (aligned with check-anchors.ts)
+  // NOTE: &amp; is decoded last to avoid double-unescaping (e.g. &amp;lt; → &lt; → <)
   text = text.replace(/&nbsp;/gi, " ");
-  text = text.replace(/&amp;/gi, "&");
   text = text.replace(/&lt;/gi, "<");
   text = text.replace(/&gt;/gi, ">");
   text = text.replace(/&quot;/gi, '"');
@@ -579,6 +585,7 @@ function getNormalizedTextContent(html: string): string {
   text = text.replace(/&ldquo;/gi, "\u201D");
   text = text.replace(/&ndash;/gi, "\u2013");
   text = text.replace(/&mdash;/gi, "\u2014");
+  text = text.replace(/&amp;/gi, "&");
   return normalizeText(text);
 }
 

--- a/packages/generator/src/evaluator.ts
+++ b/packages/generator/src/evaluator.ts
@@ -74,14 +74,14 @@ function resolveVar(
  *   { death: { place: { country: "LU" } } }
  */
 export function buildFactData(facts: Fact[]): Record<string, unknown> {
-  const data: Record<string, unknown> = {};
+  const data: Record<string, unknown> = Object.create(null);
   for (const f of facts) {
     const parts = f.fact_type.split(".");
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let current: any = data;
     for (let i = 0; i < parts.length - 1; i++) {
       if (!(parts[i] in current) || typeof current[parts[i]] !== "object") {
-        current[parts[i]] = {};
+        current[parts[i]] = Object.create(null);
       }
       current = current[parts[i]];
     }


### PR DESCRIPTION
Resolves all 6 open CodeQL code scanning alerts.

## Changes

### evaluator.ts — Prototype pollution (alerts 5 & 6)
- Use \Object.create(null)\ instead of \{}\ in \uildFactData\ to prevent prototype pollution when fact_type paths contain \__proto__\, \constructor\, or \prototype\

### check-anchors.ts — Bad tag filter + double escaping (alerts 1 & 4)
- Allow whitespace before \>\ in \</script>\ / \</style>\ closing tags (regex: \<\/script\s*>\)
- Decode \&amp;\ **last** in the entity decoding chain to prevent double-unescaping (\&amp;lt;\ → \&lt;\ → \<\)

### validate.ts — Incomplete sanitization + double escaping (alerts 2 & 3)
- Loop HTML comment stripping (\<!-- -->\) until stable, preventing crafted nested markers from surviving a single pass
- Decode \&amp;\ last (same fix as check-anchors)

## Testing
All 142 tests pass. The one flaky test (\EPERM\ on \mSync\ in \fterEach\) is a pre-existing Dropbox file-locking issue unrelated to these changes.