### PR TITLE
fix: rewrite CITATION.cff with proper formatting

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 title: "Clarvia Graph: Open Consequence Graph for Bereavement Administration"
 type: software
-version: 0.1.0-alpha.0
-doi: 10.5281/zenodo.20572455
+version: "0.1.0-alpha.0"
+doi: "10.5281/zenodo.20572455"
 date-released: "2026-06-06"
 license: EUPL-1.2
 url: "https://clarvia.org"
@@ -22,7 +22,6 @@ keywords:
   - administrative workflows
   - knowledge graph
   - consequence graph
-  - legal ontology
   - public services
   - cross-border
   - Luxembourg


### PR DESCRIPTION
The original CITATION.cff had formatting issues that caused GitHub/CFF tooling to see it as ~2 physical lines with fields run together. Rewritten with proper YAML formatting, one field per line, UTF-8 no BOM.