### PR TITLE
feat: fix CNAP URL, add source entries and snapshot registry files — #48 PR 1/2

### DIFF
--- a/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
@@ -700,12 +700,32 @@ exports[`runValidate characterization against real graph > pins schema assignmen
     "valid": true,
   },
   {
+    "file": "sources/snapshots/cnap_lu_survivor_pension_2026_06_04.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/cns_lu_death_funeral_costs_2026_06_04.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
     "file": "sources/snapshots/guichet_lu_bereavement_2026_06_03.yml",
     "schema": "source_snapshot.schema.json",
     "valid": true,
   },
   {
+    "file": "sources/snapshots/guichet_lu_bereavement_leave_2026_06_04.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
     "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/guichet_lu_funeral_allowance_2026_06_04.yml",
     "schema": "source_snapshot.schema.json",
     "valid": true,
   },
@@ -720,8 +740,8 @@ exports[`runValidate characterization against real graph > pins schema assignmen
 exports[`runValidate characterization against real graph > pins total file count and pass/fail breakdown 1`] = `
 {
   "invalid": 0,
-  "total": 142,
-  "valid": 142,
+  "total": 146,
+  "valid": 146,
 }
 `;
 
@@ -831,12 +851,32 @@ exports[`runValidate characterization against real graph > validates snapshot in
   },
   {
     "errorCount": 0,
+    "file": "sources/snapshots/guichet_lu_funeral_allowance_2026_06_04.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
     "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
     "valid": true,
   },
   {
     "errorCount": 0,
+    "file": "sources/snapshots/guichet_lu_bereavement_leave_2026_06_04.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
     "file": "sources/snapshots/guichet_lu_bereavement_2026_06_03.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/cns_lu_death_funeral_costs_2026_06_04.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/cnap_lu_survivor_pension_2026_06_04.yml",
     "valid": true,
   },
 ]

--- a/sources/register.yml
+++ b/sources/register.yml
@@ -23,7 +23,7 @@ sources:
   - id: source.lu.cnap_survivor_pension
     title: "Pension de survie"
     title_en: "Survivor pension"
-    url: "https://www.cnap.lu/informations-generales/pension-de-survie/"
+    url: "https://cnap.public.lu/fr/pensions/pension-survie.html"
     source_type: official_guidance
     jurisdiction: LU
     publisher: "CNAP (Caisse Nationale d'Assurance Pension)"
@@ -79,3 +79,51 @@ sources:
     monitoring:
       active: false
     verified_at: null
+
+  - id: source.cns_lu.death_funeral_costs
+    title: "Décès et frais funéraires"
+    title_en: "Death and funeral costs"
+    url: "https://cns.public.lu/fr/assure/droits-demarches/dossiers-thematiques/famille/deces-frais-funeraires.html"
+    source_type: official_guidance
+    jurisdiction: LU
+    publisher: "CNS (Caisse Nationale de Santé)"
+    languages: [fr]
+    domain: funeral_costs
+    life_event: bereavement
+    source_role: primary_guidance
+    monitoring:
+      active: false
+    verified_at: "2026-06-04"
+    verified_by: HirenGajjar
+
+  - id: source.guichet_lu.funeral_allowance
+    title: "Indemnité funéraire"
+    title_en: "Funeral allowance"
+    url: "https://guichet.public.lu/fr/citoyens/aides/sante/prestations-survivants/indemnite-funeraire.html"
+    source_type: government_portal
+    jurisdiction: LU
+    publisher: "Guichet.lu (Luxembourg Government)"
+    languages: [fr]
+    domain: funeral_costs
+    life_event: bereavement
+    source_role: primary_guidance
+    monitoring:
+      active: false
+    verified_at: "2026-06-04"
+    verified_by: HirenGajjar
+
+  - id: source.guichet_lu.bereavement_leave
+    title: "Congé extraordinaire pour motif personnel"
+    title_en: "Extraordinary leave for personal reasons"
+    url: "https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/conge-extraordinaire.html"
+    source_type: government_portal
+    jurisdiction: LU
+    publisher: "Guichet.lu (Luxembourg Government)"
+    languages: [fr]
+    domain: bereavement_leave
+    life_event: bereavement
+    source_role: primary_guidance
+    monitoring:
+      active: false
+    verified_at: "2026-06-04"
+    verified_by: HirenGajjar

--- a/sources/snapshots/cnap_lu_survivor_pension_2026_06_04.yml
+++ b/sources/snapshots/cnap_lu_survivor_pension_2026_06_04.yml
@@ -1,0 +1,15 @@
+id: snapshot.cnap_lu.survivor_pension.2026_06_04
+schema_version: "0.1.0"
+source_id: source.lu.cnap_survivor_pension
+captured_at: "2026-06-04T00:00:00Z"
+capture_method: manual_download
+content_hash: "sha256:45171e4c910779141e3eb0f4e7fbbc22108b9d61e7187fc0a0103d605ac1afe7"
+archive_uri: "sources/snapshots/html/lu/cnap_lu/survivor-pension/pension-survie_fr.html"
+page_url: "https://cnap.public.lu/fr/pensions/pension-survie.html"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-04"
+http_status: 200
+captured_by: "contributor.HirenGajjar"
+source_last_modified_at: null
+content_type: "text/html"

--- a/sources/snapshots/cns_lu_death_funeral_costs_2026_06_04.yml
+++ b/sources/snapshots/cns_lu_death_funeral_costs_2026_06_04.yml
@@ -1,0 +1,15 @@
+id: snapshot.cns_lu.death_funeral_costs.2026_06_04
+schema_version: "0.1.0"
+source_id: source.cns_lu.death_funeral_costs
+captured_at: "2026-06-04T00:00:00Z"
+capture_method: manual_download
+content_hash: "sha256:174e9ac0db05050f2510786a04d48e10d80bd7515e6b911c3c07d8a766e75997"
+archive_uri: "sources/snapshots/html/lu/cns_lu/death-funeral-costs/deces-frais-funeraires_fr.html"
+page_url: "https://cns.public.lu/fr/assure/droits-demarches/dossiers-thematiques/famille/deces-frais-funeraires.html"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-04"
+http_status: 200
+captured_by: "contributor.HirenGajjar"
+source_last_modified_at: null
+content_type: "text/html"

--- a/sources/snapshots/guichet_lu_bereavement_leave_2026_06_04.yml
+++ b/sources/snapshots/guichet_lu_bereavement_leave_2026_06_04.yml
@@ -1,0 +1,15 @@
+id: snapshot.guichet_lu.bereavement_leave.2026_06_04
+schema_version: "0.1.0"
+source_id: source.guichet_lu.bereavement_leave
+captured_at: "2026-06-04T00:00:00Z"
+capture_method: manual_download
+content_hash: "sha256:bdadb9fac7acfc3492b761d8a6f57fad53cea488b73810dbea313bcf3a937a32"
+archive_uri: "sources/snapshots/html/lu/guichet_lu/bereavement-leave/conge-extraordinaire_fr.html"
+page_url: "https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/conge-extraordinaire.html"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-04"
+http_status: 200
+captured_by: "contributor.HirenGajjar"
+source_last_modified_at: null
+content_type: "text/html"

--- a/sources/snapshots/guichet_lu_funeral_allowance_2026_06_04.yml
+++ b/sources/snapshots/guichet_lu_funeral_allowance_2026_06_04.yml
@@ -1,0 +1,15 @@
+id: snapshot.guichet_lu.funeral_allowance.2026_06_04
+schema_version: "0.1.0"
+source_id: source.guichet_lu.funeral_allowance
+captured_at: "2026-06-04T00:00:00Z"
+capture_method: manual_download
+content_hash: "sha256:aacabb518d74f8714fb7e278aa2645fb147bf52036dc33d8702d3fd67e508505"
+archive_uri: "sources/snapshots/html/lu/guichet_lu/funeral-allowance/indemnite-funeraire_fr.html"
+page_url: "https://guichet.public.lu/fr/citoyens/aides/sante/prestations-survivants/indemnite-funeraire.html"
+authoring_status: draft
+distribution_status: public_open
+record_valid_from: "2026-06-04"
+http_status: 200
+captured_by: "contributor.HirenGajjar"
+source_last_modified_at: null
+content_type: "text/html"


### PR DESCRIPTION
Part 1 of 2 for issue #48. This PR fixes a broken source URL discovered during verification work, registers 3 new Luxembourg sources, and creates 4 snapshot registry files for the HTML captures landed in PR #89. It is the prerequisite for PR 2/2 which will contain the assertion batches.

---

## Context

PR #89 captured 5 HTML snapshots for Priority 1 migration targets identified in `docs/migration-candidates.md` (PR #38). Before assertion batches can be authored from those snapshots, three things must be in place:

1. Correct source registry entries — so assertions can reference valid `source_id` values
2. Snapshot registry YAML files in `sources/snapshots/` — so assertions can reference valid `source_snapshot_id` values
3. SHA-256 content hashes — so snapshot integrity can be verified per CONVENTIONS.md

This PR delivers all three.

---

## Changes

### `sources/register.yml` — 1 fix, 3 new entries

#### Fix: `source.lu.cnap_survivor_pension` — broken URL corrected

During pre-flight verification, the existing CNAP URL was found to return HTTP 302 
redirect to the CNAP homepage — not the survivor pension page. Verified by curl:
curl -sI "[https://www.cnap.lu/informations-generales/pension-de-survie/](https://www.cnap.lu/informations%EE%80%80-generales/pension-de-survie/)"
→ HTTP/1.1 302 Found
→ Location: https://cnap.public.lu/

The correct URL — already used in our PR #89 snapshot — returns HTTP 200:
curl -sI "https://cnap.public.lu/fr/pensions/pension-survie.html"
→ HTTP/1.1 200 OK

Change:
- Old: `https://www.cnap.lu/informations-generales/pension-de-survie/`
- New: `https://cnap.public.lu/fr/pensions/pension-survie.html`

---

#### New entry: `source.cns_lu.death_funeral_costs`

- **URL:** `https://cns.public.lu/fr/assure/droits-demarches/dossiers-thematiques/famille/deces-frais-funeraires.html`
- **Title:** Décès et frais funéraires
- **Domain:** `funeral_costs`
- **Verified:** 2026-06-04

This is a distinct source from the existing `source.lu.cns_death_notification`. The existing entry covers the CNS death declaration process (`/vie-privee/deces.html`). This new entry covers funeral cost reimbursements — the CNS covers funeral costs under certain conditions. Different page, different domain, different claim set. Both are valid sources that will produce separate assertion batches in PR 2/2.

Originally researched and URL-verified in workflow-data PR #45. HTML captured in PR #89.

---

#### New entry: `source.guichet_lu.funeral_allowance`

- **URL:** `https://guichet.public.lu/fr/citoyens/aides/sante/prestations-survivants/indemnite-funeraire.html`
- **Title:** Indemnité funéraire
- **Domain:** `funeral_costs`
- **Verified:** 2026-06-04

Covers the Luxembourg funeral allowance (indemnité funéraire) — a lump-sum payment from the CNS to help cover funeral costs. This is the Guichet.lu citizen-facing guidance page describing eligibility and application. Feeds directly into the existing `graph/task_templates/bereavement/lu/claim_funeral_allowance.yml` task template created during the Foundation Alpha sprint.

---

#### New entry: `source.guichet_lu.bereavement_leave`

- **URL:** `https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/conge-extraordinaire.html`
- **Title:** Congé extraordinaire pour motif personnel
- **Domain:** `bereavement_leave`
- **Verified:** 2026-06-04

Covers the extraordinary leave entitlement for bereavement under Luxembourg labour law. Documents the duration of leave, eligible relationships, and employer notification requirements. Feeds directly into the existing `graph/task_templates/bereavement/lu/claim_bereavement_leave.yml` task template created during the Foundation Alpha sprint.

---

### 4 new snapshot registry files in `sources/snapshots/`

Each file follows the exact schema format of existing files 
(`guichet_lu_bereavement_2026_06_03.yml`, `guichet_lu_declaration_succession_2026_06_05.yml`).

SHA-256 hashes were computed using LF-normalised content per `docs/CONVENTIONS.md`:
```bash
tr -d '\r' < <file>.html | shasum -a 256
```

| File | Source ID | SHA-256 (LF-normalised) |
|------|-----------|-------------------------|
| `cnap_lu_survivor_pension_2026_06_04.yml` | `source.lu.cnap_survivor_pension` | `sha256:45171e4c910779141e3eb0f4e7fbbc22108b9d61e7187fc0a0103d605ac1afe7` |
| `cns_lu_death_funeral_costs_2026_06_04.yml` | `source.cns_lu.death_funeral_costs` | `sha256:174e9ac0db05050f2510786a04d48e10d80bd7515e6b911c3c07d8a766e75997` |
| `guichet_lu_funeral_allowance_2026_06_04.yml` | `source.guichet_lu.funeral_allowance` | `sha256:aacabb518d74f8714fb7e278aa2645fb147bf52036dc33d8702d3fd67e508505` |
| `guichet_lu_bereavement_leave_2026_06_04.yml` | `source.guichet_lu.bereavement_leave` | `sha256:bdadb9fac7acfc3492b761d8a6f57fad53cea488b73810dbea313bcf3a937a32` |

All 4 snapshot files set:
- `authoring_status: draft` — per CONTRIBUTING.md for external contributors
- `capture_method: manual_download` — HTML captured via `curl -L`
- `captured_by: contributor.HirenGajjar`
- `http_status: 200` — all confirmed live at capture time

Archive URIs point to the nested directory structure introduced in PR #89:
`sources/snapshots/html/lu/<publisher>/<slug>/<filename>_fr.html`

---

### Updated characterization test snapshots

`packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap`

The characterization test pins the full list of validated files. Adding 4 new snapshot registry files caused 3 snapshot assertions to fail — expected, since these files are valid additions. Updated with `pnpm vitest run -u` after confirming all 4 new files pass validation independently.

---

## Pre-existing issues confirmed not introduced by this PR

Confirmed via `git stash` + rerun before our changes:

- `pnpm check-references` — 5 broken `evidence_type_refs` in DE task templates (`evidence_type.de.todesbescheinigung`, `evidence_type.de.death_certificate`, `evidence_type.de.marriage_certificate`, `evidence_type.de.identity_document_deceased`, `evidence_type.global.pension_insurance_records`). All 5 existed before this PR.
- `pnpm lint-ids` — 1 warning: `task_template.xborder.bereavement.survivor_pension.coordinate_pension_institutions` exceeds 80-char ID length recommendation. Pre-existing.

---

## Source traceability

| Source | Originally researched in | HTML captured in |
|--------|--------------------------|-----------------|
| CNAP survivor pension (URL fix) | workflow-data PR #44 | PR #89 |
| CNS death and funeral costs | workflow-data PR #45 | PR #89 |
| Guichet funeral allowance | workflow-data PR #47 (issue #40 PR 1/4) | PR #89 |
| Guichet bereavement leave | workflow-data source corpus | PR #89 |

---

## What PR 2/2 will add

Assertion batches in `sources/assertions/lu/` for each of the 4 new sources:
- `cnap_lu/survivor_pension.yml`
- `cns_lu/death_funeral_costs.yml`
- `guichet_lu/funeral_allowance.yml`
- `guichet_lu/bereavement_leave.yml`

Each batch will reference the `source_snapshot_id` values created in this PR.

---

## Verification

- `pnpm validate` — 146/146 files pass (up from 142)
- `pnpm lint-ids` — 0 errors, 1 pre-existing warning
- `pnpm check-references` — 5 pre-existing warnings, 0 new regressions
- `pnpm test` — 261/261 pass after characterization snapshot update
- All 4 trailing newlines confirmed `0a`
- CNAP URL fix verified by curl before and after
- DCO sign-off included (`git commit -s`)
- No unintended changes — `git stash` confirmed pre-existing issues unchanged
