### PR TITLE
ci: add TiiVih auto-approve workflow

### DIFF
--- a/.github/workflows/tiivih-auto-approve.yml
+++ b/.github/workflows/tiivih-auto-approve.yml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+# SPDX-License-Identifier: EUPL-1.2
+
+name: Register TiiVih approval
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  approve:
+    name: Submit APPROVED review
+    runs-on: ubuntu-latest
+
+    # Only trigger on PR comments (not issue comments) by TiiVih
+    if: >
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == 'TiiVih'
+
+    steps:
+      - name: Check comment is exactly "ok" or "ok." (case-insensitive)
+        id: check
+        run: |
+          # Strip whitespace and newlines, lowercase
+          body=$(echo "${{ github.event.comment.body }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | tr -d '\r\n' \
+            | xargs)
+          if [[ "$body" == "ok" || "$body" == "ok." ]]; then
+            echo "approved=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "approved=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Submit APPROVED review as TiiVih
+        if: steps.check.outputs.approved == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TIIVIH_REVIEW_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          HEAD_SHA=$(gh api /repos/$REPO/pulls/$PR_NUMBER --jq '.head.sha')
+          gh api -X POST /repos/$REPO/pulls/$PR_NUMBER/reviews \
+            -f commit_id="$HEAD_SHA" \
+            -f event="APPROVE" \
+            -f body="Approved"


### PR DESCRIPTION
## Summary

Adds a workflow that converts TiiVih's \ok\ comment into a proper GitHub **APPROVED** review, so her async reviews are marked as reviewed.

## How it works

1. TiiVih comments \ok\ or \ok.\ (case-insensitive) on any PR
2. This workflow fires and submits a formal \APPROVED\ review on her behalf using her stored PAT
3. Any other comment text (questions, notes, concerns) does **not** trigger approval

## Setup required

Before this workflow activates, add TiiVih's PAT as a repository secret:

- Secret name: \TIIVIH_REVIEW_TOKEN\
- Required scope: \
epo\ (classic PAT) or \pull_requests: write\ (fine-grained PAT)