### PR TITLE
fix: resolve ESLint no-explicit-any violations in tests

### DIFF
--- a/packages/cli/src/commands/export-json.test.ts
+++ b/packages/cli/src/commands/export-json.test.ts
@@ -43,9 +43,21 @@ describe("export-json: runExportJson", () => {
     expect(existsSync(outPath)).toBe(true);
 
     const raw = readFileSync(outPath, "utf-8");
-    let content: any;
+    interface ExportedContent {
+      $schema?: string;
+      version?: string;
+      exported_at?: string;
+      consequences?: unknown[];
+      task_templates?: unknown[];
+      conditions?: unknown[];
+      deadlines?: unknown[];
+      authorities?: unknown[];
+      evidence_types?: unknown[];
+      intake_fact_types?: unknown[];
+    }
+    let content = {} as ExportedContent;
     expect(() => {
-      content = JSON.parse(raw);
+      content = JSON.parse(raw) as ExportedContent;
     }).not.toThrow();
     expect(content.$schema).toBe("clarvia-graph-export/v0.1");
     expect(content.version).toMatch(/^\d+\.\d+\.\d+/);

--- a/packages/cli/src/commands/validate.main.test.ts
+++ b/packages/cli/src/commands/validate.main.test.ts
@@ -1,13 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { main } from "./validate.js";
 
+interface MockFsGlobal {
+  __mockFsFail?: boolean;
+}
+
 // Set up dynamic mock for node:fs to trigger validation failure on YAML files
 vi.mock("node:fs", async (importOriginal) => {
   const original = await importOriginal<typeof import("node:fs")>();
   return {
     ...original,
-    readFileSync: (path: string, options: any) => {
-      if ((globalThis as any).__mockFsFail && (path.endsWith(".yml") || path.endsWith(".yaml"))) {
+    readFileSync: (
+      path: Parameters<typeof original.readFileSync>[0],
+      options: Parameters<typeof original.readFileSync>[1]
+    ) => {
+      const g = globalThis as unknown as MockFsGlobal;
+      if (
+        g.__mockFsFail &&
+        typeof path === "string" &&
+        (path.endsWith(".yml") || path.endsWith(".yaml"))
+      ) {
         throw new Error("mock read error");
       }
       return original.readFileSync(path, options);
@@ -27,12 +39,12 @@ describe("main() — validate", () => {
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
-    (globalThis as any).__mockFsFail = false;
+    (globalThis as unknown as MockFsGlobal).__mockFsFail = false;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    (globalThis as any).__mockFsFail = false;
+    (globalThis as unknown as MockFsGlobal).__mockFsFail = false;
   });
 
   it("validates all files and exits 0 when all pass", async () => {
@@ -45,7 +57,7 @@ describe("main() — validate", () => {
   });
 
   it("handles validation failure and exits non-zero", async () => {
-    (globalThis as any).__mockFsFail = true;
+    (globalThis as unknown as MockFsGlobal).__mockFsFail = true;
 
     await main();
 


### PR DESCRIPTION
This PR replaces explicit 'any' types in test files with proper types and parameters mapping to resolve ESLint failures.