### PR TITLE
fix: SonarCloud easy wins + exclude snapshots from CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+# SPDX-License-Identifier: EUPL-1.2
+
+# CodeQL configuration — exclude paths that should not be analysed.
+# See https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan
+
+paths-ignore:
+  - sources/snapshots/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: javascript-typescript
+          config-file: ./.github/codeql-config.yml
 
       - name: Run CodeQL analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/packages/cli/src/commands/export-web.ts
+++ b/packages/cli/src/commands/export-web.ts
@@ -236,7 +236,7 @@ const ENUM_LABELS: Record<string, { en: string; fr: string; de: string }> = {
 
 /** Humanize a snake_case enum value to Title Case as fallback. */
 function humanizeValue(value: string): string {
-  return value.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return value.replaceAll(/_/g, " ").replaceAll(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /**

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -235,10 +235,10 @@ function validateSnapshotIntegrity(
     errors.push("Field content_hash must be a string");
   } else if (contentHash === "pending_capture" || contentHash.startsWith("pending_")) {
     errors.push(`Field content_hash has pending value: "${contentHash}"`);
-  } else if (!contentHash.startsWith("sha256:")) {
-    errors.push(`Field content_hash must start with "sha256:", got "${contentHash}"`);
-  } else {
+  } else if (contentHash.startsWith("sha256:")) {
     errors.push(...validateArchiveHash(data, contentHash, rootDir));
+  } else {
+    errors.push(`Field content_hash must start with "sha256:", got "${contentHash}"`);
   }
 
   return errors;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ switch (command) {
 
   case "lint-ids": {
     const { main } = await import("./commands/lint-ids.js");
-    await main();
+    main();
     break;
   }
 

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -399,10 +399,10 @@ function evaluateConsequenceConditions(
     if (!cached) {
       const condition = graph.conditions.get(condRef);
       if (condition) {
-        if (!recordApplies(condition, temporalCtx)) {
-          cached = { result: false, missingFacts: [] };
-        } else {
+        if (recordApplies(condition, temporalCtx)) {
           cached = evaluateCondition(condition.expression, facts);
+        } else {
+          cached = { result: false, missingFacts: [] };
         }
       } else {
         cached = { result: "unknown", missingFacts: [] };
@@ -864,14 +864,14 @@ function makeItem(
     jurisdiction_contexts: [consequence.jurisdiction],
     checklist_group: group,
     urgency:
-      urgencyScore !== null
-        ? {
+      urgencyScore === null
+        ? null
+        : {
             score: urgencyScore,
             label: urgencyLabel(urgencyScore),
             deadline_label: deadlineLabel,
             overdue: null,
-          }
-        : null,
+          },
     action: template
       ? {
           action_type: template.action_type,


### PR DESCRIPTION
Addresses easy-win SonarCloud code smells and excludes archived HTML snapshots from CodeQL scanning.

### SonarCloud fixes:
- **S7781**: Use `replaceAll()` instead of `replace()` with regex (`export-web.ts`)
- **S4123**: Remove unnecessary `await` of non-Promise value (`index.ts`)
- **S7735**: Flip negated conditions (3 instances in `generator.ts` and `validate.ts`)

### CodeQL:
- Exclude `sources/snapshots/` from analysis (archived third-party HTML)
- Added `.github/codeql-config.yml` with `paths-ignore` for snapshot directory