### PR TITLE
Add public funding.json manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Validate funding manifest
+        run: pnpm validate:funding
+
       - name: Schema validation
         run: pnpm validate
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Clarvia Graph is an open, source-backed knowledge graph for administrative conse
 
 The provenance chain, three-valued condition logic, publication gate, and EU standards alignment are domain-agnostic patterns. The bereavement/Luxembourg dataset is a working reference implementation. If you are building source-backed regulatory workflows for a different life event or jurisdiction, this repository provides a tested starting point.
 
+## Funding
+
+Clarvia Graph is maintained by Clarvia ASBL, a Luxembourg-registered nonprofit.
+
+Our current funding needs and contribution channels are published in the project's [`funding.json`](funding.json) manifest.
+
+Current priority: an adoption-ready first release covering stable versioning, documentation, reproducible examples, validation, automated testing, governance, and independent technical review.
+
 ## License
 
 - **Code & tooling:** [EUPL-1.2](LICENSE)

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -130,6 +130,20 @@ path = [
 SPDX-FileCopyrightText = "2025-2026 CLARVIA ASBL, Luxembourg"
 SPDX-License-Identifier = "EUPL-1.2"
 
+# ── Funding manifest ────────────────────────────────────────────────
+
+[[annotations]]
+path = "funding.json"
+SPDX-FileCopyrightText = "2025-2026 CLARVIA ASBL, Luxembourg"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+# ── Standalone scripts ──────────────────────────────────────────────
+
+[[annotations]]
+path = "scripts/**/*.ts"
+SPDX-FileCopyrightText = "2025-2026 CLARVIA ASBL, Luxembourg"
+SPDX-License-Identifier = "EUPL-1.2"
+
 # ── CI/CD workflows ─────────────────────────────────────────────────
 
 [[annotations]]

--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://fundingjson.org/schema/v1.1.0.json",
+  "version": "v1.1.0",
+  "entity": {
+    "type": "organisation",
+    "role": "steward",
+    "name": "Clarvia ASBL",
+    "email": "opensource@clarvia.org",
+    "description": "Clarvia ASBL is a Luxembourg-registered nonprofit developing free and open public-interest infrastructure for navigating complex administrative processes after major life events, beginning with bereavement. Clarvia combines source-backed administrative data, open schemas, validation tooling, and accessible public services. Its first reference implementation helps families understand the practical and administrative steps that follow a death. Clarvia currently has zero paid staff, is supported by six volunteers, and develops its work with feedback from public authorities, nonprofit organisations, and commercial actors in the bereavement sector.",
+    "webpageUrl": {
+      "url": "https://clarvia.org"
+    }
+  },
+  "projects": [
+    {
+      "guid": "clarvia-graph",
+      "name": "Clarvia Graph",
+      "description": "Clarvia Graph is an open, source-backed knowledge graph and toolchain for modelling administrative consequences after major life events. It structures official rules, conditions, deadlines, required documents, responsible authorities, and source evidence so that public services, nonprofit organisations, civic-technology projects, and researchers can generate trustworthy administrative workflows.\n\nThe first reference implementation covers bereavement administration in Luxembourg, including cross-border concepts needed for European workflows. The graph directly powers Clarvia's free, multilingual bereavement checklist at clarvia.org, helping families navigate administrative steps after the loss of a loved one. Every published claim is designed to trace to an authoritative source. The project includes open schemas, controlled vocabularies, graph data, source registries, validation and generation tooling, automated tests, and exports including JSON, JSON-LD, and EU interoperability views.\n\nFunding is sought to prepare Clarvia Graph for independent evaluation and reuse through a stable versioned release, improved installation and contributor documentation, reproducible examples, stronger validation and automated testing, public governance and roadmap documentation, and an independent technical review.",
+      "webpageUrl": {
+        "url": "https://clarvia.org"
+      },
+      "repositoryUrl": {
+        "url": "https://github.com/clarvia-org/clarvia-graph"
+      },
+      "licenses": [
+        "spdx:EUPL-1.2",
+        "spdx:CC-BY-4.0"
+      ],
+      "tags": [
+        "knowledge-graph",
+        "civic-tech",
+        "open-data",
+        "public-services",
+        "developer-tools",
+        "data-provenance",
+        "interoperability",
+        "digital-public-good",
+        "government-data",
+        "social-impact"
+      ]
+    }
+  ],
+  "funding": {
+    "channels": [
+      {
+        "guid": "clarvia-bank",
+        "type": "bank",
+        "address": "https://clarvia.org/en/support",
+        "description": "Bank-transfer details for Clarvia ASBL are published on this page. Institutional funders may contact opensource@clarvia.org for due-diligence and transfer documentation."
+      }
+    ],
+    "plans": [
+      {
+        "guid": "adoption-ready-release",
+        "status": "active",
+        "name": "Clarvia Graph adoption-ready first release",
+        "description": "One-time funding to prepare Clarvia Graph for independent evaluation and reuse. The work will produce a stable versioned release, improved installation and contributor documentation, reproducible examples, stronger validation and automated testing, public governance and roadmap documentation, and an independent technical review.",
+        "amount": 20000,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "clarvia-bank"
+        ]
+      },
+      {
+        "guid": "general-support",
+        "status": "active",
+        "name": "General open-source support",
+        "description": "Flexible contributions supporting maintenance, documentation, source validation, community participation, infrastructure, and continued development of Clarvia Graph.",
+        "amount": 0,
+        "currency": "USD",
+        "frequency": "one-time",
+        "channels": [
+          "clarvia-bank"
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,16 +26,19 @@
     "export-json": "pnpm --filter @clarvia/cli run export-json",
     "export-web": "pnpm --filter @clarvia/cli run export-web",
     "capture": "pnpm --filter @clarvia/cli run capture",
-    "extract": "pnpm --filter @clarvia/cli run extract"
+    "extract": "pnpm --filter @clarvia/cli run extract",
+    "validate:funding": "tsx scripts/validate-funding.ts"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.0",
+    "@vitest/coverage-v8": "^4.1.8",
+    "ajv": "^8.17.1",
     "eslint": "^10.6.0",
     "prettier": "^3.9.4",
+    "tsx": "^4.23.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
-    "@vitest/coverage-v8": "^4.1.8",
     "vitest": "^4.1.8"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,18 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
+      ajv:
+        specifier: ^8.17.1
+        version: 8.20.0
       eslint:
         specifier: ^10.6.0
         version: 10.6.0
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/schemas/funding-json-v1.1.0.json
+++ b/schemas/funding-json-v1.1.0.json
@@ -1,0 +1,286 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": ["entity", "funding"],
+    "properties": {
+        "version": {
+            "type": "string",
+            "description": "Manifest content version"
+        },
+        "entity": {
+            "type": "object",
+            "description": "The entity associated with the project, soliciting funds.",
+            "required": ["type", "role", "name", "email", "description", "webpageUrl"],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "Type of the entity. [individual, group, organisation, other], Use the closest approximation.",
+                    "enum": ["individual", "group", "organisation", "other"]
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Role in relation to the entity. [owner, steward, maintainer, contributor, other]. Use the closest approximation.",
+                    "enum": ["owner", "steward", "maintainer", "contributor", "other"]
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the entity.",
+                    "maxLength": 250
+                },
+                "email": {
+                    "type": "string",
+                    "description": "Contact email.",
+                    "maxLength": 250
+                },
+                "phone": {
+                    "type": "string",
+                    "description": "Contact phone number. Generally suitable for organisations.",
+                    "maxLength": 32
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Information about the entity.",
+                    "maxLength": 2000
+                },
+                "webpageUrl": {
+                    "type": "object",
+                    "required": ["url"],
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Webpage with information about the entity.",
+                            "anyOf": [
+                                { "pattern": "^(https?://)" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        },
+                        "wellKnown": {
+                            "type": "string",
+                            "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                            "anyOf": [
+                                { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                { "pattern": "^$" }
+                            ],
+                            "maxLength": 250
+                        }
+                    }
+                }
+            }
+        },
+        "projects": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "description": "One or more projects for which the funding is solicited.",
+                "required": ["guid", "name", "description", "webpageUrl", "repositoryUrl", "licenses", "tags"],
+                "properties": {
+                    "guid": {
+                        "type": "string",
+                        "description": "A short unique ID for the project. Lowercase-alphanumeric-dashes only. eg: my-cool-project.",
+                        "anyOf": [
+                            { "pattern": "^[a-z0-9-]+$" },
+                            { "pattern": "^$" }
+                        ],
+                        "maxLength": 32
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the project.",
+                        "maxLength": 250
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the project.",
+                        "maxLength": 2000
+                    },
+                    "webpageUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "Webpage with information about the project.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should have the same hostname as the url to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "repositoryUrl": {
+                        "type": "object",
+                        "required": ["url"],
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "description": "URL of the repository where the project's source code and other assets are available.",
+                                "pattern": "^(https?://)",
+                                "maxLength": 250
+                            },
+                            "wellKnown": {
+                                "type": "string",
+                                "description": "Required if the above url and the URL of the funding.json manifest do not have the same hostname. This url should be a file in the repository to verify that the publisher of the manifest is authorised to solicit funding on behalf of the url. The url should end with /.well-known/funding-manifest-urls.",
+                                "anyOf": [
+                                    { "pattern": "^(https?://).*/\\.well-known/funding-manifest-urls$" },
+                                    { "pattern": "^$" }
+                                ],
+                                "maxLength": 250
+                            }
+                        }
+                    },
+                    "licenses": {
+                        "type": "array",
+                        "description": "The project's licenses (up to 5). For standard licenses, use the license ID from the SDPX index prefixed by \"spdx:\". eg: \"spdx:GPL-3.0\", \"spdx:CC-BY-SA-4.0\".",
+                        "maxItems": 5,
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tags": {
+                        "type": "array",
+                        "description": "Up to 10 general tags describing the project. For reference, see https://floss.fund/static/project-tags.txt.",
+                        "maxItems": 10,
+                        "items": {
+                            "type": "string",
+                            "pattern": "^[a-z0-9-]+$",
+                            "maxLength": 32
+                        }
+                    }
+                }
+            }
+        },
+        "funding": {
+            "type": "object",
+            "description": "This describes one or more channels via which the entity can receive funds.",
+            "required": ["channels", "plans"],
+            "properties": {
+                "channels": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "type"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the channel. Lowercase-alphanumeric-dashes only. eg: mybank, my-paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "type": {
+                                "type": "string",
+                                "description": "Type of the channel. [bank, payment-provider, cheque, cash, other].",
+                                "enum": ["bank", "payment-provider", "cheque", "cash", "other"]
+                            },
+                            "address": {
+                                "type": "string",
+                                "description": "A short unstructured textual representation of the payment address for the channel. eg: \"Account: 12345 (branch: ABCX)\", \"mypaypal@domain.com\", \"https://payment-url.com\", or a physical address for cheques.",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the payment channel.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                },
+                "plans": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["guid", "status", "name", "amount", "currency", "frequency", "channels"],
+                        "properties": {
+                            "guid": {
+                                "type": "string",
+                                "description": "A short unique ID for the plan. Lowercase-alphanumeric-dashes only. eg: mybank, paypal.",
+                                "pattern": "^[a-z0-9-]+$",
+                                "maxLength": 32
+                            },
+                            "status": {
+                                "type": "string",
+                                "description": "Indicates whether this plan is currently active or inactive. [active, inactive].",
+                                "enum": ["active", "inactive"]
+                            },
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the funding plan. eg: \"Starter support plan\", \"Infra hosting\", \"Monthly funding plan\".",
+                                "maxLength": 250
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description or instructions for the funding plan."
+                            },
+                            "amount": {
+                                "type": "number",
+                                "description": "The solicited amount for this plan. 0 is a wildcard that indicates \"any amount\"."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "frequency": {
+                                "type": "string",
+                                "description": "Frequency of the funding. [one-time, weekly, fortnightly, monthly, yearly, other]",
+                                "enum": ["one-time", "weekly", "fortnightly", "monthly", "yearly", "other"]
+                            },
+                            "channels": {
+                                "type": "array",
+                                "description": "One or more channel IDs defined in channels[] via which this plan can accept payments",
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z0-9-]+$",
+                                    "maxLength": 32
+                                }
+                            }
+                        }
+                    }
+                },
+                "history": {
+                    "type": "array",
+                    "description": "A simple summary of funding history. Only include if at least one, either income or expenses, have to be communicated.",
+                    "items": {
+                        "type": "object",
+                        "required": ["year", "currency"],
+                        "properties": {
+                            "year": {
+                                "type": "integer",
+                                "description": "Year (fiscal, preferably)."
+                            },
+                            "income": {
+                                "type": "number",
+                                "description": "Income for the year."
+                            },
+                            "expenses": {
+                                "type": "number",
+                                "description": "Expenses for the year."
+                            },
+                            "taxes": {
+                                "type": "number",
+                                "description": "Taxes for the year."
+                            },
+                            "currency": {
+                                "type": "string",
+                                "description": "Three letter ISO 4217 currency code. eg: USD, EUR.",
+                                "pattern": "^[A-Z]{3}$"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Any additional description.",
+                                "maxLength": 500
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/validate-funding.ts
+++ b/scripts/validate-funding.ts
@@ -1,0 +1,139 @@
+/**
+ * Validate the project's funding.json manifest.
+ *
+ * Checks:
+ * 1. Parses as strict JSON
+ * 2. Validates against the official funding.json v1.1.0 schema
+ * 3. Contact email is opensource@clarvia.org (project policy)
+ * 4. Repository URL points to clarvia-org/clarvia-graph (factual accuracy)
+ * 5. All URLs are well-formed https:// URLs
+ *
+ * SPDX-FileCopyrightText: 2025-2026 CLARVIA ASBL, Luxembourg
+ * SPDX-License-Identifier: EUPL-1.2
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import Ajv from "ajv";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const MANIFEST_PATH = resolve(ROOT, "funding.json");
+const SCHEMA_PATH = resolve(ROOT, "schemas", "funding-json-v1.1.0.json");
+
+const errors: string[] = [];
+
+function fail(msg: string): void {
+  errors.push(msg);
+  console.error(`  ✗ ${msg}`);
+}
+
+function pass(msg: string): void {
+  console.log(`  ✓ ${msg}`);
+}
+
+// ── 1. Parse JSON ──────────────────────────────────────────────────
+
+let manifest: Record<string, unknown>;
+try {
+  const raw = readFileSync(MANIFEST_PATH, "utf-8");
+  manifest = JSON.parse(raw) as Record<string, unknown>;
+  pass("Parses as valid JSON");
+} catch (err) {
+  fail(`Failed to parse funding.json: ${err}`);
+  process.exit(1);
+}
+
+// ── 2. Schema validation ───────────────────────────────────────────
+
+let schema: Record<string, unknown>;
+try {
+  schema = JSON.parse(readFileSync(SCHEMA_PATH, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+} catch (err) {
+  fail(`Failed to load schema: ${err}`);
+  process.exit(1);
+}
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+const valid = validate(manifest);
+
+if (valid) {
+  pass("Validates against funding.json v1.1.0 schema");
+} else {
+  for (const err of validate.errors ?? []) {
+    fail(`Schema: ${err.instancePath || "/"} ${err.message}`);
+  }
+}
+
+// ── 3. Project-policy checks ───────────────────────────────────────
+
+const entity = manifest.entity as Record<string, unknown> | undefined;
+if (entity) {
+  if (entity.email === "opensource@clarvia.org") {
+    pass("Contact email is opensource@clarvia.org");
+  } else {
+    fail(`Expected email opensource@clarvia.org, got: ${entity.email}`);
+  }
+}
+
+// ── 4. Repository URL check ────────────────────────────────────────
+
+const projects = manifest.projects as Array<Record<string, unknown>> | undefined;
+if (projects && projects.length > 0) {
+  const repoUrl = (projects[0].repositoryUrl as Record<string, unknown>)?.url;
+  if (
+    typeof repoUrl === "string" &&
+    repoUrl.includes("clarvia-org/clarvia-graph")
+  ) {
+    pass("Repository URL points to clarvia-org/clarvia-graph");
+  } else {
+    fail(`Expected repo URL containing clarvia-org/clarvia-graph, got: ${repoUrl}`);
+  }
+}
+
+// ── 5. URL well-formedness ─────────────────────────────────────────
+
+function collectUrls(obj: unknown, path = ""): Array<{ path: string; url: string }> {
+  const urls: Array<{ path: string; url: string }> = [];
+  if (obj && typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      const currentPath = path ? `${path}.${key}` : key;
+      if (
+        (key === "url" || key === "address" || key === "wellKnown") &&
+        typeof value === "string" &&
+        value.length > 0
+      ) {
+        urls.push({ path: currentPath, url: value });
+      }
+      if (typeof value === "object" && value !== null) {
+        urls.push(...collectUrls(value, currentPath));
+      }
+    }
+  }
+  return urls;
+}
+
+const urls = collectUrls(manifest);
+let allUrlsValid = true;
+for (const { path, url } of urls) {
+  if (!url.startsWith("https://")) {
+    fail(`URL at ${path} does not start with https://: ${url}`);
+    allUrlsValid = false;
+  }
+}
+if (allUrlsValid) {
+  pass(`All ${urls.length} URLs use https://`);
+}
+
+// ── Result ─────────────────────────────────────────────────────────
+
+console.log("");
+if (errors.length > 0) {
+  console.error(`funding.json validation failed with ${errors.length} error(s).`);
+  process.exit(1);
+} else {
+  console.log("funding.json validation passed.");
+}


### PR DESCRIPTION
Adds a funding.json manifest declaring Clarvia Graph's funding needs in a standard, machine-readable format (fundingjson.org v1.1.0 schema).

- `funding.json` — canonical manifest at repo root
- `scripts/validate-funding.ts` — schema + project-policy validation (funder-agnostic)
- `schemas/funding-json-v1.1.0.json` — vendored official schema for offline CI
- `package.json` — validate:funding script, ajv + tsx devDeps
- `.github/workflows/ci.yml` — funding validation step in validate-graph job
- `README.md` — Funding section added
- `REUSE.toml` — annotations for new files

Local validation passes. Website copy in clarvia-org/workflow-web#223.

Docs + config.