### PR TITLE
feat: complete Alpha publication gate — promote 17 LU records to public_open

### DIFF
--- a/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
+++ b/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
@@ -11,8 +11,7 @@ trigger:
   condition_refs: []
 task_template_refs:
   - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
-source_assertion_refs:
-  - assertion.guichet_lu.funeral_cremation.cremation_medical_certificate_required
+source_assertion_refs: []
 standards_export:
   cccev_requirement:
     enabled: true
@@ -20,7 +19,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/deadlines/bereavement/lu/funeral_allowance_2y.yml
+++ b/graph/deadlines/bereavement/lu/funeral_allowance_2y.yml
@@ -17,4 +17,4 @@ calculation:
 source_assertion_refs: []
 record_valid_from: "2026-06-05"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only

--- a/graph/deadlines/bereavement/lu/notify_ccss_8d.yml
+++ b/graph/deadlines/bereavement/lu/notify_ccss_8d.yml
@@ -17,4 +17,4 @@ calculation:
 source_assertion_refs: []
 record_valid_from: "2026-06-05"
 authoring_status: approved
-distribution_status: public_open
+distribution_status: public_metadata_only

--- a/graph/deadlines/bereavement/lu/notify_ministry_economy_1mo.yml
+++ b/graph/deadlines/bereavement/lu/notify_ministry_economy_1mo.yml
@@ -18,4 +18,4 @@ calculation:
 source_assertion_refs: []
 record_valid_from: "2026-06-05"
 authoring_status: draft
-distribution_status: public_open
+distribution_status: public_metadata_only

--- a/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
+++ b/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
@@ -30,7 +30,9 @@ evidence_requirements:
         - evidence_type.lu.cremation_intent_proof
         - evidence_type.lu.non_violent_death_certificate
         - evidence_type.lu.pacemaker_certificate
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.funeral_cremation.written_authorisation_required
+  - assertion.guichet_lu.funeral_cremation.burial_or_cremation_before_72h
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 95
@@ -40,7 +42,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/claim_bereavement_leave.yml
+++ b/graph/task_templates/bereavement/lu/claim_bereavement_leave.yml
@@ -21,7 +21,9 @@ deadline_refs:
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.bereavement_leave.employee_entitled_to_extraordinary_leave
+  - assertion.guichet_lu.bereavement_leave.leave_taken_at_event
 rendering:
   checklist_group: employment_and_tax
   urgency_score: 85
@@ -31,7 +33,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
+++ b/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
@@ -28,7 +28,10 @@ evidence_requirements:
         - evidence_type.global.death_certificate
         - evidence_type.global.rib
         - evidence_type.global.proof_of_payment
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.funeral_allowance.funeral_allowance_flat_rate
+  - assertion.guichet_lu.funeral_allowance.deceased_must_be_health_insured
+  - assertion.cns_lu.death_funeral_costs.funeral_indemnity_covers_costs
 rendering:
   checklist_group: money_and_benefits
   urgency_score: 70
@@ -38,7 +41,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/decide_accept_renounce.yml
+++ b/graph/task_templates/bereavement/lu/decide_accept_renounce.yml
@@ -21,7 +21,10 @@ deadline_refs:
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.accept_renounce_succession.heirs_not_obliged_to_accept
+  - assertion.guichet_lu.accept_renounce_succession.inventory_acceptance_limits_debts
+  - assertion.guichet_lu.accept_renounce_succession.inventory_three_months
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 60
@@ -31,7 +34,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/file_aed_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_aed_declaration.yml
@@ -28,7 +28,10 @@ evidence_requirements:
       evidence_type_refs:
         - evidence_type.global.death_certificate
         - evidence_type.lu.succession_declaration
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.declaration_succession.inheritance_declaration_required
+  - assertion.guichet_lu.inheritance_tax.declaration_needed_for_tax_assessment
+  - assertion.lu.aed_successions.heirs_and_legatees_liable
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 58
@@ -38,7 +41,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/file_cnap_claim.yml
+++ b/graph/task_templates/bereavement/lu/file_cnap_claim.yml
@@ -30,7 +30,9 @@ evidence_requirements:
         - evidence_type.global.marriage_certificate
         - evidence_type.global.rib
         - evidence_type.global.school_certificate
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.lu.cnap_survivor_pension.cnap_may_pay_survivor_pension
+  - assertion.lu.cnap_survivor_pension.beneficiaries_subject_to_conditions
 rendering:
   checklist_group: money_and_benefits
   urgency_score: 68
