### PR TITLE
fix: remove redundant undefined check in urgencyLabel

### DIFF
--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -296,7 +296,7 @@ function mergeExplanationTraces(
 // ── Urgency label from score ─────────────────────────────────────────
 
 function urgencyLabel(score: number | null): string | null {
-  if (score === null || score === undefined) return null;
+  if (score == null) return null;
   if (score >= 90) return "urgent";
   if (score >= 70) return "important";
   if (score >= 40) return "standard";


### PR DESCRIPTION
Resolves CodeQL code quality finding \js/unneeded-defensive-code\ in \generator.ts:299\.

The \urgencyLabel\ function parameter is typed \
umber | null\ — \undefined\ is impossible. Simplifies \score === null || score === undefined\ to \score == null\ (loose equality covers both).