### PR TITLE
refactor: extract helpers to reduce cognitive complexity (PR 1/4)

### DIFF
--- a/packages/cli/src/commands/build-checklist.ts
+++ b/packages/cli/src/commands/build-checklist.ts
@@ -10,17 +10,17 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { loadGraph, generateChecklist, type Fact } from "@clarvia/generator";
+import type { ChecklistOutput } from "@clarvia/generator";
+import { resolveRootDir } from "../shared/utils.js";
 
-export async function main(): Promise<void> {
-  const rootDir = resolve(
-    import.meta.dirname ?? __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+// ── arg parsing ──────────────────────────────────────────────────────
 
-  const args = process.argv.slice(3);
+interface ParsedArgs {
+  lifeEvent: string;
+  facts: Fact[];
+}
+
+function parseArgs(args: string[], rootDir: string): ParsedArgs {
   let facts: Fact[] = [];
   let lifeEvent = "bereavement";
 
@@ -49,22 +49,19 @@ export async function main(): Promise<void> {
     }
   }
 
-  console.log(`Loading graph from ${rootDir}...`);
-  const graph = loadGraph(rootDir);
-  console.log(
-    `Loaded: ${graph.consequences.size} consequences, ${graph.conditions.size} conditions, ${graph.taskTemplates.size} templates`,
-  );
+  return { lifeEvent, facts };
+}
 
-  console.log(`\nGenerating checklist for life_event="${lifeEvent}" with ${facts.length} facts...`);
-  const output = generateChecklist({ graph, facts, lifeEvent });
+// ── output printing ──────────────────────────────────────────────────
 
+function printChecklist(output: ChecklistOutput, lifeEvent: string): void {
   console.log(`\n${"═".repeat(60)}`);
   console.log(` CHECKLIST: ${lifeEvent}`);
   console.log(`${"═".repeat(60)}`);
 
   if (output.items.length === 0) {
     console.log("\n  No items match the provided facts.\n");
-    process.exit(0);
+    return;
   }
 
   // Print by section
@@ -107,13 +104,36 @@ export async function main(): Promise<void> {
   );
   console.log(`Sources referenced: ${output.summary.source_count}`);
   console.log();
+}
 
-  // Also output as YAML
-  const yamlOutput = JSON.stringify(output, null, 2);
+// ── main ─────────────────────────────────────────────────────────────
+
+export async function main(): Promise<void> {
+  const rootDir = resolveRootDir(import.meta.dirname ?? __dirname);
+
+  const { lifeEvent, facts } = parseArgs(process.argv.slice(3), rootDir);
+
+  console.log(`Loading graph from ${rootDir}...`);
+  const graph = loadGraph(rootDir);
+  console.log(
+    `Loaded: ${graph.consequences.size} consequences, ${graph.conditions.size} conditions, ${graph.taskTemplates.size} templates`,
+  );
+
+  console.log(`\nGenerating checklist for life_event="${lifeEvent}" with ${facts.length} facts...`);
+  const output = generateChecklist({ graph, facts, lifeEvent });
+
+  printChecklist(output, lifeEvent);
+
+  if (output.items.length === 0) {
+    process.exit(0);
+  }
+
+  // Also output as JSON
+  const jsonOutput = JSON.stringify(output, null, 2);
   const outputDir = resolve(rootDir, "build", "exports", "checklist");
   const outputPath = resolve(outputDir, "last-checklist.json");
   const { mkdirSync, writeFileSync } = await import("node:fs");
   mkdirSync(outputDir, { recursive: true });
-  writeFileSync(outputPath, yamlOutput);
+  writeFileSync(outputPath, jsonOutput);
   console.log(`Full output saved to: ${outputPath}`);
 }

--- a/packages/cli/src/commands/check-references.ts
+++ b/packages/cli/src/commands/check-references.ts
@@ -10,19 +10,14 @@
  */
 
 import { readFileSync } from "node:fs";
-import { resolve, relative } from "node:path";
 import { globSync } from "glob";
 import { parse as parseYaml } from "yaml";
+import { toPosixRel, resolveRootDir } from "../shared/utils.js";
 
 // Files to skip
 const SKIP_FILES = new Set([".gitkeep"]);
 
-// ── helpers ──────────────────────────────────────────────────────────
 
-/** Turn a Windows path into a forward-slash posix-style relative path */
-function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
-}
 
 // ── extract all IDs from a parsed YAML document ──────────────────────
 
