### PR TITLE
fix: resolve 12 SonarCloud quick-fix issues

### DIFF
--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -9,9 +9,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
-import { loadGraph } from "@clarvia/generator";
-import { generateChecklist } from "@clarvia/generator";
-import type { Fact } from "@clarvia/generator";
+import { loadGraph, generateChecklist, type Fact } from "@clarvia/generator";
 
 export async function main(): Promise<void> {
   const rootDir = resolve(
@@ -78,14 +76,12 @@ export async function main(): Promise<void> {
     );
 
     for (const item of sectionItems) {
-      const statusIcon =
-        item.status === "applies"
-          ? "✔"
-          : item.status === "needs_fact"
-            ? "?"
-            : item.status === "maybe_applies"
-              ? "~"
-              : "✘";
+      const statusIcons: Record<string, string> = {
+        applies: "✔",
+        needs_fact: "?",
+        maybe_applies: "~",
+      };
+      const statusIcon = statusIcons[item.status] ?? "✘";
       const urgencyTag = item.urgency?.label
         ? ` [${item.urgency.label}]`
         : "";

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 describe("CLI", () => {
   it("should export help text without errors", async () => {
-    // Smoke test: importing the module should not throw
-    expect(true).toBe(true);
+    // Mock process.exit so the CLI help handler doesn't terminate the test
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    try {
+      const mod = await import("./index.js");
+      expect(mod).toBeDefined();
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/packages/generator/src/explanation.ts
+++ b/packages/generator/src/explanation.ts
@@ -30,6 +30,13 @@ export interface ExplanationTrace {
   sources: SourceTrace[];
 }
 
+/** Convert a TriValue (true | false | "unknown") to a string label */
+function triValueToString(value: TriValue): "true" | "false" | "unknown" {
+  if (value === true) return "true";
+  if (value === false) return "false";
+  return "unknown";
+}
+
 /** Build an explanation trace for a checklist item */
 export function buildExplanationTrace(
   traceId: string,
@@ -47,8 +54,7 @@ export function buildExplanationTrace(
     const condition = graph.conditions.get(ref);
 
     if (result && condition) {
-      const resultStr =
-        result.result === true ? "true" : result.result === false ? "false" : "unknown";
+      const resultStr = triValueToString(result.result);
 
       conditions.push({
         condition_ref: ref,

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -192,7 +192,7 @@ function resolveDedupeKey(
   }
 
   const dedupe = template.dedupe;
-  if (!dedupe || !dedupe.dedupe_key_template) {
+  if (!dedupe?.dedupe_key_template) {
     return { key: `template.${template.id}`, strategy: "do_not_merge" };
   }
 
@@ -301,6 +301,14 @@ function urgencyLabel(score: number | null): string | null {
   if (score >= 70) return "important";
   if (score >= 40) return "standard";
   return "low";
+}
+
+// ── Why-maybe explanation label ──────────────────────────────────────
+
+function whyMaybeLabel(status: ItemStatus, missingFacts: string[]): string | null {
+  if (status === "maybe_applies") return "Condition could not be fully evaluated";
+  if (status === "needs_fact") return `Missing: ${missingFacts.join(", ")}`;
+  return null;
 }
 
 // ── Map condition TriValue to item status ─────────────────────────────
@@ -569,7 +577,7 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
 
     const mergedIdentity = subList
       .map(c => `${c.consequence.id}::${c.template?.id ?? c.consequence.id}`)
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .join("|");
     const mergedGroupHash = createHash("sha256")
       .update(mergedIdentity)
@@ -581,9 +589,9 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
       ...base,
       id: mergedItemId,
       status: mergedStatus,
-      jurisdiction_contexts: [...jurisdictions].sort(),
-      needed_for: [...neededFor].sort(),
-      missing_fact_refs: [...missingFacts].sort(),
+      jurisdiction_contexts: [...jurisdictions].sort((a, b) => a.localeCompare(b)),
+      needed_for: [...neededFor].sort((a, b) => a.localeCompare(b)),
+      missing_fact_refs: [...missingFacts].sort((a, b) => a.localeCompare(b)),
       source_summary: {
         assertion_count: totalAssertionCount,
         top_tier: null,
@@ -761,12 +769,7 @@ function makeItem(
       : null,
     needed_for: [consequence.title],
     missing_fact_refs: missingFacts,
-    why_maybe:
-      status === "maybe_applies"
-        ? "Condition could not be fully evaluated"
-        : status === "needs_fact"
-          ? `Missing: ${missingFacts.join(", ")}`
-          : null,
+    why_maybe: whyMaybeLabel(status, missingFacts),
     source_summary: {
       assertion_count: filteredAssertionRefs.length,
       top_tier: null,

--- a/packages/generator/src/normalize.ts
+++ b/packages/generator/src/normalize.ts
@@ -48,7 +48,7 @@ export function normalizeFacts(facts: Fact[]): Fact[] {
       // Uppercase and deduplicate — arrays are always string-based country codes
       const rawArr = Array.isArray(fact.value) ? fact.value : String(fact.value ?? "").split(",");
       const values = rawArr.map((v: unknown) => String(v).trim().toUpperCase());
-      const unique = [...new Set(values)].sort();
+      const unique = [...new Set(values)].sort((a, b) => a.localeCompare(b));
       normalized.push({ fact_type: fact.fact_type, value: unique.join(",") });
     } else if (typeof fact.value === "boolean" || typeof fact.value === "number") {
       // Preserve boolean and numeric types — conditions use typed JsonLogic comparisons


### PR DESCRIPTION
Fixes 12 of 52 SonarCloud findings (all quick-fixable ones):

**5 CRITICAL bugs** — bare \.sort()\ without \localeCompare\:
- \
ormalize.ts:51\, \generator.ts:572,584,585,586\

**1 MAJOR code smell** — optional chaining:
- \generator.ts:195\ → \dedupe?.dedupe_key_template\

**4 MAJOR code smells** — nested ternaries extracted to helpers:
- \generator.ts\ → \whyMaybeLabel()\ helper
- \explanation.ts\ → \	riValueToString()\ helper
- \uild-checklist.ts\ → status icon map

**1 MAJOR code smell** — tautological assertion:
- \index.test.ts\ → real import smoke test with \process.exit\ mock

**1 MINOR code smell** — duplicate imports:
- \uild-checklist.ts\ → merged 3 imports into 1

**Remaining 40 issues** are cognitive complexity refactors (16 functions over threshold) and 3 HTML test fixture warnings — these need deeper design work.