### PR TITLE
docs: add software quality sections to README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,17 @@ authoring_status: draft
 
 CI will reject PRs that set `review_status: approved` or `authoring_status: approved` from external contributors.
 
+## Quality checks
+
+Before opening a pull request, run:
+
+- **Tests** — `pnpm test`
+- **Linting** — `pnpm lint`
+- **Type checking** — `pnpm typecheck`
+- **Graph validation** — `pnpm validate`
+
+Pull requests are expected to pass the same CI checks that run on the main branch and releases.
+
 ## Contributor agreement
 
 We use the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). By submitting a PR, you certify that you have the right to submit the work under the project's licenses.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Every checklist item traces back to an official source. No legal consequence pub
 - **Static exports**: Consumer apps load generated JSON at build time — no runtime API dependency
 - **Privacy-first**: Client-side condition evaluation, no user data sent to servers
 
+## Software quality and reproducibility
+
+This repository uses automated quality checks for tests, linting, static analysis, dependency and security scanning, documented installation, reproducible examples, citation metadata, licensing information, and archived releases. These checks run in CI on every pull request and release.
+
 ## Standards
 
 Clarvia maintains internal Clarvia-native schemas and generates compatibility views for:


### PR DESCRIPTION
- **README.md**: add 'Software quality and reproducibility' section
- **CONTRIBUTING.md**: add 'Quality checks' section with pre-PR commands

Docs only.