### PR TITLE
ci: add CodeQL SAST, CODEOWNERS, and async review workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+# SPDX-License-Identifier: EUPL-1.2
+
+# .github/CODEOWNERS
+#
+# Repository ownership
+#
+# The maintainer is the default code owner for all files.
+# Community contributions are reviewed by the maintainer before merge.
+# Maintainer-authored pull requests request async external review via GitHub Actions.
+
+* @TommiLindfors

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+# SPDX-License-Identifier: EUPL-1.2
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 04:15 UTC
+    - cron: "15 4 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Run CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/request-async-review.yml
+++ b/.github/workflows/request-async-review.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+# SPDX-License-Identifier: EUPL-1.2
+
+name: Request async external review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  request-review:
+    name: Request @TiiVih review
+    runs-on: ubuntu-latest
+
+    if: >
+      github.event.pull_request.user.login == 'TommiLindfors' &&
+      github.event.pull_request.draft == false
+
+    steps:
+      - name: Request reviewer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "$PR_URL" --add-reviewer TiiVih


### PR DESCRIPTION
## Summary

Addresses OpenSSF Scorecard code scanning alerts on main.

### Changes

**New files:**
- **.github/CODEOWNERS** — assigns @TommiLindfors as default code owner for all files. Community PRs are automatically assigned to the maintainer for review.
- **.github/workflows/codeql.yml** — CodeQL SAST analysis for JavaScript/TypeScript, running on pushes to main, PRs, and weekly schedule. Improves Scorecard SAST coverage (alert #33, currently 6/10).
- **.github/workflows/request-async-review.yml** — auto-requests @TiiVih as async reviewer on PRs authored by @TommiLindfors. Does nothing for community PRs (those go through CODEOWNERS).

### Scorecard Alerts Addressed

| Alert | Before | Expected After |
|-------|--------|----------------|
| #33 SAST | 6/10 | Higher (CodeQL on all commits) |
| #9 Branch-Protection | 8/10 | Partial (CODEOWNERS added, but \equire_code_owner_review\ intentionally OFF) |

### Alerts NOT addressed (by design)

- **#31 Maintained (0/10)**: Repo < 90 days old — resolves with time
- **#36 CI-Tests (9/10)**: Already near-perfect, converges naturally
- **#32 Code-Review (0/10)**: Historical score — improves as reviewed PRs accumulate
- **#34 Fuzzing (0/10)**: Skipped — limited value for a data graph project

### Branch protection settings (confirmed, no changes)

- Require PR before merging: ✅ ON
- Require status checks: ✅ ON (Lint+test, Validate graph data)
- Require code owner review: ❌ OFF (intentional — avoids self-approval requirement)
- Admin bypass: ✅ ON (kept for flexibility)
- Required reviewers: 1

### Prerequisite

> ⚠️ @TiiVih has been invited to the \clarvia-org\ org (via the \eviewers\ team). She needs to **accept the invitation** before the async review workflow can request her reviews.