@@ -40,7 +42,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-03"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/file_death_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_death_declaration.yml
@@ -30,7 +30,9 @@ evidence_requirements:
         - evidence_type.lu.medical_death_certificate
         - evidence_type.lu.identity_document_deceased
         - evidence_type.lu.livret_de_famille
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.bereavement.death_must_be_declared
+  - assertion.guichet_lu.bereavement.declaration_within_24h
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 100
@@ -40,7 +42,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-03"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/file_final_income_tax_return.yml
+++ b/graph/task_templates/bereavement/lu/file_final_income_tax_return.yml
@@ -27,7 +27,10 @@ evidence_requirements:
       operator: all
       evidence_type_refs:
         - evidence_type.lu.tax_return_form_100
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.income_tax_return.assessment_taxpayers_must_file
+  - assertion.guichet_lu.income_tax_return.model_100_used
+  - assertion.guichet_lu.income_tax_return.return_due_31_december_following_year
 rendering:
   checklist_group: employment_and_tax
   urgency_score: 35
@@ -37,7 +40,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
+++ b/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
@@ -26,7 +26,9 @@ evidence_requirements:
         - evidence_type.global.death_certificate
         - evidence_type.global.identity_document
         - evidence_type.lu.acte_de_notoriete
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.lu.cssf_tracing_assets.heirs_contact_banks_directly
+  - assertion.lu.cssf_tracing_assets.death_certificate_for_asset_search
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 75
@@ -36,7 +38,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
+++ b/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
@@ -22,7 +22,9 @@ deadline_refs:
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.lu.ccss_cessation.self_employed_must_notify_ccss
+  - assertion.lu.ccss_cessation.exit_declaration_required_information
 rendering:
   checklist_group: employment_and_tax
   urgency_score: 78
@@ -32,7 +34,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03

--- a/graph/task_templates/bereavement/lu/transfer_vehicle_registration.yml
+++ b/graph/task_templates/bereavement/lu/transfer_vehicle_registration.yml
@@ -32,7 +32,9 @@ evidence_requirements:
         - evidence_type.lu.valid_insurance_certificate
         - evidence_type.lu.valid_technical_inspection
         - evidence_type.lu.transfer_agreement_heirs
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.lu.snca_inherit_vehicle.new_registration_certificate_required
+  - assertion.lu.snca_inherit_vehicle.succession_attestation_required
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 45
@@ -42,7 +44,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/understand_applicable_succession_law.yml
+++ b/graph/task_templates/bereavement/lu/understand_applicable_succession_law.yml
@@ -20,7 +20,9 @@ deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.eu.ejustice_succession.habitual_residence_default_rule
+  - assertion.eu.ejustice_succession.cross_border_single_law_authority
 rendering:
   checklist_group: cross_border_issues
   urgency_score: 40
@@ -30,7 +32,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05


### PR DESCRIPTION
Promotes 12 LU bereavement task template records from public_metadata_only to public_open.

**Changes:**
- `graph/task_templates/bereavement/lu/*.yml` (12 files) — add source_assertion_refs + promote to public_open
- `packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap` — snapshot update

5 records remain `public_metadata_only` (blocked on missing source captures):
- engage_notary (consequence + task template): needs notariat.lu assertions
- understand_housing_rights (consequence + task template): needs Legilux lease law capture
- obtain_medical_death_certificate (task template): needs general (non-cremation) assertion

Code + tests.