### PR TITLE
fix: resolve 44 SonarCloud code smells (S7781, S6551, S5906)

### DIFF
--- a/packages/cli/src/commands/capture.ts
+++ b/packages/cli/src/commands/capture.ts
@@ -18,7 +18,7 @@ import { parse as parseYaml, stringify } from "yaml";
 
 /** Turn a Windows path into a forward-slash posix-style relative path */
 function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 // ── types ────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/check-anchors.ts
+++ b/packages/cli/src/commands/check-anchors.ts
@@ -17,7 +17,7 @@ import { parse as parseYaml } from "yaml";
 
 /** Turn a Windows path into a forward-slash posix-style relative path */
 function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 /** Strip HTML tags from a string, returning text content only. */

--- a/packages/cli/src/commands/check-publication-gate.ts
+++ b/packages/cli/src/commands/check-publication-gate.ts
@@ -23,7 +23,7 @@ import { parse as parseYaml } from "yaml";
 
 /** Turn a Windows path into a forward-slash posix-style relative path */
 function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 // ── public result types ──────────────────────────────────────────────

--- a/packages/cli/src/commands/export-json.test.ts
+++ b/packages/cli/src/commands/export-json.test.ts
@@ -179,13 +179,13 @@ describe("export-json: runExportJson", () => {
     const result = runExportJson(ROOT_DIR);
     const content = JSON.parse(readFileSync(outPath, "utf-8"));
 
-    expect(content.consequences.length).toBe(result.stats.consequences);
-    expect(content.task_templates.length).toBe(result.stats.task_templates);
-    expect(content.conditions.length).toBe(result.stats.conditions);
-    expect(content.deadlines.length).toBe(result.stats.deadlines);
-    expect(content.authorities.length).toBe(result.stats.authorities);
-    expect(content.evidence_types.length).toBe(result.stats.evidence_types);
-    expect(content.intake_fact_types.length).toBe(
+    expect(content.consequences).toHaveLength(result.stats.consequences);
+    expect(content.task_templates).toHaveLength(result.stats.task_templates);
+    expect(content.conditions).toHaveLength(result.stats.conditions);
+    expect(content.deadlines).toHaveLength(result.stats.deadlines);
+    expect(content.authorities).toHaveLength(result.stats.authorities);
+    expect(content.evidence_types).toHaveLength(result.stats.evidence_types);
+    expect(content.intake_fact_types).toHaveLength(
       result.stats.intake_fact_types,
     );
   });

--- a/packages/cli/src/commands/export-web.ts
+++ b/packages/cli/src/commands/export-web.ts
@@ -236,7 +236,7 @@ const ENUM_LABELS: Record<string, { en: string; fr: string; de: string }> = {
 
 /** Humanize a snake_case enum value to Title Case as fallback. */
 function humanizeValue(value: string): string {
-  return value.replaceAll(/_/g, " ").replaceAll(/\b\w/g, (c) => c.toUpperCase());
+  return value.replaceAll("_", " ").replaceAll(/\b\w/g, (c) => c.toUpperCase());
 }
 
 /**

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -18,7 +18,7 @@ import { parse as parseYaml, stringify } from "yaml";
 
 /** Turn a Windows path into a forward-slash posix-style relative path */
 function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 // ── types ────────────────────────────────────────────────────────────

--- a/packages/cli/src/commands/test-scenarios.ts
+++ b/packages/cli/src/commands/test-scenarios.ts
@@ -27,7 +27,7 @@ import {
 
 /** Turn a Windows path into a forward-slash posix-style relative path */
 function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 // ── public result types ──────────────────────────────────────────────

--- a/packages/cli/src/shared/utils.ts
+++ b/packages/cli/src/shared/utils.ts
@@ -13,7 +13,7 @@ import { resolve, relative } from "node:path";
  * was duplicated in every CLI command.
  */
 export function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).split("\\").join("/");
+  return relative(root, abs).replaceAll("\\", "/");
 }
 
 /**

--- a/packages/generator/src/generator.test.ts
+++ b/packages/generator/src/generator.test.ts
@@ -82,7 +82,7 @@ describe("generateChecklist", () => {
       lifeEvent: "marriage", // no records for this
     });
 
-    expect(output.items.length).toBe(0);
+    expect(output.items).toHaveLength(0);
   });
 
   it("returns no DE items when DE consequences are restricted_source", () => {
@@ -102,7 +102,7 @@ describe("generateChecklist", () => {
     // DE consequences are distribution_status: restricted_source,
     // so the generator filters them out per spec §10.6.
     // LU conditions are also false → no items at all.
-    expect(output.items.length).toBe(0);
+    expect(output.items).toHaveLength(0);
   });
 
   it("output has correct structure", () => {
@@ -308,7 +308,7 @@ describe("generateChecklist", () => {
 
     // DE consequences are restricted_source → no DE items in public output
     const deItems = output.items.filter((i) => i.jurisdiction_contexts.includes("DE"));
-    expect(deItems.length).toBe(0);
+    expect(deItems).toHaveLength(0);
 
     // Should still have jurisdiction_roles populated (based on facts, not output)
     expect(output.jurisdiction_roles.death_place).toContain("LU");
@@ -391,7 +391,7 @@ describe("generateChecklist", () => {
     const output2 = generateChecklist({ graph, facts: factsUpper, lifeEvent: "bereavement", asOfDate: "2026-06-03" });
 
     // After normalization, both should produce the same result
-    expect(output1.items.length).toBe(output2.items.length);
+    expect(output1.items).toHaveLength(output2.items.length);
     expect(output1.id).toBe(output2.id);
   });
 
@@ -470,7 +470,7 @@ describe("generateChecklist", () => {
         lifeEvent: "bereavement",
       });
 
-      expect(output.items.length).toBe(1);
+      expect(output.items).toHaveLength(1);
       expect(output.items[0].title).toBe("Merged Task");
       expect(output.items[0].needed_for).toEqual(["Consequence 1", "Consequence 2"]);
       expect(output.items[0].jurisdiction_contexts).toEqual(["LU"]);
@@ -553,7 +553,7 @@ describe("generateChecklist", () => {
         lifeEvent: "bereavement",
       });
 
-      expect(output.items.length).toBe(2);
+      expect(output.items).toHaveLength(2);
       expect(output.items[0].id).not.toBe(output.items[1].id);
     });
 
@@ -715,7 +715,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(1);
+      expect(output.items).toHaveLength(1);
       expect(output.items[0].source_summary?.assertion_count).toBe(1);
     });
 
@@ -729,7 +729,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes expired consequence by record_valid_to", () => {
@@ -742,7 +742,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes not-yet-effective consequence by legal_effective_from", () => {
@@ -755,7 +755,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes legally expired consequence by legal_effective_to", () => {
@@ -768,7 +768,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes task template if it does not apply temporally", () => {
@@ -782,7 +782,7 @@ describe("generateChecklist", () => {
         eventDate: "2026-06-03",
       });
       // The consequence itself applies, but has no tasks since the only task template doesn't apply
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes condition when it does not apply temporally, causing trigger to fail", () => {
@@ -811,7 +811,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(0);
+      expect(output.items).toHaveLength(0);
     });
 
     it("excludes deadline when it does not apply temporally", () => {
@@ -825,7 +825,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(1);
+      expect(output.items).toHaveLength(1);
       expect(output.items[0].urgency?.deadline_label).toBeNull();
     });
 
@@ -839,7 +839,7 @@ describe("generateChecklist", () => {
         asOfDate: "2026-06-03",
         eventDate: "2026-06-03",
       });
-      expect(output.items.length).toBe(1);
+      expect(output.items).toHaveLength(1);
       expect(output.items[0].source_summary?.assertion_count).toBe(0);
     });
   });

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -722,7 +722,7 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
   // Determine event date for temporal filtering
   const eventDate = optEventDate ?? facts.find(f => f.fact_type === "death.date" || f.fact_type === "death.datetime")?.value ?? referenceDate;
 
-  const temporalCtx: TemporalContext = { asOfDate: referenceDate, eventDate: String(eventDate) };
+  const temporalCtx: TemporalContext = { asOfDate: referenceDate, eventDate: typeof eventDate === "string" ? eventDate : String(eventDate) };
 
   // Compute deterministic scenario hash
   const canonicalFacts = JSON.stringify(

--- a/packages/generator/src/golden.test.ts
+++ b/packages/generator/src/golden.test.ts
@@ -878,7 +878,7 @@ describe("golden: generator pipeline internals", () => {
     });
 
     // Both items should have the same status (applies), derived from cached condition
-    expect(output.items.length).toBe(2);
+    expect(output.items).toHaveLength(2);
     expect(output.items[0].status).toBe("applies");
     expect(output.items[1].status).toBe("applies");
   });
@@ -903,7 +903,7 @@ describe("golden: generator pipeline internals", () => {
       eventDate: FIXED_AS_OF,
     });
 
-    expect(output.items.length).toBe(1);
+    expect(output.items).toHaveLength(1);
     expect(output.items[0].title).toBe("Bare Consequence Title");
     expect(output.items[0].action).toBeNull();
   });
@@ -938,7 +938,7 @@ describe("golden: generator pipeline internals", () => {
       // eventDate NOT provided — should fall back to death.date
     });
 
-    expect(output.items.length).toBe(1);
+    expect(output.items).toHaveLength(1);
   });
 
   // ── 6f. Item sorting order ────────────────────────────────────────
@@ -1098,14 +1098,14 @@ describe("golden: generator pipeline internals", () => {
     });
 
     // Two consequences merge into one visible item
-    expect(output.items.length).toBe(1);
+    expect(output.items).toHaveLength(1);
     expect(output.items[0].title).toBe("Merged Task");
     expect(output.items[0].needed_for).toEqual(["Merge Consequence 1", "Merge Consequence 2"]);
     expect(output.items[0].jurisdiction_contexts).toEqual(["LU"]);
     // Merged assertion count
     expect(output.items[0].source_summary?.assertion_count).toBe(2);
     // Merged explanation trace exists
-    expect(output.explanation_traces.length).toBe(1);
+    expect(output.explanation_traces).toHaveLength(1);
   });
 
   // ── 6j. Dedupe strategy: do_not_merge ─────────────────────────────
@@ -1144,7 +1144,7 @@ describe("golden: generator pipeline internals", () => {
     });
 
     // Items remain separate
-    expect(output.items.length).toBe(2);
+    expect(output.items).toHaveLength(2);
     expect(output.items[0].id).not.toBe(output.items[1].id);
     const titles = output.items.map(i => i.title).sort();
     expect(titles).toEqual(["Task Separate 1", "Task Separate 2"]);
@@ -1196,13 +1196,13 @@ describe("golden: generator pipeline internals", () => {
     });
 
     // LU pair merges into one, DE stays separate → 2 items total
-    expect(output.items.length).toBe(2);
+    expect(output.items).toHaveLength(2);
 
     const luItems = output.items.filter(i => i.jurisdiction_contexts.includes("LU"));
     const deItems = output.items.filter(i => i.jurisdiction_contexts.includes("DE"));
 
-    expect(luItems.length).toBe(1);
-    expect(deItems.length).toBe(1);
+    expect(luItems).toHaveLength(1);
+    expect(deItems).toHaveLength(1);
 
     // Merged LU item has combined needed_for
     expect(luItems[0].needed_for).toEqual(["LU Consequence 1", "LU Consequence 2"]);

--- a/packages/generator/src/jurisdiction-roles.ts
+++ b/packages/generator/src/jurisdiction-roles.ts
@@ -61,7 +61,7 @@ export function resolveJurisdictionRoles(facts: Fact[]): JurisdictionRoles {
   };
 
   for (const fact of facts) {
-    const val = String(fact.value ?? "");
+    const val = typeof fact.value === "string" ? fact.value : String(fact.value ?? "");
 
     // Single-value roles
     const singleRole = ROLE_MAPPING[fact.fact_type];

--- a/packages/generator/src/normalize.ts
+++ b/packages/generator/src/normalize.ts
@@ -46,7 +46,8 @@ export function normalizeFacts(facts: Fact[]): Fact[] {
     // Handle array facts (e.g., work_history.country with multiple values)
     if (COUNTRY_ARRAY_PATHS.has(fact.fact_type)) {
       // Uppercase and deduplicate — arrays are always string-based country codes
-      const rawArr = Array.isArray(fact.value) ? fact.value : String(fact.value ?? "").split(",");
+      const rawStr = typeof fact.value === "string" ? fact.value : String(fact.value ?? "");
+      const rawArr = Array.isArray(fact.value) ? fact.value : rawStr.split(",");
       const values = rawArr.map((v: unknown) => String(v).trim().toUpperCase());
       const unique = [...new Set(values)].sort((a, b) => a.localeCompare(b));
       normalized.push({ fact_type: fact.fact_type, value: unique.join(",") });
@@ -57,7 +58,7 @@ export function normalizeFacts(facts: Fact[]): Fact[] {
       // Preserve arrays (e.g., employment_status: [self_employed, business_owner])
       normalized.push({ fact_type: fact.fact_type, value: fact.value });
     } else {
-      const val = String(fact.value ?? "");
+      const val = typeof fact.value === "string" ? fact.value : String(fact.value ?? "");
       normalized.push({
         fact_type: fact.fact_type,
         value: normalizeValue(fact.fact_type, val),

--- a/packages/generator/src/temporal.ts
+++ b/packages/generator/src/temporal.ts
@@ -11,13 +11,15 @@ export interface TemporalContext {
 /** Returns true if `fieldValue` is after `referenceDate` (ISO string comparison). */
 function isAfterDate(fieldValue: unknown, referenceDate: string): boolean {
   if (fieldValue === undefined || fieldValue === null) return false;
-  return String(fieldValue) > referenceDate;
+  const str = typeof fieldValue === "string" ? fieldValue : String(fieldValue);
+  return str > referenceDate;
 }
 
 /** Returns true if `fieldValue` is on or before `referenceDate` (ISO string comparison). */
 function isOnOrBeforeDate(fieldValue: unknown, referenceDate: string): boolean {
   if (fieldValue === undefined || fieldValue === null) return false;
-  return String(fieldValue) <= referenceDate;
+  const str = typeof fieldValue === "string" ? fieldValue : String(fieldValue);
+  return str <= referenceDate;
 }
 
 export function recordApplies(record: Record<string, unknown>, ctx: TemporalContext): boolean {


### PR DESCRIPTION
Closes 44 of 49 open SonarCloud issues on the new code period.

- **utils.ts, capture.ts, extract.ts, check-anchors.ts, check-publication-gate.ts, test-scenarios.ts**: split().join() → replaceAll()
- **export-web.ts**: redundant regex in replaceAll → string literal
- **temporal.ts, normalize.ts, generator.ts, jurisdiction-roles.ts**: explicit type narrowing before String()
- **export-json.test.ts, generator.test.ts, golden.test.ts**: .length.toBe() → .toHaveLength()

Code + tests. All 282 tests pass.