### PR TITLE
fix: remove references to demoted/unbacked deadlines from public tasks

### DIFF
--- a/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
+++ b/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
@@ -16,8 +16,7 @@ target:
 authority_refs:
   - authority.lu.cns
 form_refs: []
-deadline_refs:
-  - deadline.lu.bereavement.health_insurance.funeral_allowance_2y
+deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets:

--- a/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
+++ b/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
@@ -17,8 +17,7 @@ authority_refs:
   - authority.lu.ccss
   - authority.lu.ministry_economy_business_permits
 form_refs: []
-deadline_refs:
-  - deadline.lu.bereavement.employment.notify_ccss_8d
+deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []

--- a/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
@@ -156,7 +156,7 @@ exports[`export-web characterization > produces runtime/bereavement.json with ex
     "consequence.lu.bereavement.succession.understand_applicable_succession_law",
     "consequence.lu.bereavement.survivor_pension.claim_survivor_pension",
   ],
-  "deadline_count": 9,
+  "deadline_count": 7,
   "evidence_type_count": 24,
   "task_template_count": 15,
   "task_template_ids": [

--- a/packages/cli/src/commands/check-anchors.test.ts
+++ b/packages/cli/src/commands/check-anchors.test.ts
@@ -84,6 +84,8 @@ describe("runCheckAnchors characterization", () => {
         "assertion.guichet_lu.inheritance_tax.duties_vary_by_relationship_and_assets",
         "assertion.guichet_lu.inheritance_tax.tax_due_six_weeks_after_request",
         "assertion.guichet_lu.inheritance_tax.two_inheritance_tax_categories",
+        "assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation",
+        "assertion.legilux_lu.bail_habitation.tenant_death_lease_termination",
         "assertion.lu.acd_form100.email_not_accepted",
         "assertion.lu.acd_form100.model_100_required_for_assessment",
         "assertion.lu.acd_form100.myguichet_online_filing_available",


### PR DESCRIPTION
Closes no issue (general cleanup).
graph/task_templates/bereavement/lu/claim_funeral_allowance.yml: Remove reference to demoted/unbacked funeral allowance 2-year deadline.
graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml: Remove reference to demoted/unbacked CCSS 8-day deadline.
packages/cli/src/commands/check-anchors.test.ts: Include missing assertions in test file.
packages/cli/src/commands/__snapshots__/export-web.test.ts.snap: Update export count snapshot.

Code + tests.