### PR TITLE
refactor: CLI cognitive complexity — validate + check commands (PR 4b/4)

### DIFF
--- a/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
@@ -1,0 +1,48 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runCheckAnchors characterization > snapshots the full results array for determinism 1`] = `
+[
+  {
+    "assertionId": "assertion.guichet_lu.bereavement.death_must_be_declared",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "declared within 24 hours to the civil registrar's office",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.bereavement.declaration_within_24h",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "within 24 hours",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.bereavement.survivor_pension_available",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "survivor's pension",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.declaration_succession.inheritance_declaration_required",
+    "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.declaration_succession.2026_06_05",
+    "textQuote": "déposée par écrit dans les 6 mois du décès",
+  },
+  {
+    "assertionId": "assertion.service_public_fr.succession.notaire_obligatoire",
+    "file": "sources/assertions/fr/service_public_fr/succession.yml",
+    "found": true,
+    "snapshotId": "snapshot.service_public_fr.succession.2026_06_05",
+    "textQuote": "Le recours à un notaire est-il obligatoire dans le cadre d'une succession",
+  },
+  {
+    "assertionId": "assertion.service_public_fr.succession.option_successorale",
+    "file": "sources/assertions/fr/service_public_fr/succession.yml",
+    "found": true,
+    "snapshotId": "snapshot.service_public_fr.succession.2026_06_05",
+    "textQuote": "Accepter ou renoncer à la succession (option successorale)",
+  },
+]
+`;

--- a/packages/cli/src/commands/__snapshots__/check-contradictions.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/check-contradictions.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runCheckContradictions — characterization > pins scope keys, claim types, and resolved status if contradictions exist 1`] = `[]`;

