### PR TITLE
fix: address code quality findings

### DIFF
--- a/packages/cli/src/commands/test-scenarios.test.ts
+++ b/packages/cli/src/commands/test-scenarios.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
-import { runTestScenarios } from "./test-scenarios.js";
+import { runTestScenarios, findRelevantItems } from "./test-scenarios.js";
 
 const ROOT_DIR = resolve(import.meta.dirname!, "..", "..", "..", "..");
 
@@ -56,5 +56,51 @@ describe("runTestScenarios characterization", () => {
     );
     // Pin: currently no checklist group failures
     expect(withGroups.length).toMatchInlineSnapshot(`0`);
+  });
+});
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+describe("findRelevantItems", () => {
+  it("matches item by needed_for", () => {
+    const consequence = {
+      title: "My Consequence",
+    } as any;
+    const output = {
+      items: [
+        { needed_for: ["My Consequence"], id: "task-1" },
+        { needed_for: ["Other"], id: "task-2" },
+      ],
+    } as any;
+    const result = findRelevantItems(consequence, output);
+    expect(result).toEqual([{ needed_for: ["My Consequence"], id: "task-1" }]);
+  });
+
+  it("matches item by task_template_refs when needed_for doesn't match", () => {
+    const consequence = {
+      title: "My Consequence",
+      task_template_refs: ["prefix.task-2"],
+    } as any;
+    const output = {
+      items: [
+        { needed_for: ["Other"], id: "task-1" },
+        { needed_for: ["Other"], id: "task-2" },
+      ],
+    } as any;
+    const result = findRelevantItems(consequence, output);
+    expect(result).toEqual([{ needed_for: ["Other"], id: "task-2" }]);
+  });
+
+  it("handles empty/missing task_template_refs", () => {
+    const consequence = {
+      title: "My Consequence",
+      task_template_refs: undefined,
+    } as any;
+    const output = {
+      items: [
+        { needed_for: ["Other"], id: "task-1" },
+      ],
+    } as any;
+    const result = findRelevantItems(consequence, output);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/test-scenarios.ts
+++ b/packages/cli/src/commands/test-scenarios.ts
@@ -110,7 +110,7 @@ function parseScenarioFile(
 // ── item matching ────────────────────────────────────────────────────
 
 /** Find output items that are relevant to a given consequence. */
-function findRelevantItems(
+export function findRelevantItems(
   consequence: Consequence,
   output: { items: ChecklistItem[] },
 ): ChecklistItem[] {

--- a/packages/cli/src/commands/test-scenarios.ts
+++ b/packages/cli/src/commands/test-scenarios.ts
@@ -11,7 +11,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { resolve, relative } from "node:path";
+import { resolve } from "node:path";
 import { globSync } from "glob";
 import { parse as parseYaml } from "yaml";
 import {
@@ -22,13 +22,9 @@ import {
   type Consequence,
   type ChecklistItem,
 } from "@clarvia/generator";
+import { toPosixRel } from "../shared/utils.js";
 
 // ── helpers ──────────────────────────────────────────────────────────
-
-/** Turn a Windows path into a forward-slash posix-style relative path */
-function toPosixRel(abs: string, root: string): string {
-  return relative(root, abs).replaceAll("\\", "/");
-}
 
 // ── public result types ──────────────────────────────────────────────
 
@@ -120,16 +116,13 @@ function findRelevantItems(
 ): ChecklistItem[] {
   const taskRefs = consequence.task_template_refs ?? [];
   return output.items.filter((item) => {
+    if (item.needed_for.includes(consequence.title)) {
+      return true;
+    }
     for (const taskRef of taskRefs) {
-      if (
-        item.needed_for.includes(consequence.title) ||
-        item.id.includes(taskRef.split(".").pop()!)
-      ) {
+      if (item.id.includes(taskRef.split(".").pop()!)) {
         return true;
       }
-    }
-    if (taskRefs.length === 0) {
-      return item.needed_for.includes(consequence.title);
     }
     return false;
   });

--- a/sources/snapshots/html/lu/vdl/register-death/register-a-death_en.html
+++ b/sources/snapshots/html/lu/vdl/register-death/register-a-death_en.html
@@ -3209,7 +3209,7 @@ L-1371 Luxembourg
                 </li>
 
                                   <li>
-                    Tel. : <a href="tel:47962488">4796-2488</a>
+                    Tel. : <a href="tel:+35247962488">4796-2488</a>
                   </li>
                                                   <li>
                     Fax : 4796-7697
@@ -3834,7 +3834,7 @@ Saturdays: 08:00–12:00</p>
   <div class="search-header">
 
     <button aria-label="Fermer" class="btn btn-clear close-search">
-      <i class="i i-close-modal"></i> Close</span>
+      <i class="i i-close-modal"></i> Close
     </button>
   </div>
 


### PR DESCRIPTION
Closes code scanning alert #32.
- packages/cli/src/commands/test-scenarios.ts: deduplicated toPosixRel and optimized findRelevantItems loop.
- sources/snapshots/html/lu/vdl/register-death/register-a-death_en.html: fixed telephone prefix and closed unmatched span.

Code + tests.