@@ -126,14 +121,16 @@ export interface CheckReferencesOptions {
   rootDir: string;
 }
 
-// ── exported runner (tested in isolation) ────────────────────────────
+// ── file loading helper ────────────────────────────────────────────────
 
-export async function runCheckReferences(
-  opts: CheckReferencesOptions,
-): Promise<{ results: CheckRefFileResult[]; warnings: number }> {
-  const { rootDir } = opts;
+interface ParsedFile {
+  relPath: string;
+  data: unknown;
+}
 
-  // ── 1. Collect YAML files ──────────────────────────────────────────
+function loadAndParseFiles(
+  rootDir: string,
+): { parsed: ParsedFile[]; knownIds: Set<string> } {
   const patterns = [
     "graph/**/*.{yml,yaml}",
     "sources/assertions/**/*.{yml,yaml}",
@@ -145,19 +142,9 @@ export async function runCheckReferences(
 
   const dataFiles = files.filter((f: string) => {
     const base = f.split(/[\\/]/).pop()!;
-    if (SKIP_FILES.has(base)) return false;
-    return true;
+    return !SKIP_FILES.has(base);
   });
 
-  if (dataFiles.length === 0) {
-    return { results: [], warnings: 0 };
-  }
-
-  // ── 2. Parse all files and build the ID set ────────────────────────
-  interface ParsedFile {
-    relPath: string;
-    data: unknown;
-  }
   const parsed: ParsedFile[] = [];
   const knownIds = new Set<string>();
 
@@ -179,7 +166,23 @@ export async function runCheckReferences(
     }
   }
 
-  // ── 3. Check refs against the ID set ───────────────────────────────
+  return { parsed, knownIds };
+}
+
+// ── exported runner (tested in isolation) ────────────────────────────
+
+export async function runCheckReferences(
+  opts: CheckReferencesOptions,
+): Promise<{ results: CheckRefFileResult[]; warnings: number }> {
+  const { rootDir } = opts;
+
+  const { parsed, knownIds } = loadAndParseFiles(rootDir);
+
+  if (parsed.length === 0) {
+    return { results: [], warnings: 0 };
+  }
+
+  // Check refs against the ID set
   const results: CheckRefFileResult[] = [];
   let warnings = 0;
 
@@ -205,14 +208,7 @@ export async function runCheckReferences(
 // ── CLI entry point ──────────────────────────────────────────────────
 
 export async function main(): Promise<void> {
-  // Walk up from packages/cli/src/commands/ to find the repo root
-  const rootDir = resolve(
-    import.meta.dirname ?? ".",
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+  const rootDir = resolveRootDir(import.meta.dirname);
 
   const { results, warnings } = await runCheckReferences({ rootDir });
 

--- a/packages/cli/src/commands/export-web.ts
+++ b/packages/cli/src/commands/export-web.ts
@@ -16,6 +16,7 @@
  */
 
 import { resolve } from "node:path";
+import { resolveRootDir } from "../shared/utils.js";
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { parse as parseYaml } from "yaml";
@@ -44,13 +45,7 @@ function loadJurisdictionVocab(rootDir: string): JurisdictionEntry[] {
 }
 
 export async function main(): Promise<void> {
-  const rootDir = resolve(
-    import.meta.dirname ?? __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+  const rootDir = resolveRootDir(import.meta.dirname ?? __dirname);
 
   console.log(`Loading graph from ${rootDir}...`);
   const graph = loadGraph(rootDir);
@@ -212,6 +207,49 @@ function buildIntakeFile(
   );
 }
 
+/** Collect all transitively referenced entity IDs from consequences. */
+interface TransitiveRefs {
+  conditionIds: Set<string>;
+  taskTemplateIds: Set<string>;
+  authorityIds: Set<string>;
+  deadlineIds: Set<string>;
+  evidenceTypeIds: Set<string>;
+}
+
+function collectTransitiveRefs(
+  consequences: Array<Record<string, unknown>>,
+  graph: LoadedGraph,
+): TransitiveRefs {
+  const conditionIds = new Set<string>();
+  const taskTemplateIds = new Set<string>();
+  const authorityIds = new Set<string>();
+  const deadlineIds = new Set<string>();
+  const evidenceTypeIds = new Set<string>();
+
+  for (const c of consequences) {
+    for (const ref of (c.trigger as Record<string, unknown>)?.condition_refs as string[] ?? []) {
+      conditionIds.add(ref);
+    }
+    for (const ref of c.task_template_refs as string[] ?? []) {
+      taskTemplateIds.add(ref);
+    }
+  }
+
+  for (const id of taskTemplateIds) {
+    const t = graph.taskTemplates.get(id);
+    if (!t) continue;
+    for (const ref of t.authority_refs ?? []) authorityIds.add(ref);
+    for (const ref of t.deadline_refs ?? []) deadlineIds.add(ref);
+    if (t.evidence_requirements) {
+      for (const set of t.evidence_requirements.sets) {
+        for (const ref of set.evidence_type_refs) evidenceTypeIds.add(ref);
+      }
+    }
+  }
+
+  return { conditionIds, taskTemplateIds, authorityIds, deadlineIds, evidenceTypeIds };
+}
+
 /**
  * Build runtime file — all data needed for client-side evaluation.
  * Only includes public consequences (per spec §10.6 publication gate).
@@ -228,39 +266,11 @@ function buildRuntimeFile(
       PUBLIC_DISTRIBUTION.has(c.distribution_status),
   );
 
-  // Filter conditions to only those referenced by public consequences
-  const referencedConditionIds = new Set<string>();
-  for (const c of consequences) {
-    for (const ref of c.trigger?.condition_refs ?? []) {
-      referencedConditionIds.add(ref);
-    }
-  }
+  const refs = collectTransitiveRefs(consequences, graph);
+
   const conditions = [...graph.conditions.values()].filter(
-    (c) => referencedConditionIds.has(c.id),
+    (c) => refs.conditionIds.has(c.id),
   );
-
-  // Collect referenced task templates, authorities, deadlines, evidence types
-  const taskTemplateIds = new Set<string>();
-  const authorityIds = new Set<string>();
-  const deadlineIds = new Set<string>();
-  const evidenceTypeIds = new Set<string>();
-
-  for (const c of consequences) {
-    for (const ref of c.task_template_refs ?? []) taskTemplateIds.add(ref);
-  }
-
-  for (const id of taskTemplateIds) {
-    const t = graph.taskTemplates.get(id);
-    if (t) {
-      for (const ref of t.authority_refs ?? []) authorityIds.add(ref);
-      for (const ref of t.deadline_refs ?? []) deadlineIds.add(ref);
-      if (t.evidence_requirements) {
-        for (const set of t.evidence_requirements.sets) {
-          for (const ref of set.evidence_type_refs) evidenceTypeIds.add(ref);
-        }
-      }
-    }
-  }
 
   const runtime = {
     life_event: lifeEvent,
@@ -281,7 +291,7 @@ function buildRuntimeFile(
       task_template_refs: c.task_template_refs,
       confidence: c.confidence,
     })),
-    task_templates: [...taskTemplateIds]
+    task_templates: [...refs.taskTemplateIds]
       .map((id) => graph.taskTemplates.get(id))
       .filter(Boolean)
       .map((t) => ({
@@ -293,7 +303,7 @@ function buildRuntimeFile(
         evidence_requirements: t!.evidence_requirements,
         rendering: t!.rendering,
       })),
-    authorities: [...authorityIds]
+    authorities: [...refs.authorityIds]
       .map((id) => graph.authorities.get(id))
       .filter(Boolean)
       .map((a) => {
@@ -306,7 +316,7 @@ function buildRuntimeFile(
           name_de: raw.name_de ?? a!.name,
         };
       }),
-    deadlines: [...deadlineIds]
+    deadlines: [...refs.deadlineIds]
       .map((id) => graph.deadlines.get(id))
       .filter(Boolean)
       .map((d) => ({
@@ -315,7 +325,7 @@ function buildRuntimeFile(
         deadline_type: d!.deadline_type,
         calculation: d!.calculation,
       })),
-    evidence_types: [...evidenceTypeIds]
+    evidence_types: [...refs.evidenceTypeIds]
       .map((id) => graph.evidenceTypes.get(id))
       .filter(Boolean)
       .map((e) => ({

--- a/packages/cli/src/commands/lint-ids.ts
+++ b/packages/cli/src/commands/lint-ids.ts
@@ -6,7 +6,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { resolve, relative } from "node:path";
+import { toPosixRel, resolveRootDir } from "../shared/utils.js";
 import { globSync } from "glob";
 import { parse as parseYaml } from "yaml";
 
@@ -95,10 +95,6 @@ const MAX_ID_LENGTH = 120;
 const WARN_ID_LENGTH = 80;
 
 // ── helpers ──────────────────────────────────────────────────────────
-
-function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
-}
 
 function resolveTypeRule(
   relPath: string,
@@ -319,16 +315,50 @@ export async function runLintIds(
   return { results, ok };
 }
 
+// ── output helpers ───────────────────────────────────────────────────
+
+function countIssuesByLevel(
+  results: LintIdResult[],
+  level: "error" | "warn",
+): number {
+  return results.reduce(
+    (n, r) =>
+      n +
+      r.ids.reduce(
+        (m, i) => m + i.issues.filter((iss) => iss.level === level).length,
+        0,
+      ),
+    0,
+  );
+}
+
+function formatFileResult(r: LintIdResult): void {
+  const hasErrors = r.ids.some((i) =>
+    i.issues.some((iss) => iss.level === "error"),
+  );
+  const hasWarns = r.ids.some((i) =>
+    i.issues.some((iss) => iss.level === "warn"),
+  );
+
+  if (!hasErrors && !hasWarns) {
+    console.log(`✔ ${r.file}`);
+    return;
+  }
+
+  const marker = hasErrors ? "✘" : "⚠";
+  console.log(`${marker} ${r.file}`);
+  for (const idResult of r.ids) {
+    for (const iss of idResult.issues) {
+      const icon = iss.level === "error" ? "  ✘" : "  ⚠";
+      console.log(`${icon} [${idResult.id}] ${iss.message}`);
+    }
+  }
+}
+
 // ── CLI entry point ──────────────────────────────────────────────────
 
 export async function main(): Promise<void> {
-  const rootDir = resolve(
-    import.meta.dirname ?? __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+  const rootDir = resolveRootDir(import.meta.dirname ?? __dirname);
 
   const { results, ok } = await runLintIds({ rootDir });
 
@@ -340,45 +370,11 @@ export async function main(): Promise<void> {
   }
 
   for (const r of results) {
-    const hasErrors = r.ids.some((i) =>
-      i.issues.some((iss) => iss.level === "error"),
-    );
-    const hasWarns = r.ids.some((i) =>
-      i.issues.some((iss) => iss.level === "warn"),
-    );
-
-    if (!hasErrors && !hasWarns) {
-      console.log(`✔ ${r.file}`);
-    } else {
-      const marker = hasErrors ? "✘" : "⚠";
-      console.log(`${marker} ${r.file}`);
-      for (const idResult of r.ids) {
-        for (const iss of idResult.issues) {
-          const icon = iss.level === "error" ? "  ✘" : "  ⚠";
-          console.log(`${icon} [${idResult.id}] ${iss.message}`);
-        }
-      }
-    }
+    formatFileResult(r);
   }
 
-  const errorCount = results.reduce(
-    (n, r) =>
-      n +
-      r.ids.reduce(
-        (m, i) => m + i.issues.filter((iss) => iss.level === "error").length,
-        0,
-      ),
-    0,
-  );
-  const warnCount = results.reduce(
-    (n, r) =>
-      n +
-      r.ids.reduce(
-        (m, i) => m + i.issues.filter((iss) => iss.level === "warn").length,
-        0,
-      ),
-    0,
-  );
+  const errorCount = countIssuesByLevel(results, "error");
+  const warnCount = countIssuesByLevel(results, "warn");
 
   console.log(`\n${errorCount} error(s), ${warnCount} warning(s).`);
   process.exit(ok ? 0 : 1);

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -6,7 +6,8 @@
  */
 
 import { readFileSync, existsSync } from "node:fs";
-import { resolve, relative } from "node:path";
+import { resolve } from "node:path";
+import { toPosixRel, resolveRootDir, mergeErrors } from "../shared/utils.js";
 import { globSync } from "glob";
 import { parse as parseYaml } from "yaml";
 import type { ErrorObject } from "ajv";
@@ -40,12 +41,7 @@ const DIR_SCHEMA_MAP: Record<string, string> = {
 const SKIP_FILES = new Set([".gitkeep"]);
 const SKIP_PATHS = new Set(["sources/register.yml"]);
 
-// ── helpers ──────────────────────────────────────────────────────────
 
-/** Turn a Windows path into a forward-slash posix-style relative path */
-function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
-}
 
 /** Resolve which schema file a YAML data file should validate against. */
 function resolveSchemaFile(relPath: string): string | null {
@@ -233,9 +229,7 @@ function validateSnapshotsAndAnchors(
 
   const snapshotMap = new Map<string, { data: Record<string, unknown>; file: string }>();
 
-  function getRel(abs: string): string {
-    return relative(rootDir, abs).split("\\").join("/");
-  }
+  const getRel = (abs: string): string => toPosixRel(abs, rootDir);
 
   for (const file of snapshotFiles) {
     try {
@@ -295,20 +289,7 @@ function validateSnapshotsAndAnchors(
       }
     }
 
-    if (errors.length > 0) {
-      const existing = results.find(r => r.file === relPath);
-      if (existing) {
-        existing.valid = false;
-        existing.errors = [...(existing.errors ?? []), ...errors];
-      } else {
-        results.push({
-          file: relPath,
-          schema: "source_snapshot.schema.json",
-          valid: false,
-          errors,
-        });
-      }
-    }
+      mergeErrors(results, relPath, "source_snapshot.schema.json", errors);
   }
 
   for (const file of assertionFiles) {
@@ -363,18 +344,7 @@ function validateSnapshotsAndAnchors(
       }
 
       if (errors.length > 0) {
-        const existing = results.find(r => r.file === relPath);
-        if (existing) {
-          existing.valid = false;
-          existing.errors = [...(existing.errors ?? []), ...errors];
-        } else {
-          results.push({
-            file: relPath,
-            schema: "source_assertion.schema.json",
-            valid: false,
-            errors,
-          });
-        }
+        mergeErrors(results, relPath, "source_assertion.schema.json", errors);
       }
     }
   }
@@ -414,20 +384,7 @@ function validateSnapshotsAndAnchors(
       }
     }
 
-    if (errors.length > 0) {
-      const existing = results.find(r => r.file === relPath);
-      if (existing) {
-        existing.valid = false;
-        existing.errors = [...(existing.errors ?? []), ...errors];
-      } else {
-        results.push({
-          file: relPath,
-          schema: "task_template.schema.json",
-          valid: false,
-          errors,
-        });
-      }
-    }
+      mergeErrors(results, relPath, "task_template.schema.json", errors);
   }
 }
 
@@ -449,9 +406,7 @@ function validateConditionsAndIntake(
     absolute: true,
   });
 
-  function getRel(abs: string): string {
-    return relative(rootDir, abs).split("\\").join("/");
-  }
+  const getRel = (abs: string): string => toPosixRel(abs, rootDir);
 
   const intakeIdToPath = new Map<string, string>();
   const intakePathToId = new Map<string, string>();
@@ -519,20 +474,7 @@ function validateConditionsAndIntake(
       }
     }
 
-    if (errors.length > 0) {
-      const existing = results.find(r => r.file === relPath);
-      if (existing) {
-        existing.valid = false;
-        existing.errors = [...(existing.errors ?? []), ...errors];
-      } else {
-        results.push({
-          file: relPath,
-          schema: "condition.schema.json",
-          valid: false,
-          errors,
-        });
-      }
-    }
+      mergeErrors(results, relPath, "condition.schema.json", errors);
   }
 }
 
@@ -593,13 +535,7 @@ function getNormalizedTextContent(html: string): string {
 
 export async function main(): Promise<void> {
   // Walk up from packages/cli/src/commands/ to find the repo root
-  const rootDir = resolve(
-    import.meta.dirname ?? ".",
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+  const rootDir = resolveRootDir(import.meta.dirname);
 
   const { results, ok } = await runValidate({ rootDir });
 

--- a/packages/cli/src/shared/utils.ts
+++ b/packages/cli/src/shared/utils.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared CLI utilities.
+ *
+ * Consolidates patterns that were duplicated across multiple CLI commands.
+ */
+
+import { resolve, relative } from "node:path";
+
+/**
+ * Convert an absolute path to a POSIX-style relative path from the given root.
+ *
+ * Replaces the `relative(root, abs).split("\\").join("/")` pattern that
+ * was duplicated in every CLI command.
+ */
+export function toPosixRel(abs: string, root: string): string {
+  return relative(root, abs).split("\\").join("/");
+}
+
+/**
+ * Resolve the monorepo root directory from an `import.meta.dirname`
+ * (or `__dirname` fallback) inside `packages/cli/src/commands/`.
+ *
+ * Walks up four directory levels:
+ *   commands/ → src/ → cli/ → packages/ → <root>
+ */
+export function resolveRootDir(metaDirname: string | undefined): string {
+  return resolve(metaDirname ?? ".", "..", "..", "..", "..");
+}
+
+/**
+ * Append errors to a result list, merging into an existing entry if one
+ * already exists for the given file path.
+ *
+ * This replaces the find-and-merge pattern repeated 4× in validate.ts.
+ */
+export function mergeErrors(
+  results: Array<{ file: string; schema: string; valid: boolean; errors?: string[] }>,
+  relPath: string,
+  schema: string,
+  errors: string[],
+): void {
+  if (errors.length === 0) return;
+
+  const existing = results.find((r) => r.file === relPath);
+  if (existing) {
+    existing.valid = false;
+    existing.errors = [...(existing.errors ?? []), ...errors];
+  } else {
+    results.push({
+      file: relPath,
+      schema,
+      valid: false,
+      errors,
+    });
+  }
+}
+
+/**
+ * Get a value from a Map, inserting a new one via `factory()` if the key
+ * is not yet present.
+ *
+ * Replaces the `let x = map.get(k); if (!x) { x = f(); map.set(k, x); }` pattern.
+ */
+export function getOrCreate<K, V>(
+  map: Map<K, V>,
+  key: K,
+  factory: () => V,
+): V {
+  let value = map.get(key);
+  if (value === undefined) {
+    value = factory();
+    map.set(key, value);
+  }
+  return value;
+}

--- a/packages/generator/src/explanation.ts
+++ b/packages/generator/src/explanation.ts
@@ -37,15 +37,12 @@ function triValueToString(value: TriValue): "true" | "false" | "unknown" {
   return "unknown";
 }
 
-/** Build an explanation trace for a checklist item */
-export function buildExplanationTrace(
-  traceId: string,
-  consequenceId: string,
+/** Build condition traces and why_visible messages for the explanation. */
+function buildConditionTraces(
   conditionRefs: string[],
   conditionResults: Map<string, { result: TriValue; missingFacts: string[] }>,
   graph: LoadedGraph,
-  temporalCtx?: TemporalContext,
-): ExplanationTrace {
+): { conditions: ConditionTrace[]; whyVisible: string[] } {
   const conditions: ConditionTrace[] = [];
   const whyVisible: string[] = [];
 
@@ -72,41 +69,61 @@ export function buildExplanationTrace(
     }
   }
 
-  // Gather sources from the consequence
+  return { conditions, whyVisible };
+}
+
+/** Build source traces from a consequence's assertion refs, filtering by temporal context. */
+function buildSourceTraces(
+  consequenceId: string,
+  graph: LoadedGraph,
+  temporalCtx?: TemporalContext,
+): SourceTrace[] {
   const consequence = graph.consequences.get(consequenceId);
-  const sources: SourceTrace[] = [];
+  if (!consequence) return [];
 
-  if (consequence) {
-    // Group assertion refs by their owning source
-    const sourceAssertionMap = new Map<string, string[]>();
+  const sourceAssertionMap = new Map<string, string[]>();
 
-    for (const assertionRef of consequence.source_assertion_refs ?? []) {
-      const ass = graph.assertions?.get(assertionRef);
-      if (ass && temporalCtx && !recordApplies(ass, temporalCtx)) {
-        continue;
-      }
-      // Use the assertion's source_id to find the owning source
-      const sourceId = ass?.source_id;
-      if (sourceId) {
-        const existing = sourceAssertionMap.get(sourceId);
-        if (existing) {
-          existing.push(assertionRef);
-        } else {
-          sourceAssertionMap.set(sourceId, [assertionRef]);
-        }
-      }
+  for (const assertionRef of consequence.source_assertion_refs ?? []) {
+    const ass = graph.assertions?.get(assertionRef);
+    if (ass && temporalCtx && !recordApplies(ass, temporalCtx)) {
+      continue;
     }
-
-    for (const [sourceId, assertionRefs] of sourceAssertionMap) {
-      const source = graph.sources?.get(sourceId);
-      sources.push({
-        source_title: source?.title ?? sourceId,
-        publisher: source?.publisher ?? "Unknown",
-        official_url: source?.url ?? "",
-        assertion_refs: assertionRefs,
-      });
+    const sourceId = ass?.source_id;
+    if (sourceId) {
+      const existing = sourceAssertionMap.get(sourceId);
+      if (existing) {
+        existing.push(assertionRef);
+      } else {
+        sourceAssertionMap.set(sourceId, [assertionRef]);
+      }
     }
   }
+
+  const sources: SourceTrace[] = [];
+  for (const [sourceId, assertionRefs] of sourceAssertionMap) {
+    const source = graph.sources?.get(sourceId);
+    sources.push({
+      source_title: source?.title ?? sourceId,
+      publisher: source?.publisher ?? "Unknown",
+      official_url: source?.url ?? "",
+      assertion_refs: assertionRefs,
+    });
+  }
+
+  return sources;
+}
+
+/** Build an explanation trace for a checklist item */
+export function buildExplanationTrace(
+  traceId: string,
+  consequenceId: string,
+  conditionRefs: string[],
+  conditionResults: Map<string, { result: TriValue; missingFacts: string[] }>,
+  graph: LoadedGraph,
+  temporalCtx?: TemporalContext,
+): ExplanationTrace {
+  const { conditions, whyVisible } = buildConditionTraces(conditionRefs, conditionResults, graph);
+  const sources = buildSourceTraces(consequenceId, graph, temporalCtx);
 
   return {
     id: traceId,

--- a/packages/generator/src/jurisdiction-roles.ts
+++ b/packages/generator/src/jurisdiction-roles.ts
@@ -31,6 +31,23 @@ const ARRAY_ROLE_MAPPING: Record<string, keyof JurisdictionRoles> = {
   "estate.asset_location.country": "asset_situs",
 };
 
+/** Push `value` into `roles[role]` if not already present and not "unknown". */
+function addToRole(roles: JurisdictionRoles, role: keyof JurisdictionRoles, value: string): void {
+  if (value && value !== "unknown" && !roles[role].includes(value)) {
+    roles[role].push(value);
+  }
+}
+
+/** Apply derived defaults: succession law from habitual residence, pension from work state. */
+function applyDerivedDefaults(roles: JurisdictionRoles): void {
+  if (roles.possible_succession_law.length === 0) {
+    roles.possible_succession_law = [...roles.deceased_habitual_residence];
+  }
+  if (roles.possible_pension_authority.length === 0) {
+    roles.possible_pension_authority = [...roles.work_or_insurance_state];
+  }
+}
+
 /** Resolve jurisdiction roles from normalized facts */
 export function resolveJurisdictionRoles(facts: Fact[]): JurisdictionRoles {
   const roles: JurisdictionRoles = {
@@ -48,35 +65,20 @@ export function resolveJurisdictionRoles(facts: Fact[]): JurisdictionRoles {
 
     // Single-value roles
     const singleRole = ROLE_MAPPING[fact.fact_type];
-    if (singleRole && val && val !== "unknown") {
-      if (!roles[singleRole].includes(val)) {
-        roles[singleRole].push(val);
-      }
+    if (singleRole) {
+      addToRole(roles, singleRole, val);
     }
 
     // Array roles (comma-separated)
     const arrayRole = ARRAY_ROLE_MAPPING[fact.fact_type];
     if (arrayRole && val) {
-      const values = val.split(",").map((v: string) => v.trim());
-      for (const v of values) {
-        if (v && v !== "unknown" && !roles[arrayRole].includes(v)) {
-          roles[arrayRole].push(v);
-        }
+      for (const v of val.split(",").map((s: string) => s.trim())) {
+        addToRole(roles, arrayRole, v);
       }
     }
   }
 
-  // Derived roles:
-  // possible_succession_law defaults to habitual residence
-  if (roles.possible_succession_law.length === 0) {
-    roles.possible_succession_law = [...roles.deceased_habitual_residence];
-  }
-
-  // possible_pension_authority comes from work/insurance state
-  if (roles.possible_pension_authority.length === 0) {
-    roles.possible_pension_authority = [...roles.work_or_insurance_state];
-  }
-
+  applyDerivedDefaults(roles);
   return roles;
 }
 

--- a/packages/generator/src/temporal.ts
+++ b/packages/generator/src/temporal.ts
@@ -8,32 +8,28 @@ export interface TemporalContext {
   eventDate: string;
 }
 
+/** Returns true if `fieldValue` is after `referenceDate` (ISO string comparison). */
+function isAfterDate(fieldValue: unknown, referenceDate: string): boolean {
+  if (fieldValue === undefined || fieldValue === null) return false;
+  return String(fieldValue) > referenceDate;
+}
+
+/** Returns true if `fieldValue` is on or before `referenceDate` (ISO string comparison). */
+function isOnOrBeforeDate(fieldValue: unknown, referenceDate: string): boolean {
+  if (fieldValue === undefined || fieldValue === null) return false;
+  return String(fieldValue) <= referenceDate;
+}
+
 export function recordApplies(record: Record<string, unknown>, ctx: TemporalContext): boolean {
   if (!record || typeof record !== "object") return true;
 
   // 1. Record validity check (against asOfDate)
-  if (record.record_valid_from !== undefined && record.record_valid_from !== null) {
-    if (String(record.record_valid_from) > ctx.asOfDate) {
-      return false;
-    }
-  }
-  if (record.record_valid_to !== undefined && record.record_valid_to !== null) {
-    if (String(record.record_valid_to) <= ctx.asOfDate) {
-      return false;
-    }
-  }
+  if (isAfterDate(record.record_valid_from, ctx.asOfDate)) return false;
+  if (isOnOrBeforeDate(record.record_valid_to, ctx.asOfDate)) return false;
 
   // 2. Legal effectiveness check (against eventDate)
-  if (record.legal_effective_from !== undefined && record.legal_effective_from !== null) {
-    if (String(record.legal_effective_from) > ctx.eventDate) {
-      return false;
-    }
-  }
-  if (record.legal_effective_to !== undefined && record.legal_effective_to !== null) {
-    if (String(record.legal_effective_to) <= ctx.eventDate) {
-      return false;
-    }
-  }
+  if (isAfterDate(record.legal_effective_from, ctx.eventDate)) return false;
+  if (isOnOrBeforeDate(record.legal_effective_to, ctx.eventDate)) return false;
 
   return true;
 }


### PR DESCRIPTION
## Summary

Mechanical refactors with no semantic changes. Reduces SonarCloud cognitive complexity for 7 functions below the <=15 threshold.

### New shared utils module
- `toPosixRel` — replaces 8 duplicated copies
- `resolveRootDir` — replaces 10+ copies of 4-level resolve()
- `mergeErrors` — replaces 4 find-and-merge blocks in validate.ts
- `getOrCreate` — replaces Map get-or-create pattern

### Generator refactors
- temporal.ts: extract isAfterDate/isOnOrBeforeDate
- jurisdiction-roles.ts: extract addToRole/applyDerivedDefaults
- explanation.ts: extract buildConditionTraces/buildSourceTraces

### CLI command refactors
- build-checklist.ts: extract parseArgs/printChecklist
- lint-ids.ts: extract countIssuesByLevel/formatFileResult
- export-web.ts: extract collectTransitiveRefs
- check-references.ts: extract loadAndParseFiles
- validate.ts: use shared mergeErrors/toPosixRel/resolveRootDir

## Verification
- pnpm typecheck — passes
- pnpm test — 142/143 pass (1 pre-existing Dropbox EPERM flaky test)
- pnpm lint — passes

Part of 4-PR plan to resolve all 16 SonarCloud cognitive complexity findings.