--- a/packages/cli/src/commands/__snapshots__/check-publication-gate.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/check-publication-gate.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runCheckPublicationGate — characterization > pins violation record IDs, rules, and files if violations exist 1`] = `[]`;
+
+exports[`runCheckPublicationGate — characterization > snapshots the full violations array for determinism 1`] = `[]`;

--- a/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
@@ -1,0 +1,843 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`runValidate characterization against real graph > pins exact error messages for any invalid files 1`] = `[]`;
+
+exports[`runValidate characterization against real graph > pins schema assignments for all validated files 1`] = `
+[
+  {
+    "file": "graph/authorities/be/sfp.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/de/drv.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/de/standesamt.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/eu/ejustice_portal.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/fr/carsat.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/fr/notaire.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/fr/scec.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/acd.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/aed.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/bureau_etat_civil.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/ccss.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/chambre_notaires.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/cnap.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/cns.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/cssf.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/district_court_registry.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/employer.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/medecin_inspecteur_sante.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/ministry_economy_business_permits.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/snca.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/lu/vdl_bierger_center.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/authorities/pt/seguranca_social.yml",
+    "schema": "authority.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/de/death_occurred_in_de.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/de/deceased_was_de_insured.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/fr/assets_in_fr.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/aed_declaration_may_be_required.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/cohabitant_lived_six_months.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/death_occurred_in_lu.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_owned_real_estate.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_owned_vehicle.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_was_lu_health_insured.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_was_lu_insured.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_was_self_employed.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/deceased_was_tenant.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/habitual_residence_lu.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/relationship_eligible_survivor.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/survivor_is_employee.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/lu/survivor_is_spouse_or_partner.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/xborder/cross_border_pension.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/conditions/bereavement/xborder/repatriation_requested.yml",
+    "schema": "condition.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/de/claim_survivor_pension_de.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/de/register_death_de.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/fr/settle_fr_succession.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/arrange_funeral_or_cremation.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/claim_bereavement_leave.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/claim_funeral_allowance.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/claim_survivor_pension.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/decide_accept_or_renounce.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/declare_death.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/engage_notary.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/file_final_income_tax_return.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/file_inheritance_declaration.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/notify_banks_trace_assets.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/notify_ccss_business_matters.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/transfer_vehicle_registration.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/understand_applicable_succession_law.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/lu/understand_housing_rights.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/consequences/bereavement/xborder/coordinate_cross_border_pension.yml",
+    "schema": "consequence.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/bereavement_leave_at_event.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/death_declaration_deadline.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/final_tax_return_31dec.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/funeral_allowance_2y.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/funeral_cremation_72h.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/inventory_3mo.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/notify_ccss_8d.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/notify_ministry_economy_1mo.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/reflection_40d.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/deadlines/bereavement/lu/succession_declaration_6mo.yml",
+    "schema": "deadline.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/eu/european_certificate_succession.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/death_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/identity_document.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/marriage_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/proof_of_payment.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/rib.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/global/school_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/acte_de_notoriete.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/aed_attestation_succession.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/burial_or_cremation_authorisation.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/cnap_survivor_pension_form.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/cremation_intent_proof.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/death_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/funeral_invoice_paid.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/identity_document_deceased.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/livret_de_famille.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/marriage_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/medical_death_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/non_violent_death_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/pacemaker_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/proof_cohabitation.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/succession_declaration.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/tax_return_form_100.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/transfer_agreement_heirs.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/valid_insurance_certificate.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/valid_technical_inspection.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/vehicle_registration_certificate_part1.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/evidence_types/lu/vehicle_registration_certificate_part2.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/forms/lu/model_100.yml",
+    "schema": "form.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/forms/lu/orphan_pension_application.yml",
+    "schema": "form.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/forms/lu/registration_certificate_application.yml",
+    "schema": "form.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/forms/lu/survivor_pension_application.yml",
+    "schema": "form.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/forms/lu/wills_register_search.yml",
+    "schema": "form.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/date_of_death.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/death_datetime.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/deceased_employment_status.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/deceased_habitual_residence.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/deceased_owned_vehicle.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/deceased_pension_jurisdiction.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/deceased_was_tenant.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/estate_asset_country.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/estate_real_estate_exists.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/jurisdiction_of_death.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/marriage_or_partnership_status.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/relationship_to_deceased.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/repatriation_requested.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/survivor_cohabitation_months.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/intake_fact_types/bereavement/survivor_employment_status.yml",
+    "schema": "intake_fact_type.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/de/file_drv_claim.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/de/register_death_standesamt.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/fr/estate_assets/engage_notaire.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/claim_bereavement_leave.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/claim_funeral_allowance.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/decide_accept_renounce.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/engage_notary.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/file_aed_declaration.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/file_cnap_claim.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/file_death_declaration.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/file_final_income_tax_return.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/obtain_medical_death_certificate.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/transfer_vehicle_registration.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/understand_applicable_succession_law.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/lu/understand_housing_rights.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "graph/task_templates/bereavement/xborder/coordinate_pension_institutions.yml",
+    "schema": "task_template.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/assertions/fr/service_public_fr/succession.yml",
+    "schema": "source_assertion.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "schema": "source_assertion.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
+    "schema": "source_assertion.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/guichet_lu_bereavement_2026_06_03.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/service_public_fr_succession_2026_06_05.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+]
+`;
+
+exports[`runValidate characterization against real graph > pins total file count and pass/fail breakdown 1`] = `
+{
+  "invalid": 0,
+  "total": 142,
+  "valid": 142,
+}
+`;
+
+exports[`runValidate characterization against real graph > pins total file count and pass/fail breakdown 2`] = `true`;
+
+exports[`runValidate characterization against real graph > validates condition-intake cross-references exist 1`] = `
+[
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/xborder/repatriation_requested.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/xborder/cross_border_pension.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/survivor_is_spouse_or_partner.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/survivor_is_employee.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/relationship_eligible_survivor.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/habitual_residence_lu.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_was_tenant.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_was_self_employed.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_was_lu_insured.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_was_lu_health_insured.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_owned_vehicle.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/deceased_owned_real_estate.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/death_occurred_in_lu.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/cohabitant_lived_six_months.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/lu/aed_declaration_may_be_required.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/fr/assets_in_fr.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/de/deceased_was_de_insured.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "graph/conditions/bereavement/de/death_occurred_in_de.yml",
+    "valid": true,
+  },
+]
+`;
+
+exports[`runValidate characterization against real graph > validates snapshot integrity checks exist 1`] = `
+[
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/service_public_fr_succession_2026_06_05.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/guichet_lu_bereavement_2026_06_03.yml",
+    "valid": true,
+  },
+]
+`;

--- a/packages/cli/src/commands/check-anchors.test.ts
+++ b/packages/cli/src/commands/check-anchors.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { resolve } from "node:path";
+import { runCheckAnchors } from "./check-anchors.js";
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
+
+describe("runCheckAnchors characterization", () => {
+  let results: Awaited<ReturnType<typeof runCheckAnchors>>["results"];
+  let errors: number;
+
+  // Run once, share across tests
+  beforeAll(async () => {
+    const out = await runCheckAnchors({ rootDir: ROOT_DIR });
+    results = out.results;
+    errors = out.errors;
+  }, 30_000);
+
+  it("pins the total result count", () => {
+    // Will fail on first run — update with actual value
+    expect(results.length).toMatchInlineSnapshot(`6`);
+  });
+
+  it("pins the error count", () => {
+    expect(errors).toMatchInlineSnapshot(`0`);
+  });
+
+  it("pins the found/not-found breakdown", () => {
+    const found = results.filter((r) => r.found).length;
+    const notFound = results.filter((r) => !r.found).length;
+    expect({ found, notFound }).toMatchInlineSnapshot(`
+      {
+        "found": 6,
+        "notFound": 0,
+      }
+    `);
+  });
+
+  it("pins the assertion IDs that were checked", () => {
+    const ids = results.map((r) => r.assertionId).sort();
+    expect(ids).toMatchInlineSnapshot(`
+      [
+        "assertion.guichet_lu.bereavement.death_must_be_declared",
+        "assertion.guichet_lu.bereavement.declaration_within_24h",
+        "assertion.guichet_lu.bereavement.survivor_pension_available",
+        "assertion.guichet_lu.declaration_succession.inheritance_declaration_required",
+        "assertion.service_public_fr.succession.notaire_obligatoire",
+        "assertion.service_public_fr.succession.option_successorale",
+      ]
+    `);
+  });
+
+  it("snapshots the full results array for determinism", () => {
+    // Sort for stability since glob order is not guaranteed
+    const sorted = [...results].sort((a, b) =>
+      a.assertionId.localeCompare(b.assertionId),
+    );
+    expect(sorted).toMatchSnapshot();
+  });
+});

--- a/packages/cli/src/commands/check-anchors.ts
+++ b/packages/cli/src/commands/check-anchors.ts
@@ -59,23 +59,35 @@ export interface CheckAnchorsOptions {
   rootDir: string;
 }
 
-// ── exported runner (tested in isolation) ────────────────────────────
+// ── internal types ───────────────────────────────────────────────────
 
-export async function runCheckAnchors(
-  opts: CheckAnchorsOptions,
-): Promise<{ results: AnchorResult[]; errors: number }> {
-  const { rootDir } = opts;
+interface SnapshotRecord {
+  id: string;
+  archive_uri: string;
+}
 
-  // ── 1. Load snapshot records (NOT from html/) ──────────────────────
+interface AssertionBatch {
+  source_id?: string;
+  source_snapshot_id?: string;
+  assertions?: Array<{
+    id: string;
+    source_snapshot_id?: string;
+    anchor?: {
+      selector_type?: string;
+      text_quote?: string;
+    };
+    [key: string]: unknown;
+  }>;
+}
+
+// ── extracted helpers ────────────────────────────────────────────────
+
+/** Glob + parse snapshot YAML files into a Map keyed by snapshot id. */
+function loadSnapshotRecords(rootDir: string): Map<string, SnapshotRecord> {
   const snapshotFiles = globSync("sources/snapshots/*.{yml,yaml}", {
     cwd: rootDir,
     absolute: true,
   });
-
-  interface SnapshotRecord {
-    id: string;
-    archive_uri: string;
-  }
 
   const snapshots = new Map<string, SnapshotRecord>();
   for (const file of snapshotFiles) {
@@ -89,26 +101,103 @@ export async function runCheckAnchors(
       // Skip unparseable files
     }
   }
+  return snapshots;
+}
+
+/**
+ * Check a single assertion's anchor against its snapshot HTML.
+ * Returns null if the assertion has no text_quote (caller should skip).
+ * Returns an AnchorResult otherwise, and sets `result.found` accordingly.
+ *
+ * When an HTML file is loaded and stripped, it is cached in `htmlCache`
+ * for subsequent lookups.
+ */
+function checkAssertionAnchor(
+  assertion: NonNullable<AssertionBatch["assertions"]>[number],
+  batch: AssertionBatch,
+  snapshots: Map<string, SnapshotRecord>,
+  htmlCache: Map<string, string>,
+  rootDir: string,
+  relPath: string,
+): AnchorResult | null {
+  if (!assertion.anchor?.text_quote) return null;
+
+  const textQuote = assertion.anchor.text_quote;
+  const snapshotId =
+    assertion.source_snapshot_id ?? batch.source_snapshot_id;
+
+  if (!snapshotId) {
+    return {
+      assertionId: assertion.id,
+      file: relPath,
+      textQuote,
+      snapshotId: "(missing)",
+      found: false,
+      error: "No source_snapshot_id found",
+    };
+  }
+
+  const snapshot = snapshots.get(snapshotId);
+  if (!snapshot) {
+    return {
+      assertionId: assertion.id,
+      file: relPath,
+      textQuote,
+      snapshotId,
+      found: false,
+      error: `Snapshot record not found: ${snapshotId}`,
+    };
+  }
+
+  // Get plain text from HTML
+  let plainText = htmlCache.get(snapshotId);
+  if (plainText === undefined) {
+    const htmlPath = resolve(rootDir, snapshot.archive_uri);
+    try {
+      const html = readFileSync(htmlPath, "utf-8");
+      plainText = stripHtmlTags(html);
+      htmlCache.set(snapshotId, plainText);
+    } catch {
+      return {
+        assertionId: assertion.id,
+        file: relPath,
+        textQuote,
+        snapshotId,
+        found: false,
+        error: `Cannot read HTML: ${snapshot.archive_uri}`,
+      };
+    }
+  }
+
+  // Case-insensitive check
+  const found = plainText
+    .toLowerCase()
+    .includes(textQuote.toLowerCase());
+
+  return {
+    assertionId: assertion.id,
+    file: relPath,
+    textQuote,
+    snapshotId,
+    found,
+  };
+}
+
+// ── exported runner (tested in isolation) ────────────────────────────
+
+export async function runCheckAnchors(
+  opts: CheckAnchorsOptions,
+): Promise<{ results: AnchorResult[]; errors: number }> {
+  const { rootDir } = opts;
+
+  // ── 1. Load snapshot records (NOT from html/) ──────────────────────
+  const snapshots = loadSnapshotRecords(rootDir);
 
   // ── 2. Load assertion batch files ──────────────────────────────────
   const assertionFiles = globSync("sources/assertions/**/*.{yml,yaml}", {
     cwd: rootDir,
     absolute: true,
   });
-
-  interface AssertionBatch {
-    source_id?: string;
-    source_snapshot_id?: string;
-    assertions?: Array<{
-      id: string;
-      source_snapshot_id?: string;
-      anchor?: {
-        selector_type?: string;
-        text_quote?: string;
-      };
-      [key: string]: unknown;
-    }>;
-  }
 
   const results: AnchorResult[] = [];
   let errors = 0;
@@ -129,77 +218,18 @@ export async function runCheckAnchors(
     if (!batch?.assertions || !Array.isArray(batch.assertions)) continue;
 
     for (const assertion of batch.assertions) {
-      if (!assertion.anchor?.text_quote) continue;
+      const result = checkAssertionAnchor(
+        assertion,
+        batch,
+        snapshots,
+        htmlCache,
+        rootDir,
+        relPath,
+      );
+      if (!result) continue;
 
-      const textQuote = assertion.anchor.text_quote;
-      const snapshotId =
-        assertion.source_snapshot_id ?? batch.source_snapshot_id;
-
-      if (!snapshotId) {
-        results.push({
-          assertionId: assertion.id,
-          file: relPath,
-          textQuote,
-          snapshotId: "(missing)",
-          found: false,
-          error: "No source_snapshot_id found",
-        });
-        errors++;
-        continue;
-      }
-
-      const snapshot = snapshots.get(snapshotId);
-      if (!snapshot) {
-        results.push({
-          assertionId: assertion.id,
-          file: relPath,
-          textQuote,
-          snapshotId,
-          found: false,
-          error: `Snapshot record not found: ${snapshotId}`,
-        });
-        errors++;
-        continue;
-      }
-
-      // Get plain text from HTML
-      let plainText = htmlCache.get(snapshotId);
-      if (plainText === undefined) {
-        const htmlPath = resolve(rootDir, snapshot.archive_uri);
-        try {
-          const html = readFileSync(htmlPath, "utf-8");
-          plainText = stripHtmlTags(html);
-          htmlCache.set(snapshotId, plainText);
-        } catch {
-          results.push({
-            assertionId: assertion.id,
-            file: relPath,
-            textQuote,
-            snapshotId,
-            found: false,
-            error: `Cannot read HTML: ${snapshot.archive_uri}`,
-          });
-          errors++;
-          continue;
-        }
-      }
-
-      // Case-insensitive check
-      const found = plainText
-        .toLowerCase()
-        .includes(textQuote.toLowerCase());
-
-      results.push({
-        assertionId: assertion.id,
-        file: relPath,
-        textQuote,
-        snapshotId,
-        found,
-      });
-
-      if (!found) {
-        errors++;
-      }
+      results.push(result);
+      if (!result.found) errors++;
     }
   }
 

--- a/packages/cli/src/commands/check-contradictions.test.ts
+++ b/packages/cli/src/commands/check-contradictions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { runCheckContradictions } from "./check-contradictions.js";
+
+/**
+ * Characterization tests for `clarvia check-contradictions`.
+ *
+ * These pin the current behavior of the contradiction checker against
+ * the real graph data so that refactoring cannot silently change results.
+ */
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
+
+describe("runCheckContradictions — characterization", () => {
+  it("returns a result with contradictions array and reportPath", async () => {
+    const result = await runCheckContradictions({ rootDir: ROOT_DIR });
+
+    expect(result).toHaveProperty("contradictions");
+    expect(result).toHaveProperty("reportPath");
+    expect(Array.isArray(result.contradictions)).toBe(true);
+    expect(typeof result.reportPath).toBe("string");
+  });
+
+  it("pins the contradiction count", async () => {
+    const { contradictions } = await runCheckContradictions({
+      rootDir: ROOT_DIR,
+    });
+
+    expect(contradictions.length).toMatchInlineSnapshot(`0`);
+  });
+
+  it("pins the reportPath segments", async () => {
+    const { reportPath } = await runCheckContradictions({ rootDir: ROOT_DIR });
+
+    expect(reportPath).toContain("build");
+    expect(reportPath).toContain("reports");
+    expect(reportPath).toContain("contradictions.yml");
+  });
+
+  it("pins scope keys, claim types, and resolved status if contradictions exist", async () => {
+    const { contradictions } = await runCheckContradictions({
+      rootDir: ROOT_DIR,
+    });
+
+    const summary = contradictions.map((c) => ({
+      scope_key: c.scope_key,
+      claim_type: c.claim_type,
+      resolved: c.resolved,
+    }));
+
+    expect(summary).toMatchSnapshot();
+  });
+
+  it("every contradiction has type direct_value_conflict", async () => {
+    const { contradictions } = await runCheckContradictions({
+      rootDir: ROOT_DIR,
+    });
+
+    for (const c of contradictions) {
+      expect(c.type).toBe("direct_value_conflict");
+    }
+  });
+
+  it("every contradiction has at least two assertions", async () => {
+    const { contradictions } = await runCheckContradictions({
+      rootDir: ROOT_DIR,
+    });
+
+    for (const c of contradictions) {
+      expect(c.assertions.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+});

--- a/packages/cli/src/commands/check-contradictions.ts
+++ b/packages/cli/src/commands/check-contradictions.ts
@@ -36,31 +36,32 @@ export interface CheckContradictionsOptions {
   rootDir: string;
 }
 
-// ── exported runner (tested in isolation) ────────────────────────────
+// ── internal types ───────────────────────────────────────────────────
 
-export async function runCheckContradictions(
-  opts: CheckContradictionsOptions,
-): Promise<{ contradictions: Contradiction[]; reportPath: string }> {
-  const { rootDir } = opts;
+interface LoadedAssertion {
+  id: string;
+  claim_type?: string;
+  claim_text?: string;
+  claim_scope?: {
+    jurisdiction?: string;
+    life_event?: string;
+    domain?: string;
+  };
+  extracted_value?: unknown;
+  [key: string]: unknown;
+}
 
-  // ── 1. Load assertion batch files ──────────────────────────────────
+// ── helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Glob + parse all assertion batch files under sources/assertions/.
+ * Skips unparseable files and assertions without an id.
+ */
+function loadAllAssertions(rootDir: string): LoadedAssertion[] {
   const assertionFiles = globSync("sources/assertions/**/*.{yml,yaml}", {
     cwd: rootDir,
     absolute: true,
   });
-
-  interface LoadedAssertion {
-    id: string;
-    claim_type?: string;
-    claim_text?: string;
-    claim_scope?: {
-      jurisdiction?: string;
-      life_event?: string;
-      domain?: string;
-    };
-    extracted_value?: unknown;
-    [key: string]: unknown;
-  }
 
   const allAssertions: LoadedAssertion[] = [];
 
@@ -82,10 +83,19 @@ export async function runCheckContradictions(
     }
   }
 
-  // ── 2. Group by claim_scope key ────────────────────────────────────
+  return allAssertions;
+}
+
+/**
+ * Group assertions by their claim_scope key: {jurisdiction}.{life_event}.{domain}.
+ * Assertions without a complete claim_scope are skipped.
+ */
+function groupByScopeKey(
+  assertions: LoadedAssertion[],
+): Map<string, LoadedAssertion[]> {
   const scopeGroups = new Map<string, LoadedAssertion[]>();
 
-  for (const ass of allAssertions) {
+  for (const ass of assertions) {
     if (!ass.claim_scope) continue;
     const { jurisdiction, life_event, domain } = ass.claim_scope;
     if (!jurisdiction || !life_event || !domain) continue;
@@ -99,55 +109,86 @@ export async function runCheckContradictions(
     group.push(ass);
   }
 
-  // ── 3. Check for direct_value_conflict ─────────────────────────────
+  return scopeGroups;
+}
+
+/**
+ * Within a scope group, sub-group by claim_type and detect value conflicts.
+ * Returns a Contradiction for each claim_type that has multiple distinct
+ * extracted_value values.
+ */
+function findValueConflicts(
+  scopeKey: string,
+  group: LoadedAssertion[],
+): Contradiction[] {
   const contradictions: Contradiction[] = [];
 
+  // Sub-group by claim_type
+  const byClaimType = new Map<string, LoadedAssertion[]>();
+  for (const ass of group) {
+    if (!ass.claim_type) continue;
+    let sub = byClaimType.get(ass.claim_type);
+    if (!sub) {
+      sub = [];
+      byClaimType.set(ass.claim_type, sub);
+    }
+    sub.push(ass);
+  }
+
+  for (const [claimType, sameType] of byClaimType) {
+    // Only check assertions that have extracted_value
+    const withValue = sameType.filter(
+      (a) => a.extracted_value !== undefined && a.extracted_value !== null,
+    );
+    if (withValue.length < 2) continue;
+
+    // Compare extracted_value — use JSON.stringify for deep comparison
+    const uniqueValues = new Map<string, LoadedAssertion[]>();
+    for (const a of withValue) {
+      const key = JSON.stringify(a.extracted_value);
+      let list = uniqueValues.get(key);
+      if (!list) {
+        list = [];
+        uniqueValues.set(key, list);
+      }
+      list.push(a);
+    }
+
+    if (uniqueValues.size > 1) {
+      contradictions.push({
+        type: "direct_value_conflict",
+        scope_key: scopeKey,
+        claim_type: claimType,
+        assertions: withValue.map((a) => ({
+          id: a.id,
+          extracted_value: a.extracted_value,
+          claim_text: a.claim_text ?? "",
+        })),
+        resolved: false,
+      });
+    }
+  }
+
+  return contradictions;
+}
+
+// ── exported runner (tested in isolation) ────────────────────────────
+
+export async function runCheckContradictions(
+  opts: CheckContradictionsOptions,
+): Promise<{ contradictions: Contradiction[]; reportPath: string }> {
+  const { rootDir } = opts;
+
+  // ── 1. Load assertion batch files ──────────────────────────────────
+  const allAssertions = loadAllAssertions(rootDir);
+
+  // ── 2. Group by claim_scope key ────────────────────────────────────
+  const scopeGroups = groupByScopeKey(allAssertions);
+
+  // ── 3. Check for direct_value_conflict ─────────────────────────────
+  const contradictions: Contradiction[] = [];
   for (const [scopeKey, group] of scopeGroups) {
-    // Sub-group by claim_type
-    const byClaimType = new Map<string, LoadedAssertion[]>();
-    for (const ass of group) {
-      if (!ass.claim_type) continue;
-      let sub = byClaimType.get(ass.claim_type);
-      if (!sub) {
-        sub = [];
-        byClaimType.set(ass.claim_type, sub);
-      }
-      sub.push(ass);
-    }
-
-    for (const [claimType, sameType] of byClaimType) {
-      // Only check assertions that have extracted_value
-      const withValue = sameType.filter(
-        (a) => a.extracted_value !== undefined && a.extracted_value !== null,
-      );
-      if (withValue.length < 2) continue;
-
-      // Compare extracted_value — use JSON.stringify for deep comparison
-      const uniqueValues = new Map<string, LoadedAssertion[]>();
-      for (const a of withValue) {
-        const key = JSON.stringify(a.extracted_value);
-        let list = uniqueValues.get(key);
-        if (!list) {
-          list = [];
-          uniqueValues.set(key, list);
-        }
-        list.push(a);
-      }
-
-      if (uniqueValues.size > 1) {
-        contradictions.push({
-          type: "direct_value_conflict",
-          scope_key: scopeKey,
-          claim_type: claimType,
-          assertions: withValue.map((a) => ({
-            id: a.id,
-            extracted_value: a.extracted_value,
-            claim_text: a.claim_text ?? "",
-          })),
-          resolved: false,
-        });
-      }
-    }
+    contradictions.push(...findValueConflicts(scopeKey, group));
   }
 
   // ── 4. Write report ────────────────────────────────────────────────

--- a/packages/cli/src/commands/check-publication-gate.test.ts
+++ b/packages/cli/src/commands/check-publication-gate.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { runCheckPublicationGate } from "./check-publication-gate.js";
+
+/**
+ * Characterization tests for `clarvia check-publication-gate`.
+ *
+ * These pin the current behavior of the publication gate checker against
+ * the real graph data so that refactoring cannot silently change results.
+ */
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
+
+describe("runCheckPublicationGate — characterization", () => {
+  it("returns a result with violations array", async () => {
+    const result = await runCheckPublicationGate({ rootDir: ROOT_DIR });
+
+    expect(result).toHaveProperty("violations");
+    expect(Array.isArray(result.violations)).toBe(true);
+  });
+
+  it("pins the violation count", async () => {
+    const { violations } = await runCheckPublicationGate({
+      rootDir: ROOT_DIR,
+    });
+
+    expect(violations.length).toMatchInlineSnapshot(`0`);
+  });
+
+  it("pins violation record IDs, rules, and files if violations exist", async () => {
+    const { violations } = await runCheckPublicationGate({
+      rootDir: ROOT_DIR,
+    });
+
+    const summary = violations.map((v) => ({
+      recordId: v.recordId,
+      rule: v.rule,
+      file: v.file,
+    }));
+
+    expect(summary).toMatchSnapshot();
+  });
+
+  it("snapshots the full violations array for determinism", async () => {
+    const { violations } = await runCheckPublicationGate({
+      rootDir: ROOT_DIR,
+    });
+
+    expect(violations).toMatchSnapshot();
+  });
+
+  it("every violation has all required fields", async () => {
+    const { violations } = await runCheckPublicationGate({
+      rootDir: ROOT_DIR,
+    });
+
+    for (const v of violations) {
+      expect(typeof v.recordId).toBe("string");
+      expect(typeof v.file).toBe("string");
+      expect(typeof v.rule).toBe("string");
+      expect(typeof v.detail).toBe("string");
+    }
+  });
+});

--- a/packages/cli/src/commands/check-publication-gate.ts
+++ b/packages/cli/src/commands/check-publication-gate.ts
@@ -40,24 +40,36 @@ export interface CheckPublicationGateOptions {
   rootDir: string;
 }
 
-// ── exported runner (tested in isolation) ────────────────────────────
+// ── module-level interfaces ──────────────────────────────────────────
 
-export async function runCheckPublicationGate(
-  opts: CheckPublicationGateOptions,
-): Promise<{ violations: GateViolation[] }> {
-  const { rootDir } = opts;
+interface LoadedAssertion {
+  id: string;
+  review_status?: string;
+  anchor?: { selector_type?: string; text_quote?: string };
+  source_id?: string;
+  source_snapshot_id?: string;
+  confidence?: unknown;
+  [key: string]: unknown;
+}
 
-  // ── 1. Load assertions (with batch-level inheritance) ──────────────
-  interface LoadedAssertion {
-    id: string;
-    review_status?: string;
-    anchor?: { selector_type?: string; text_quote?: string };
-    source_id?: string;
-    source_snapshot_id?: string;
-    confidence?: unknown;
-    [key: string]: unknown;
-  }
+interface GateRecord {
+  id: string;
+  authoring_status?: string;
+  distribution_status?: string;
+  source_assertion_refs?: string[];
+  [key: string]: unknown;
+}
 
+interface GateFileEntry {
+  relPath: string;
+  record: GateRecord;
+}
+
+// ── extracted helpers ────────────────────────────────────────────────
+
+function loadAssertionsWithInheritance(
+  rootDir: string,
+): Map<string, LoadedAssertion> {
   const assertions = new Map<string, LoadedAssertion>();
   const assertionFiles = globSync("sources/assertions/**/*.{yml,yaml}", {
     cwd: rootDir,
@@ -89,20 +101,10 @@ export async function runCheckPublicationGate(
     }
   }
 
-  // ── 2. Load consequences and task_templates ────────────────────────
-  interface GateRecord {
-    id: string;
-    authoring_status?: string;
-    distribution_status?: string;
-    source_assertion_refs?: string[];
-    [key: string]: unknown;
-  }
+  return assertions;
+}
 
-  interface GateFileEntry {
-    relPath: string;
-    record: GateRecord;
-  }
-
+function loadGateRecords(rootDir: string): GateFileEntry[] {
   const gateRecords: GateFileEntry[] = [];
 
   const patterns = [
@@ -131,13 +133,100 @@ export async function runCheckPublicationGate(
     }
   }
 
-  // ── 3. Check publication gate rules ────────────────────────────────
+  return gateRecords;
+}
+
+function checkAssertionRefs(
+  record: GateRecord,
+  assertions: Map<string, LoadedAssertion>,
+  relPath: string,
+): GateViolation[] {
+  const violations: GateViolation[] = [];
+  const refs = record.source_assertion_refs;
+
+  if (!Array.isArray(refs)) {
+    return violations;
+  }
+
+  for (const ref of refs) {
+    const ass = assertions.get(ref);
+    if (!ass) {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_exists",
+        detail: `Referenced assertion not found: ${ref}`,
+      });
+      continue;
+    }
+
+    // review_status === 'approved'
+    if (ass.review_status !== "approved") {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_review_status",
+        detail: `${ref}: review_status is '${ass.review_status ?? "(missing)"}', expected 'approved'`,
+      });
+    }
+
+    // anchor present
+    if (!ass.anchor) {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_anchor",
+        detail: `${ref}: anchor is missing`,
+      });
+    }
+
+    // source_id present
+    if (!ass.source_id) {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_source_id",
+        detail: `${ref}: source_id is missing`,
+      });
+    }
+
+    // source_snapshot_id present
+    if (!ass.source_snapshot_id) {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_source_snapshot_id",
+        detail: `${ref}: source_snapshot_id is missing`,
+      });
+    }
+
+    // confidence not null/undefined
+    if (ass.confidence == null) {
+      violations.push({
+        recordId: record.id,
+        file: relPath,
+        rule: "assertion_confidence",
+        detail: `${ref}: confidence is null or missing`,
+      });
+    }
+  }
+
+  return violations;
+}
+
+// ── exported runner (tested in isolation) ────────────────────────────
+
+export async function runCheckPublicationGate(
+  opts: CheckPublicationGateOptions,
+): Promise<{ violations: GateViolation[] }> {
+  const { rootDir } = opts;
+
+  const assertions = loadAssertionsWithInheritance(rootDir);
+  const gateRecords = loadGateRecords(rootDir);
+
   const violations: GateViolation[] = [];
 
   for (const { relPath, record } of gateRecords) {
-    // The publication gate only applies to records destined for public
-    // distribution. Records with other statuses are intentionally not
-    // publishable and do not need to pass the gate.
     if (record.distribution_status !== "public_open") {
       continue;
     }
@@ -164,70 +253,7 @@ export async function runCheckPublicationGate(
     }
 
     // Rules on each referenced assertion
-    if (Array.isArray(refs)) {
-      for (const ref of refs) {
-        const ass = assertions.get(ref);
-        if (!ass) {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_exists",
-            detail: `Referenced assertion not found: ${ref}`,
-          });
-          continue;
-        }
-
-        // review_status === 'approved'
-        if (ass.review_status !== "approved") {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_review_status",
-            detail: `${ref}: review_status is '${ass.review_status ?? "(missing)"}', expected 'approved'`,
-          });
-        }
-
-        // anchor present
-        if (!ass.anchor) {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_anchor",
-            detail: `${ref}: anchor is missing`,
-          });
-        }
-
-        // source_id present
-        if (!ass.source_id) {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_source_id",
-            detail: `${ref}: source_id is missing`,
-          });
-        }
-
-        // source_snapshot_id present
-        if (!ass.source_snapshot_id) {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_source_snapshot_id",
-            detail: `${ref}: source_snapshot_id is missing`,
-          });
-        }
-
-        // confidence not null/undefined
-        if (ass.confidence == null) {
-          violations.push({
-            recordId: record.id,
-            file: relPath,
-            rule: "assertion_confidence",
-            detail: `${ref}: confidence is null or missing`,
-          });
-        }
-      }
-    }
+    violations.push(...checkAssertionRefs(record, assertions, relPath));
   }
 
   return { violations };

--- a/packages/cli/src/commands/validate.characterization.test.ts
+++ b/packages/cli/src/commands/validate.characterization.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Characterization tests for validate.ts — extended.
+ *
+ * These pin the EXACT current behavior of runValidate against the
+ * real graph. They supplement the existing validate.test.ts unit tests.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { runValidate } from "./validate.js";
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
+
+describe("runValidate characterization against real graph", () => {
+  it("pins total file count and pass/fail breakdown", async () => {
+    const { results, ok } = await runValidate({ rootDir: ROOT_DIR });
+
+    expect(results.length).toBeGreaterThan(0);
+
+    const validCount = results.filter((r) => r.valid).length;
+    const invalidCount = results.filter((r) => !r.valid).length;
+
+    // Pin the counts
+    expect({ total: results.length, valid: validCount, invalid: invalidCount }).toMatchSnapshot();
+    expect(ok).toMatchSnapshot();
+  });
+
+  it("pins schema assignments for all validated files", async () => {
+    const { results } = await runValidate({ rootDir: ROOT_DIR });
+
+    // Pin the file → schema mapping (sorted for determinism)
+    const fileSchemaMap = results
+      .map((r) => ({ file: r.file, schema: r.schema, valid: r.valid }))
+      .sort((a, b) => a.file.localeCompare(b.file));
+
+    expect(fileSchemaMap).toMatchSnapshot();
+  });
+
+  it("pins exact error messages for any invalid files", async () => {
+    const { results } = await runValidate({ rootDir: ROOT_DIR });
+
+    const invalid = results
+      .filter((r) => !r.valid)
+      .map((r) => ({
+        file: r.file,
+        schema: r.schema,
+        errors: r.errors,
+      }))
+      .sort((a, b) => a.file.localeCompare(b.file));
+
+    expect(invalid).toMatchSnapshot();
+  });
+
+  it("validates snapshot integrity checks exist", async () => {
+    const { results } = await runValidate({ rootDir: ROOT_DIR });
+
+    // Snapshot files should be validated
+    const snapshotResults = results.filter((r) =>
+      r.file.startsWith("sources/snapshots/"),
+    );
+    expect(snapshotResults.length).toBeGreaterThan(0);
+
+    // Pin snapshot validation results
+    const snapshotSummary = snapshotResults.map((r) => ({
+      file: r.file,
+      valid: r.valid,
+      errorCount: r.errors?.length ?? 0,
+    }));
+    expect(snapshotSummary).toMatchSnapshot();
+  });
+
+  it("validates condition-intake cross-references exist", async () => {
+    const { results } = await runValidate({ rootDir: ROOT_DIR });
+
+    // Condition files should be validated
+    const conditionResults = results.filter((r) =>
+      r.file.startsWith("graph/conditions/"),
+    );
+    expect(conditionResults.length).toBeGreaterThan(0);
+
+    // Pin condition validation results
+    const conditionSummary = conditionResults.map((r) => ({
+      file: r.file,
+      valid: r.valid,
+      errorCount: r.errors?.length ?? 0,
+    }));
+    expect(conditionSummary).toMatchSnapshot();
+  });
+});

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -211,7 +211,184 @@ export async function runValidate(
   return { results, ok };
 }
 
-// ── Snapshot and Anchor validation helper ────────────────────────────
+// ── Snapshot map type ────────────────────────────────────────────────
+
+interface SnapshotEntry {
+  data: Record<string, unknown>;
+  file: string;
+}
+
+// ── Snapshot integrity validation ────────────────────────────────────
+
+function validateSnapshotIntegrity(
+  data: Record<string, unknown>,
+  rootDir: string,
+): string[] {
+  const errors: string[] = [];
+
+  if (data.http_status === undefined || data.http_status === null) {
+    errors.push("Missing required field: http_status");
+  }
+
+  const contentHash = data.content_hash;
+  if (typeof contentHash !== "string") {
+    errors.push("Field content_hash must be a string");
+  } else if (contentHash === "pending_capture" || contentHash.startsWith("pending_")) {
+    errors.push(`Field content_hash has pending value: "${contentHash}"`);
+  } else if (!contentHash.startsWith("sha256:")) {
+    errors.push(`Field content_hash must start with "sha256:", got "${contentHash}"`);
+  } else {
+    errors.push(...validateArchiveHash(data, contentHash, rootDir));
+  }
+
+  return errors;
+}
+
+/** Validate archive file hash against content_hash. */
+function validateArchiveHash(
+  data: Record<string, unknown>,
+  contentHash: string,
+  rootDir: string,
+): string[] {
+  const errors: string[] = [];
+  const archiveUri = data.archive_uri;
+
+  if (typeof archiveUri !== "string") {
+    errors.push("Field archive_uri must be a string");
+    return errors;
+  }
+
+  const archivePath = resolve(rootDir, archiveUri);
+  if (!existsSync(archivePath)) {
+    errors.push(`Archive file does not exist at path: ${archiveUri}`);
+    return errors;
+  }
+
+  try {
+    const expectedHash = contentHash.substring(7).toLowerCase();
+    let fileBytes = readFileSync(archivePath);
+    // Clarvia convention: text archive content_hash values are computed
+    // over LF-normalized UTF-8 content. Binary archive hashes use raw bytes.
+    // See docs/CONVENTIONS.md.
+    const isTextArchive = archivePath.endsWith(".html") || archivePath.endsWith(".txt");
+    if (isTextArchive) {
+      fileBytes = Buffer.from(fileBytes.toString("utf-8").replace(/\r\n/g, "\n"));
+    }
+    const actualHash = createHash("sha256").update(fileBytes).digest("hex").toLowerCase();
+    if (actualHash !== expectedHash) {
+      const method = isTextArchive ? " using Clarvia LF-normalized text hashing" : "";
+      errors.push(`Hash mismatch for archive file. Expected sha256:${expectedHash}, computed sha256:${actualHash}${method}`);
+    }
+  } catch (err: unknown) {
+    errors.push(`Error reading archive file: ${(err as Error).message}`);
+  }
+
+  return errors;
+}
+
+// ── Assertion anchor validation ──────────────────────────────────────
+
+function validateAssertionAnchors(
+  file: string,
+  snapshotMap: Map<string, SnapshotEntry>,
+  rootDir: string,
+): { relPath: string; errors: string[] } | null {
+  const getRel = (abs: string): string => toPosixRel(abs, rootDir);
+  const relPath = getRel(file);
+
+  let rawData: Record<string, unknown> | null;
+  try {
+    rawData = parseYaml(readFileSync(file, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (!rawData || typeof rawData !== "object") return null;
+
+  const snapshotId = rawData.source_snapshot_id;
+  if (typeof snapshotId !== "string") return null;
+
+  const snapshotEntry = snapshotMap.get(snapshotId);
+  if (!snapshotEntry) return null;
+
+  const { data: snapshotData } = snapshotEntry;
+  const archiveUri = snapshotData.archive_uri;
+  if (typeof archiveUri !== "string") return null;
+
+  const archivePath = resolve(rootDir, archiveUri);
+  if (!existsSync(archivePath)) return null;
+
+  let archiveContent: string;
+  try {
+    archiveContent = readFileSync(archivePath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  const normalizedHtmlText = getNormalizedTextContent(archiveContent);
+  const assertions = rawData.assertions;
+  if (!Array.isArray(assertions)) return null;
+
+  const errors: string[] = [];
+  for (const assertion of assertions) {
+    if (!assertion || typeof assertion !== "object") continue;
+    const anchor = assertion.anchor;
+    if (anchor && typeof anchor === "object" && anchor.selector_type === "text_quote") {
+      const textQuote = anchor.text_quote;
+      if (typeof textQuote === "string") {
+        const normalizedQuote = normalizeText(textQuote);
+        if (!normalizedHtmlText.includes(normalizedQuote)) {
+          errors.push(
+            `Assertion "${assertion.id}" anchor text_quote "${textQuote}" not found in snapshot archive "${archiveUri}"`
+          );
+        }
+      }
+    }
+  }
+
+  return errors.length > 0 ? { relPath, errors } : null;
+}
+
+// ── Template provenance validation ───────────────────────────────────
+
+function validateTemplateProvenance(
+  file: string,
+  snapshotMap: Map<string, SnapshotEntry>,
+  rootDir: string,
+): { relPath: string; errors: string[] } | null {
+  const relPath = toPosixRel(file, rootDir);
+
+  let data: Record<string, unknown> | null;
+  try {
+    data = parseYaml(readFileSync(file, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (!data || typeof data !== "object") return null;
+
+  const errors: string[] = [];
+
+  if (data.distribution_status === "public_open" && data.authoring_status === "approved") {
+    if (!data.provenance) {
+      errors.push("Public and approved task template requires a provenance block");
+    }
+  }
+
+  if (data.provenance && typeof data.provenance === "object") {
+    const prov = data.provenance as Record<string, unknown>;
+    const ref = prov.derived_from_snapshot_ref;
+    if (typeof ref !== "string") {
+      errors.push("Field provenance.derived_from_snapshot_ref must be a string");
+    } else if (!snapshotMap.has(ref)) {
+      errors.push(`provenance.derived_from_snapshot_ref "${ref}" does not resolve to an existing source snapshot`);
+    }
+  }
+
+  return errors.length > 0 ? { relPath, errors } : null;
+}
+
+// ── Snapshot and Anchor validation orchestrator ──────────────────────
 
 function validateSnapshotsAndAnchors(
   rootDir: string,
@@ -227,7 +404,7 @@ function validateSnapshotsAndAnchors(
     absolute: true,
   });
 
-  const snapshotMap = new Map<string, { data: Record<string, unknown>; file: string }>();
+  const snapshotMap = new Map<string, SnapshotEntry>();
 
   const getRel = (abs: string): string => toPosixRel(abs, rootDir);
 
@@ -243,109 +420,18 @@ function validateSnapshotsAndAnchors(
     }
   }
 
+  // 1. Validate snapshot integrity
   for (const [, { data, file }] of snapshotMap.entries()) {
     const relPath = getRel(file);
-    const errors: string[] = [];
-
-    if (data.http_status === undefined || data.http_status === null) {
-      errors.push("Missing required field: http_status");
-    }
-
-    const contentHash = data.content_hash;
-    if (typeof contentHash !== "string") {
-      errors.push("Field content_hash must be a string");
-    } else if (contentHash === "pending_capture" || contentHash.startsWith("pending_")) {
-      errors.push(`Field content_hash has pending value: "${contentHash}"`);
-    } else if (!contentHash.startsWith("sha256:")) {
-      errors.push(`Field content_hash must start with "sha256:", got "${contentHash}"`);
-    } else {
-      const archiveUri = data.archive_uri;
-      if (typeof archiveUri !== "string") {
-        errors.push("Field archive_uri must be a string");
-      } else {
-        const archivePath = resolve(rootDir, archiveUri);
-        if (!existsSync(archivePath)) {
-          errors.push(`Archive file does not exist at path: ${archiveUri}`);
-        } else {
-          try {
-            const expectedHash = contentHash.substring(7).toLowerCase();
-            let fileBytes = readFileSync(archivePath);
-            // Clarvia convention: text archive content_hash values are computed
-            // over LF-normalized UTF-8 content. Binary archive hashes use raw bytes.
-            // See docs/CONVENTIONS.md.
-            const isTextArchive = archivePath.endsWith(".html") || archivePath.endsWith(".txt");
-            if (isTextArchive) {
-              fileBytes = Buffer.from(fileBytes.toString("utf-8").replace(/\r\n/g, "\n"));
-            }
-            const actualHash = createHash("sha256").update(fileBytes).digest("hex").toLowerCase();
-            if (actualHash !== expectedHash) {
-              const method = isTextArchive ? " using Clarvia LF-normalized text hashing" : "";
-              errors.push(`Hash mismatch for archive file. Expected sha256:${expectedHash}, computed sha256:${actualHash}${method}`);
-            }
-          } catch (err: unknown) {
-            errors.push(`Error reading archive file: ${(err as Error).message}`);
-          }
-        }
-      }
-    }
-
-      mergeErrors(results, relPath, "source_snapshot.schema.json", errors);
+    const errors = validateSnapshotIntegrity(data, rootDir);
+    mergeErrors(results, relPath, "source_snapshot.schema.json", errors);
   }
 
+  // 2. Validate assertion anchors
   for (const file of assertionFiles) {
-    const relPath = getRel(file);
-    let rawData: Record<string, unknown> | null;
-    try {
-      rawData = parseYaml(readFileSync(file, "utf-8")) as Record<string, unknown>;
-    } catch {
-      continue;
-    }
-
-    if (!rawData || typeof rawData !== "object") continue;
-
-    const snapshotId = rawData.source_snapshot_id;
-    if (typeof snapshotId !== "string") continue;
-
-    const snapshotEntry = snapshotMap.get(snapshotId);
-    if (!snapshotEntry) continue;
-
-    const { data: snapshotData } = snapshotEntry;
-    const archiveUri = snapshotData.archive_uri;
-    if (typeof archiveUri !== "string") continue;
-
-    const archivePath = resolve(rootDir, archiveUri);
-    if (!existsSync(archivePath)) continue;
-
-    let archiveContent: string;
-    try {
-      archiveContent = readFileSync(archivePath, "utf-8");
-    } catch {
-      continue;
-    }
-
-    const normalizedHtmlText = getNormalizedTextContent(archiveContent);
-    const assertions = rawData.assertions;
-    if (Array.isArray(assertions)) {
-      const errors: string[] = [];
-      for (const assertion of assertions) {
-        if (!assertion || typeof assertion !== "object") continue;
-        const anchor = assertion.anchor;
-        if (anchor && typeof anchor === "object" && anchor.selector_type === "text_quote") {
-          const textQuote = anchor.text_quote;
-          if (typeof textQuote === "string") {
-            const normalizedQuote = normalizeText(textQuote);
-            if (!normalizedHtmlText.includes(normalizedQuote)) {
-              errors.push(
-                `Assertion "${assertion.id}" anchor text_quote "${textQuote}" not found in snapshot archive "${archiveUri}"`
-              );
-            }
-          }
-        }
-      }
-
-      if (errors.length > 0) {
-        mergeErrors(results, relPath, "source_assertion.schema.json", errors);
-      }
+    const result = validateAssertionAnchors(file, snapshotMap, rootDir);
+    if (result) {
+      mergeErrors(results, result.relPath, "source_assertion.schema.json", result.errors);
     }
   }
 
@@ -356,41 +442,74 @@ function validateSnapshotsAndAnchors(
   });
 
   for (const file of templateFiles) {
-    const relPath = getRel(file);
-    let data: Record<string, unknown> | null;
-    try {
-      data = parseYaml(readFileSync(file, "utf-8")) as Record<string, unknown>;
-    } catch {
-      continue;
+    const result = validateTemplateProvenance(file, snapshotMap, rootDir);
+    if (result) {
+      mergeErrors(results, result.relPath, "task_template.schema.json", result.errors);
     }
-
-    if (!data || typeof data !== "object") continue;
-
-    const errors: string[] = [];
-
-    if (data.distribution_status === "public_open" && data.authoring_status === "approved") {
-      if (!data.provenance) {
-        errors.push("Public and approved task template requires a provenance block");
-      }
-    }
-
-    if (data.provenance && typeof data.provenance === "object") {
-      const prov = data.provenance as Record<string, unknown>;
-      const ref = prov.derived_from_snapshot_ref;
-      if (typeof ref !== "string") {
-        errors.push("Field provenance.derived_from_snapshot_ref must be a string");
-      } else if (!snapshotMap.has(ref)) {
-        errors.push(`provenance.derived_from_snapshot_ref "${ref}" does not resolve to an existing source snapshot`);
-      }
-    }
-
-      mergeErrors(results, relPath, "task_template.schema.json", errors);
   }
 }
+
+// ── Condition var path validation ────────────────────────────────────
 
 const NON_INTAKE_CONDITION_VARS = new Set<string>([
   // Allowlist for internal or system variables
 ]);
+
+/** Check condition var paths against intake fact types. */
+function checkConditionVarPaths(
+  varPaths: string[],
+  intakePathToId: Map<string, string>,
+): string[] {
+  const errors: string[] = [];
+  for (const varPath of varPaths) {
+    if (NON_INTAKE_CONDITION_VARS.has(varPath)) continue;
+    if (!intakePathToId.has(varPath)) {
+      errors.push(`Condition references var path "${varPath}" which is not defined in any intake fact type.`);
+    }
+  }
+  return errors;
+}
+
+/** Check concept refs resolve to intake fact types and cover var paths. */
+function checkConceptRefs(
+  conceptRefs: unknown,
+  intakeIdToPath: Map<string, string>,
+  varPaths: string[],
+  intakePathToId: Map<string, string>,
+): string[] {
+  const errors: string[] = [];
+  const referencedPaths = new Set<string>();
+
+  if (conceptRefs && Array.isArray(conceptRefs)) {
+    for (const ref of conceptRefs) {
+      if (typeof ref !== "string") continue;
+
+      const path = intakeIdToPath.get(ref);
+      if (!path) {
+        errors.push(`information_concept_ref "${ref}" does not resolve to any defined intake fact type.`);
+      } else {
+        referencedPaths.add(path);
+      }
+    }
+  } else if (conceptRefs !== undefined) {
+    errors.push("Field information_concept_refs must be an array");
+  }
+
+  for (const varPath of varPaths) {
+    if (NON_INTAKE_CONDITION_VARS.has(varPath)) continue;
+
+    if (!referencedPaths.has(varPath) && intakePathToId.has(varPath)) {
+      const matchingId = intakePathToId.get(varPath);
+      errors.push(
+        `Condition references var path "${varPath}" but does not reference its intake fact type ID "${matchingId}" in information_concept_refs.`
+      );
+    }
+  }
+
+  return errors;
+}
+
+// ── Condition-intake validation orchestrator ─────────────────────────
 
 function validateConditionsAndIntake(
   rootDir: string,
@@ -434,47 +553,13 @@ function validateConditionsAndIntake(
 
     if (!data || typeof data !== "object") continue;
 
-    const errors: string[] = [];
     const varPaths = extractVarPathsFromExpression(data.expression);
+    const errors: string[] = [];
 
-    for (const varPath of varPaths) {
-      if (NON_INTAKE_CONDITION_VARS.has(varPath)) continue;
+    errors.push(...checkConditionVarPaths(varPaths, intakePathToId));
+    errors.push(...checkConceptRefs(data.information_concept_refs, intakeIdToPath, varPaths, intakePathToId));
 
-      if (!intakePathToId.has(varPath)) {
-        errors.push(`Condition references var path "${varPath}" which is not defined in any intake fact type.`);
-      }
-    }
-
-    const conceptRefs = data.information_concept_refs;
-    const referencedPaths = new Set<string>();
-
-    if (conceptRefs && Array.isArray(conceptRefs)) {
-      for (const ref of conceptRefs) {
-        if (typeof ref !== "string") continue;
-
-        const path = intakeIdToPath.get(ref);
-        if (!path) {
-          errors.push(`information_concept_ref "${ref}" does not resolve to any defined intake fact type.`);
-        } else {
-          referencedPaths.add(path);
-        }
-      }
-    } else if (conceptRefs !== undefined) {
-      errors.push("Field information_concept_refs must be an array");
-    }
-
-    for (const varPath of varPaths) {
-      if (NON_INTAKE_CONDITION_VARS.has(varPath)) continue;
-
-      if (!referencedPaths.has(varPath) && intakePathToId.has(varPath)) {
-        const matchingId = intakePathToId.get(varPath);
-        errors.push(
-          `Condition references var path "${varPath}" but does not reference its intake fact type ID "${matchingId}" in information_concept_refs.`
-        );
-      }
-    }
-
-      mergeErrors(results, relPath, "condition.schema.json", errors);
+    mergeErrors(results, relPath, "condition.schema.json", errors);
   }
 }
 
@@ -505,7 +590,7 @@ function normalizeText(text: string): string {
 }
 
 function getNormalizedTextContent(html: string): string {
-  // Loop to handle crafted/nested comment markers like <!-<!-- -->->
+  // Loop to handle crafted/nested comment markers like <!--<!- --> -->
   let text = html;
   let prev: string;
   do {
@@ -562,4 +647,3 @@ export async function main(): Promise<void> {
   );
   process.exit(ok ? 0 : 1);
 }
-


### PR DESCRIPTION
## PR 4b — validate.ts + check-publication-gate.ts + check-anchors.ts + check-contradictions.ts

### What
Reduces cognitive complexity in 4 CLI validation commands by extracting helpers. No behavior changes.

### Approach: characterization tests first, then refactor

#### Commit 1: Characterization tests (21 tests, 10 snapshots)

**validate.characterization.test.ts** (5 tests):
- File count and pass/fail breakdown against real graph
- Schema assignments for all validated files
- Exact error messages for invalid files
- Snapshot integrity validation results
- Condition-intake cross-reference results

**check-anchors.test.ts** (5 tests):
- Total results, error count, found/not-found breakdown
- Assertion IDs checked (6)
- Full results array snapshot

**check-contradictions.test.ts** (6 tests):
- Contradiction count, scope keys, claim types
- Report path structure, resolved status
- Type invariants

**check-publication-gate.test.ts** (5 tests):
- Violation count, record IDs, rules, files
- Full violations array snapshot
- Field presence invariants

#### Commit 2: Refactoring (only the 4 target .ts files changed)

**validate.ts** — 6 extracted helpers:
- \\alidateSnapshotIntegrity()\\ — hash/status/content_hash checks
- \\alidateArchiveHash()\\ — archive file hash validation
- \\alidateAssertionAnchors()\\ — per-file anchor text matching
- \\alidateTemplateProvenance()\\ — provenance block checks
- \\checkConditionVarPaths()\\ — var path → intake check
- \\checkConceptRefs()\\ — concept ref resolution + cross-check

**check-publication-gate.ts** (~61 → ~8) — 3 extracted helpers:
- \\loadAssertionsWithInheritance()\\ — glob + parse + batch inheritance
- \\loadGateRecords()\\ — load consequences + task_templates
- \\checkAssertionRefs()\\ — 5-rule assertion check loop

**check-anchors.ts** (~32 → ~8) — 2 extracted helpers:
- \\loadSnapshotRecords()\\ — glob + parse snapshot YAMLs
- \\checkAssertionAnchor()\\ — per-assertion anchor checking

**check-contradictions.ts** (~44 → ~8) — 3 extracted helpers:
- \\loadAllAssertions()\\ — glob + parse assertion files
- \\groupByScopeKey()\\ — scope key grouping
- \\indValueConflicts()\\ — claim type comparison

### Verification
- 231/232 tests pass (1 pre-existing EPERM)
- 0 snapshot updates in Commit 2
- Only the 4 target .ts files modified in Commit 2
- No helpers centralized across commands
- pnpm typecheck, pnpm lint all clean

Part of: #96 (SonarCloud cognitive complexity reduction)