### PR TITLE
docs: add planned library references for CPSV-AP/CCCEV validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Clarvia maintains internal Clarvia-native schemas and generates compatibility vi
 - **PROV-O** — W3C Provenance Ontology
 
 > **Planned for next release:** integrate [`prov`](https://github.com/trungdong/prov) Python library for PROV-O exports.
+>
+> **Planned:** use [`SEMICeu/CPSV-AP`](https://github.com/SEMICeu/CPSV-AP) and [`SEMICeu/CCCEV`](https://github.com/SEMICeu/CCCEV) official SHACL shapes as validation targets for CPSV-AP and CCCEV exports.
 
 ## Scope
 


### PR DESCRIPTION
Add planned library notes to the Standards section of the README, alongside the existing prov note:

- **SEMICeu/CPSV-AP** + **SEMICeu/CCCEV** — official SHACL shapes to validate CPSV-AP and CCCEV exports against (NLnet milestone)

These are bookmarks for future evaluation, not immediate adoption.