### PR TITLE
chore: ignore local AI IDE tooling in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ coverage/
 pnpm-lock.yaml~
 build/
 .clarvia-output/
+
+# Local AI IDE tooling (Cursor + Antigravity) — personal setup only
+.cursor/
+.cursorrules
+.cursorignore
+.agent/
+.agents/
+AGENTS.md


### PR DESCRIPTION
## Summary
- Ignore local Cursor and Antigravity tooling paths in `.gitignore`
- Keeps personal IDE/agent config out of shared repos so teammates using different tooling are unaffected

## Test plan
- [x] Verified only `.gitignore` changed
- [ ] CI passes on PR