### PR TITLE
test: coverage quick wins — export-json + shared utils

### DIFF
--- a/packages/cli/src/commands/export-json.test.ts
+++ b/packages/cli/src/commands/export-json.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { runExportJson } from "./export-json.js";
+
+const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
+
+describe("export-json: runExportJson", () => {
+  const outDir = resolve(ROOT_DIR, "build", "exports", "json");
+  const outPath = resolve(outDir, "graph-export.json");
+
+  it("exports graph as JSON with correct structure", () => {
+    const result = runExportJson(ROOT_DIR);
+
+    expect(result.outPath).toBe(outPath);
+    expect(result.stats.total).toBeGreaterThan(0);
+    expect(result.stats.consequences).toBeGreaterThanOrEqual(0);
+    expect(result.stats.task_templates).toBeGreaterThanOrEqual(0);
+    expect(result.stats.conditions).toBeGreaterThanOrEqual(0);
+    expect(result.stats.deadlines).toBeGreaterThanOrEqual(0);
+    expect(result.stats.authorities).toBeGreaterThanOrEqual(0);
+    expect(result.stats.evidence_types).toBeGreaterThanOrEqual(0);
+    expect(result.stats.intake_fact_types).toBeGreaterThanOrEqual(0);
+    expect(result.stats.total).toBe(
+      result.stats.consequences +
+        result.stats.task_templates +
+        result.stats.conditions +
+        result.stats.deadlines +
+        result.stats.authorities +
+        result.stats.evidence_types +
+        result.stats.intake_fact_types,
+    );
+  });
+
+  it("writes valid JSON file to disk", () => {
+    runExportJson(ROOT_DIR);
+    expect(existsSync(outPath)).toBe(true);
+
+    const content = JSON.parse(readFileSync(outPath, "utf-8"));
+    expect(content.$schema).toBe("clarvia-graph-export/v0.1");
+    expect(content.version).toBeDefined();
+    expect(content.exported_at).toBeDefined();
+    expect(Array.isArray(content.consequences)).toBe(true);
+    expect(Array.isArray(content.task_templates)).toBe(true);
+    expect(Array.isArray(content.conditions)).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/export-json.ts
+++ b/packages/cli/src/commands/export-json.ts
@@ -1,53 +1,60 @@
 /**
  * clarvia export-json — Export the complete graph as a single JSON file.
  *
- * Outputs to .clarvia-output/graph-export.json
+ * Outputs to build/exports/json/graph-export.json
  * Contains all records organized by type, plus metadata.
  */
 
 import { resolve } from "node:path";
 import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { loadGraph } from "@clarvia/generator";
+import { resolveRootDir } from "../shared/utils.js";
 
-export async function main(): Promise<void> {
-  const rootDir = resolve(
-    import.meta.dirname ?? __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-  );
+export interface ExportResult {
+  outPath: string;
+  stats: {
+    consequences: number;
+    task_templates: number;
+    conditions: number;
+    deadlines: number;
+    authorities: number;
+    evidence_types: number;
+    intake_fact_types: number;
+    total: number;
+  };
+}
 
-  console.log(`Loading graph from ${rootDir}...`);
+export function runExportJson(rootDir: string): ExportResult {
   const graph = loadGraph(rootDir);
 
-  // Read package.json for version
   const pkgRaw = readFileSync(resolve(rootDir, "package.json"), "utf-8");
   const pkg = JSON.parse(pkgRaw) as { version: string };
 
   const mapToArray = <T>(m: Map<string, T>): T[] => [...m.values()];
 
+  const stats = {
+    consequences: graph.consequences.size,
+    task_templates: graph.taskTemplates.size,
+    conditions: graph.conditions.size,
+    deadlines: graph.deadlines.size,
+    authorities: graph.authorities.size,
+    evidence_types: graph.evidenceTypes.size,
+    intake_fact_types: graph.intakeFactTypes.size,
+    total:
+      graph.consequences.size +
+      graph.taskTemplates.size +
+      graph.conditions.size +
+      graph.deadlines.size +
+      graph.authorities.size +
+      graph.evidenceTypes.size +
+      graph.intakeFactTypes.size,
+  };
+
   const exportData = {
     $schema: "clarvia-graph-export/v0.1",
     version: pkg.version,
     exported_at: new Date().toISOString(),
-    stats: {
-      consequences: graph.consequences.size,
-      task_templates: graph.taskTemplates.size,
-      conditions: graph.conditions.size,
-      deadlines: graph.deadlines.size,
-      authorities: graph.authorities.size,
-      evidence_types: graph.evidenceTypes.size,
-      intake_fact_types: graph.intakeFactTypes.size,
-      total:
-        graph.consequences.size +
-        graph.taskTemplates.size +
-        graph.conditions.size +
-        graph.deadlines.size +
-        graph.authorities.size +
-        graph.evidenceTypes.size +
-        graph.intakeFactTypes.size,
-    },
+    stats,
     consequences: mapToArray(graph.consequences),
     task_templates: mapToArray(graph.taskTemplates),
     conditions: mapToArray(graph.conditions),
@@ -63,13 +70,22 @@ export async function main(): Promise<void> {
   const outPath = resolve(outDir, "graph-export.json");
   writeFileSync(outPath, JSON.stringify(exportData, null, 2));
 
-  console.log(`\nExported ${exportData.stats.total} records:`);
-  console.log(`  ${exportData.stats.consequences} consequences`);
-  console.log(`  ${exportData.stats.task_templates} task templates`);
-  console.log(`  ${exportData.stats.conditions} conditions`);
-  console.log(`  ${exportData.stats.deadlines} deadlines`);
-  console.log(`  ${exportData.stats.authorities} authorities`);
-  console.log(`  ${exportData.stats.evidence_types} evidence types`);
-  console.log(`  ${exportData.stats.intake_fact_types} intake fact types`);
+  return { outPath, stats };
+}
+
+export async function main(): Promise<void> {
+  const rootDir = resolveRootDir(import.meta.dirname ?? __dirname);
+
+  console.log(`Loading graph from ${rootDir}...`);
+  const { outPath, stats } = runExportJson(rootDir);
+
+  console.log(`\nExported ${stats.total} records:`);
+  console.log(`  ${stats.consequences} consequences`);
+  console.log(`  ${stats.task_templates} task templates`);
+  console.log(`  ${stats.conditions} conditions`);
+  console.log(`  ${stats.deadlines} deadlines`);
+  console.log(`  ${stats.authorities} authorities`);
+  console.log(`  ${stats.evidence_types} evidence types`);
+  console.log(`  ${stats.intake_fact_types} intake fact types`);
   console.log(`\nSaved to: ${outPath}`);
 }

--- a/packages/cli/src/shared/utils.test.ts
+++ b/packages/cli/src/shared/utils.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { toPosixRel, resolveRootDir, mergeErrors, getOrCreate } from "./utils.js";
+import { resolve } from "node:path";
+
+describe("toPosixRel", () => {
+  it("converts absolute path to posix-style relative path", () => {
+    const root = resolve("/project/root");
+    const abs = resolve("/project/root/src/file.ts");
+    expect(toPosixRel(abs, root)).toBe("src/file.ts");
+  });
+});
+
+describe("resolveRootDir", () => {
+  it("resolves four levels up from the given directory", () => {
+    const dir = resolve("/project/packages/cli/src/commands");
+    const result = resolveRootDir(dir);
+    expect(result).toBe(resolve("/project"));
+  });
+
+  it("falls back to current directory when undefined", () => {
+    const result = resolveRootDir(undefined);
+    // Should resolve from "." four levels up
+    expect(result).toBe(resolve(".", "..", "..", "..", ".."));
+  });
+});
+
+describe("mergeErrors", () => {
+  it("does nothing when errors array is empty", () => {
+    const results: Array<{ file: string; schema: string; valid: boolean; errors?: string[] }> = [];
+    mergeErrors(results, "test.yml", "test.schema.json", []);
+    expect(results).toHaveLength(0);
+  });
+
+  it("creates a new result entry when file is not yet in results", () => {
+    const results: Array<{ file: string; schema: string; valid: boolean; errors?: string[] }> = [];
+    mergeErrors(results, "test.yml", "test.schema.json", ["Error 1"]);
+    expect(results).toEqual([
+      { file: "test.yml", schema: "test.schema.json", valid: false, errors: ["Error 1"] },
+    ]);
+  });
+
+  it("merges errors into existing result entry", () => {
+    const results: Array<{ file: string; schema: string; valid: boolean; errors?: string[] }> = [
+      { file: "test.yml", schema: "test.schema.json", valid: true },
+    ];
+    mergeErrors(results, "test.yml", "test.schema.json", ["Error 1"]);
+    expect(results[0].valid).toBe(false);
+    expect(results[0].errors).toEqual(["Error 1"]);
+  });
+
+  it("appends to existing errors", () => {
+    const results: Array<{ file: string; schema: string; valid: boolean; errors?: string[] }> = [
+      { file: "test.yml", schema: "test.schema.json", valid: false, errors: ["Error 1"] },
+    ];
+    mergeErrors(results, "test.yml", "test.schema.json", ["Error 2"]);
+    expect(results[0].errors).toEqual(["Error 1", "Error 2"]);
+  });
+});
+
+describe("getOrCreate", () => {
+  it("returns existing value when key is present", () => {
+    const map = new Map<string, number[]>();
+    map.set("a", [1, 2]);
+    const result = getOrCreate(map, "a", () => []);
+    expect(result).toEqual([1, 2]);
+  });
+
+  it("creates and inserts new value when key is missing", () => {
+    const map = new Map<string, number[]>();
+    const result = getOrCreate(map, "a", () => [99]);
+    expect(result).toEqual([99]);
+    expect(map.get("a")).toEqual([99]);
+  });
+});


### PR DESCRIPTION
## Coverage quick wins

Adds targeted tests for the two lowest-coverage files to lift overall coverage.

### Changes

#### export-json.ts (0% → ~90%)
- Extracted `runExportJson(rootDir)` from `main()` for testability
- Added 2 tests: structure validation + file output verification

#### shared/utils.ts (38% → ~100%)  
- Added 9 tests covering all 4 exported functions:
  - `toPosixRel`: path conversion
  - `resolveRootDir`: dirname resolution + undefined fallback
  - `mergeErrors`: empty, new entry, merge existing, append
  - `getOrCreate`: existing key + missing key

### Impact
- 11 new tests (255/256 total, 1 pre-existing EPERM)
- Typecheck + lint clean
- 0 snapshot updates
- Expected coverage lift: ~70% → ~73%