### PR TITLE
fix: resolve remaining 5 SonarCloud issues (S3776, S107)

### DIFF
--- a/packages/cli/src/commands/check-references.ts
+++ b/packages/cli/src/commands/check-references.ts
@@ -67,6 +67,20 @@ export interface RefEntry {
 export function extractRefs(data: unknown): RefEntry[] {
   const refs: RefEntry[] = [];
 
+  function collectArrayRefs(key: string, val: unknown[]): void {
+    for (const item of val) {
+      if (typeof item === "string" && item.length > 0) {
+        refs.push({ field: key, target: item });
+      }
+    }
+  }
+
+  function collectSingleRef(key: string, val: unknown): void {
+    if (typeof val === "string" && val.length > 0) {
+      refs.push({ field: key, target: val });
+    }
+  }
+
   function walk(obj: unknown): void {
     if (obj == null || typeof obj !== "object") return;
 
@@ -77,20 +91,10 @@ export function extractRefs(data: unknown): RefEntry[] {
 
     const record = obj as Record<string, unknown>;
     for (const [key, val] of Object.entries(record)) {
-      if (key.endsWith("_refs")) {
-        // Array of IDs
-        if (Array.isArray(val)) {
-          for (const item of val) {
-            if (typeof item === "string" && item.length > 0) {
-              refs.push({ field: key, target: item });
-            }
-          }
-        }
+      if (key.endsWith("_refs") && Array.isArray(val)) {
+        collectArrayRefs(key, val);
       } else if (key.endsWith("_ref")) {
-        // Single ID
-        if (typeof val === "string" && val.length > 0) {
-          refs.push({ field: key, target: val });
-        }
+        collectSingleRef(key, val);
       }
 
       // Recurse into nested objects and arrays regardless

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -135,73 +135,7 @@ export async function runValidate(
   const results: ValidateResult[] = [];
 
   for (const file of dataFiles) {
-    const relPath = toPosixRel(file, rootDir);
-    const schemaFile = resolveSchemaFile(relPath);
-
-    if (!schemaFile) {
-      results.push({
-        file: relPath,
-        schema: "(unknown)",
-        valid: false,
-        errors: [`No schema mapping for path: ${relPath}`],
-      });
-      continue;
-    }
-
-    const schema = schemaCache.get(schemaFile);
-    if (!schema) {
-      results.push({
-        file: relPath,
-        schema: schemaFile,
-        valid: false,
-        errors: [
-          `Schema file not found: schemas/v0.1/${schemaFile} — it may not have been created yet`,
-        ],
-      });
-      continue;
-    }
-
-    let data: unknown;
-    try {
-      const raw = readFileSync(file, "utf-8");
-      data = parseYaml(raw);
-    } catch (err) {
-      results.push({
-        file: relPath,
-        schema: schemaFile,
-        valid: false,
-        errors: [`YAML parse error: ${(err as Error).message}`],
-      });
-      continue;
-    }
-
-    const schemaId = schema["$id"] as string | undefined;
-    const validate = schemaId
-      ? ajv.getSchema(schemaId)
-      : ajv.compile(schema);
-
-    if (!validate) {
-      results.push({
-        file: relPath,
-        schema: schemaFile,
-        valid: false,
-        errors: [`Could not compile schema: ${schemaFile}`],
-      });
-      continue;
-    }
-
-    const valid = validate(data) as boolean;
-    results.push({
-      file: relPath,
-      schema: schemaFile,
-      valid,
-      errors: valid
-        ? undefined
-        : (validate.errors ?? []).map(
-            (e: ErrorObject) =>
-              `${e.instancePath || "/"} ${e.message ?? "unknown error"}`,
-          ),
-    });
+    results.push(validateSingleFile(file, rootDir, schemaCache, ajv));
   }
 
   validateSnapshotsAndAnchors(rootDir, results);
@@ -209,6 +143,78 @@ export async function runValidate(
 
   const ok = results.every((r: ValidateResult) => r.valid);
   return { results, ok };
+}
+
+/** Validate a single YAML file against its mapped schema. */
+function validateSingleFile(
+  file: string,
+  rootDir: string,
+  schemaCache: Map<string, Record<string, unknown>>,
+  ajv: InstanceType<typeof Ajv>,
+): ValidateResult {
+  const relPath = toPosixRel(file, rootDir);
+  const schemaFile = resolveSchemaFile(relPath);
+
+  if (!schemaFile) {
+    return {
+      file: relPath,
+      schema: "(unknown)",
+      valid: false,
+      errors: [`No schema mapping for path: ${relPath}`],
+    };
+  }
+
+  const schema = schemaCache.get(schemaFile);
+  if (!schema) {
+    return {
+      file: relPath,
+      schema: schemaFile,
+      valid: false,
+      errors: [
+        `Schema file not found: schemas/v0.1/${schemaFile} — it may not have been created yet`,
+      ],
+    };
+  }
+
+  let data: unknown;
+  try {
+    const raw = readFileSync(file, "utf-8");
+    data = parseYaml(raw);
+  } catch (err) {
+    return {
+      file: relPath,
+      schema: schemaFile,
+      valid: false,
+      errors: [`YAML parse error: ${(err as Error).message}`],
+    };
+  }
+
+  const schemaId = schema["$id"] as string | undefined;
+  const validate = schemaId
+    ? ajv.getSchema(schemaId)
+    : ajv.compile(schema);
+
+  if (!validate) {
+    return {
+      file: relPath,
+      schema: schemaFile,
+      valid: false,
+      errors: [`Could not compile schema: ${schemaFile}`],
+    };
+  }
+
+  const valid = validate(data) as boolean;
+  return {
+    file: relPath,
+    schema: schemaFile,
+    valid,
+    errors: valid
+      ? undefined
+      : (validate.errors ?? []).map(
+          (e: ErrorObject) =>
+            `${e.instancePath || "/"} ${e.message ?? "unknown error"}`,
+        ),
+  };
 }
 
 // ── Snapshot map type ────────────────────────────────────────────────

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -389,9 +389,36 @@ function filterCandidateConsequences(
 
 // ── Step 4: Evaluate consequence conditions ──────────────────────────
 
+type ConditionResult = { result: TriValue; missingFacts: string[] };
+
+/** Resolve a single condition ref, using cache if available. */
+function resolveCondition(
+  condRef: string,
+  conditionResultCache: Map<string, ConditionResult>,
+  graph: LoadedGraph,
+  facts: Fact[],
+  temporalCtx: TemporalContext,
+): ConditionResult {
+  const cached = conditionResultCache.get(condRef);
+  if (cached) return cached;
+
+  const condition = graph.conditions.get(condRef);
+  let resolved: ConditionResult;
+  if (!condition) {
+    resolved = { result: "unknown", missingFacts: [] };
+  } else if (recordApplies(condition, temporalCtx)) {
+    resolved = evaluateCondition(condition.expression, facts);
+  } else {
+    resolved = { result: false, missingFacts: [] };
+  }
+
+  conditionResultCache.set(condRef, resolved);
+  return resolved;
+}
+
 function evaluateConsequenceConditions(
   consequence: Consequence,
-  conditionResultCache: Map<string, { result: TriValue; missingFacts: string[] }>,
+  conditionResultCache: Map<string, ConditionResult>,
   graph: LoadedGraph,
   facts: Fact[],
   temporalCtx: TemporalContext,
@@ -401,28 +428,14 @@ function evaluateConsequenceConditions(
   const allMissingFacts: string[] = [];
 
   for (const condRef of conditionRefs) {
-    let cached = conditionResultCache.get(condRef);
-    if (!cached) {
-      const condition = graph.conditions.get(condRef);
-      if (condition) {
-        if (recordApplies(condition, temporalCtx)) {
-          cached = evaluateCondition(condition.expression, facts);
-        } else {
-          cached = { result: false, missingFacts: [] };
-        }
-      } else {
-        cached = { result: "unknown", missingFacts: [] };
-      }
-      conditionResultCache.set(condRef, cached);
-    }
+    const resolved = resolveCondition(condRef, conditionResultCache, graph, facts, temporalCtx);
+    allMissingFacts.push(...resolved.missingFacts);
 
-    allMissingFacts.push(...cached.missingFacts);
-
-    if (cached.result === false) {
+    if (resolved.result === false) {
       overallResult = false;
       break;
     }
-    if (cached.result === "unknown") {
+    if (resolved.result === "unknown") {
       overallResult = "unknown";
     }
   }
@@ -436,16 +449,19 @@ function evaluateConsequenceConditions(
 
 // ── Step 5: Expand consequence into candidate items ──────────────────
 
-function expandConsequenceToItems(
-  consequence: Consequence,
-  overallResult: TriValue,
-  allMissingFacts: string[],
-  conditionRefs: string[],
-  conditionResultCache: Map<string, { result: TriValue; missingFacts: string[] }>,
-  scenarioHash: string,
-  graph: LoadedGraph,
-  temporalCtx: TemporalContext,
-): CandidateItem[] {
+interface ExpandContext {
+  consequence: Consequence;
+  overallResult: TriValue;
+  allMissingFacts: string[];
+  conditionRefs: string[];
+  conditionResultCache: Map<string, ConditionResult>;
+  scenarioHash: string;
+  graph: LoadedGraph;
+  temporalCtx: TemporalContext;
+}
+
+function expandConsequenceToItems(ctx: ExpandContext): CandidateItem[] {
+  const { consequence, overallResult, allMissingFacts, conditionRefs, conditionResultCache, scenarioHash, graph, temporalCtx } = ctx;
   const taskRefs = consequence.task_template_refs ?? [];
   const results: CandidateItem[] = [];
 
@@ -750,10 +766,10 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     const { overallResult, allMissingFacts } = evaluateConsequenceConditions(
       consequence, conditionResultCache, graph, facts, temporalCtx,
     );
-    candidatesList.push(...expandConsequenceToItems(
+    candidatesList.push(...expandConsequenceToItems({
       consequence, overallResult, allMissingFacts, conditionRefs,
       conditionResultCache, scenarioHash, graph, temporalCtx,
-    ));
+    }));
   }
 
   // ─── Deduplicate and merge candidates ───────────────────────────

--- a/packages/generator/src/loader.ts
+++ b/packages/generator/src/loader.ts
@@ -168,7 +168,8 @@ function loadDir<T extends GraphRecord>(
   return map;
 }
 
-export function loadGraph(rootDir: string): LoadedGraph {
+/** Load and index assertion records from batch files. */
+function loadAssertions(rootDir: string): Map<string, SourceAssertion> {
   const assertions = new Map<string, SourceAssertion>();
   const assertionFiles = globSync("sources/assertions/**/*.{yml,yaml}", { cwd: rootDir, absolute: true });
 
@@ -177,15 +178,7 @@ export function loadGraph(rootDir: string): LoadedGraph {
       const raw = readFileSync(file, "utf-8");
       const doc = parseYaml(raw) as { source_id: string; source_snapshot_id: string; assertions?: SourceAssertion[] };
       if (doc?.assertions && Array.isArray(doc.assertions)) {
-        for (const ass of doc.assertions) {
-          if (ass && typeof ass === "object" && typeof ass.id === "string") {
-            assertions.set(ass.id, {
-              ...ass,
-              source_id: ass.source_id || doc.source_id,
-              source_snapshot_id: ass.source_snapshot_id || doc.source_snapshot_id,
-            });
-          }
-        }
+        indexAssertionBatch(assertions, doc);
       }
     } catch (err) {
       // Ignore files that fail to load (will be caught by schema validation)
@@ -196,6 +189,26 @@ export function loadGraph(rootDir: string): LoadedGraph {
     }
   }
 
+  return assertions;
+}
+
+/** Index individual assertions from a parsed batch document. */
+function indexAssertionBatch(
+  assertions: Map<string, SourceAssertion>,
+  doc: { source_id: string; source_snapshot_id: string; assertions?: SourceAssertion[] },
+): void {
+  for (const ass of doc.assertions!) {
+    if (ass && typeof ass === "object" && typeof ass.id === "string") {
+      assertions.set(ass.id, {
+        ...ass,
+        source_id: ass.source_id || doc.source_id,
+        source_snapshot_id: ass.source_snapshot_id || doc.source_snapshot_id,
+      });
+    }
+  }
+}
+
+export function loadGraph(rootDir: string): LoadedGraph {
   return {
     consequences: loadDir<Consequence>(
       rootDir,
@@ -226,6 +239,6 @@ export function loadGraph(rootDir: string): LoadedGraph {
       rootDir,
       "sources/!(assertions|snapshots)/**/*.{yml,yaml}",
     ),
-    assertions,
+    assertions: loadAssertions(rootDir),
   };
 }


### PR DESCRIPTION
Closes the final 5 SonarCloud issues, bringing the total from 49 to 0.

- **loader.ts**: extract loadAssertions() + indexAssertionBatch() helpers (complexity 17 → ~8)
- **generator.ts**: extract resolveCondition() helper (complexity 17 → ~10), group expandConsequenceToItems into ExpandContext (8 → 1 param)
- **check-references.ts**: extract collectArrayRefs() + collectSingleRef() (complexity 28 → ~12)
- **validate.ts**: extract validateSingleFile() (complexity 24 → ~10)

Code + refactor. All 282 tests pass.