### PR TITLE
fix: remove references to demoted/unbacked deadlines from public tasks (re-opened)

### DIFF
--- a/graph/consequences/bereavement/lu/engage_notary.yml
+++ b/graph/consequences/bereavement/lu/engage_notary.yml
@@ -13,7 +13,9 @@ trigger:
   condition_refs: []
 task_template_refs:
   - task_template.lu.bereavement.succession.engage_notary
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.declaration_succession.notary_recommended
+  - assertion.guichet_lu.declaration_succession.wills_register_search
 standards_export:
   cccev_requirement:
     enabled: true
@@ -21,7 +23,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
+++ b/graph/consequences/bereavement/lu/obtain_medical_death_certificate.yml
@@ -11,7 +11,8 @@ trigger:
   condition_refs: []
 task_template_refs:
   - task_template.lu.bereavement.death_registration.obtain_medical_death_certificate
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.declaration_deces.medical_attestation_required
 standards_export:
   cccev_requirement:
     enabled: true
@@ -19,7 +20,7 @@ standards_export:
   cpsv_public_service:
     enabled: true
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/consequences/bereavement/lu/understand_housing_rights.yml
+++ b/graph/consequences/bereavement/lu/understand_housing_rights.yml
@@ -12,7 +12,9 @@ trigger:
     - condition.lu.bereavement.estate_assets.deceased_was_tenant
 task_template_refs:
   - task_template.lu.bereavement.estate_assets.understand_housing_rights
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation
+  - assertion.legilux_lu.bail_habitation.tenant_death_lease_termination
 standards_export:
   cccev_requirement:
     enabled: true
@@ -20,7 +22,7 @@ standards_export:
   cpsv_public_service:
     enabled: false
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 monitoring_status: unmonitored
 confidence: medium
 record_valid_from: "2026-06-05"

--- a/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
+++ b/graph/task_templates/bereavement/lu/claim_funeral_allowance.yml
@@ -16,8 +16,7 @@ target:
 authority_refs:
   - authority.lu.cns
 form_refs: []
-deadline_refs:
-  - deadline.lu.bereavement.health_insurance.funeral_allowance_2y
+deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets:

--- a/graph/task_templates/bereavement/lu/engage_notary.yml
+++ b/graph/task_templates/bereavement/lu/engage_notary.yml
@@ -30,7 +30,9 @@ evidence_requirements:
         - evidence_type.global.death_certificate
         - evidence_type.global.identity_document
         - evidence_type.lu.acte_de_notoriete
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.declaration_succession.notary_recommended
+  - assertion.guichet_lu.declaration_succession.wills_register_search
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 62
@@ -40,7 +42,7 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
   derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05

--- a/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
+++ b/graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml
@@ -17,8 +17,7 @@ authority_refs:
   - authority.lu.ccss
   - authority.lu.ministry_economy_business_permits
 form_refs: []
-deadline_refs:
-  - deadline.lu.bereavement.employment.notify_ccss_8d
+deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []

--- a/graph/task_templates/bereavement/lu/obtain_medical_death_certificate.yml
+++ b/graph/task_templates/bereavement/lu/obtain_medical_death_certificate.yml
@@ -19,7 +19,8 @@ deadline_refs: []
 evidence_requirements:
   satisfy_if: any_set_satisfied
   sets: []
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.guichet_lu.declaration_deces.medical_attestation_required
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 100
@@ -28,10 +29,10 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
-  derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03
+  derived_from_snapshot_ref: snapshot.guichet_lu.declaration_deces.2026_06_05
   extraction_method: ai_assisted
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"

--- a/graph/task_templates/bereavement/lu/understand_housing_rights.yml
+++ b/graph/task_templates/bereavement/lu/understand_housing_rights.yml
@@ -23,7 +23,9 @@ evidence_requirements:
       evidence_type_refs:
         - evidence_type.lu.proof_cohabitation
         - evidence_type.global.death_certificate
-source_assertion_refs: []
+source_assertion_refs:
+  - assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation
+  - assertion.legilux_lu.bail_habitation.tenant_death_lease_termination
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 55
@@ -33,10 +35,10 @@ dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
 authoring_status: approved
-distribution_status: public_metadata_only
+distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
-  derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05
+  derived_from_snapshot_ref: snapshot.legilux_lu.bail_habitation.consolide_20240801
   extraction_method: ai_assisted
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"

--- a/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
@@ -164,11 +164,32 @@ exports[`runCheckAnchors characterization > snapshots the full results array for
     "textQuote": "survivor's pension",
   },
   {
+    "assertionId": "assertion.guichet_lu.declaration_deces.medical_attestation_required",
+    "file": "sources/assertions/lu/guichet_lu/declaration_deces.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.declaration_deces.2026_06_05",
+    "textQuote": "le médecin établit une attestation médicale",
+  },
+  {
     "assertionId": "assertion.guichet_lu.declaration_succession.inheritance_declaration_required",
     "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
     "found": true,
     "snapshotId": "snapshot.guichet_lu.declaration_succession.2026_06_05",
     "textQuote": "déposée par écrit dans les 6 mois du décès",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.declaration_succession.notary_recommended",
+    "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.declaration_succession.2026_06_05",
+    "textQuote": "n’est pas obligatoire, mais fortement recommandée",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.declaration_succession.wills_register_search",
+    "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.declaration_succession.2026_06_05",
+    "textQuote": "recherche testamentaire dans le registre des dispositions de dernière volonté",
   },
   {
     "assertionId": "assertion.guichet_lu.funeral_allowance.allowance_amount_current_index",
@@ -295,6 +316,20 @@ exports[`runCheckAnchors characterization > snapshots the full results array for
     "found": true,
     "snapshotId": "snapshot.guichet_lu.inheritance_tax.2026_06_10",
     "textQuote": "2 catégories d’impôts sur les biens reçus en héritage",
+  },
+  {
+    "assertionId": "assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation",
+    "file": "sources/assertions/lu/legilux_lu/bail_habitation.yml",
+    "found": true,
+    "snapshotId": "snapshot.legilux_lu.bail_habitation.consolide_20240801",
+    "textQuote": "le contrat de bail continue",
+  },
+  {
+    "assertionId": "assertion.legilux_lu.bail_habitation.tenant_death_lease_termination",
+    "file": "sources/assertions/lu/legilux_lu/bail_habitation.yml",
+    "found": true,
+    "snapshotId": "snapshot.legilux_lu.bail_habitation.consolide_20240801",
+    "textQuote": "le contrat de bail est résilié de plein droit",
   },
   {
     "assertionId": "assertion.lu.acd_form100.email_not_accepted",

--- a/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
@@ -156,7 +156,7 @@ exports[`export-web characterization > produces runtime/bereavement.json with ex
     "consequence.lu.bereavement.succession.understand_applicable_succession_law",
     "consequence.lu.bereavement.survivor_pension.claim_survivor_pension",
   ],
-  "deadline_count": 9,
+  "deadline_count": 7,
   "evidence_type_count": 24,
   "task_template_count": 15,
   "task_template_ids": [

--- a/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
@@ -715,6 +715,11 @@ exports[`runValidate characterization against real graph > pins schema assignmen
     "valid": true,
   },
   {
+    "file": "sources/assertions/lu/guichet_lu/declaration_deces.yml",
+    "schema": "source_assertion.schema.json",
+    "valid": true,
+  },
+  {
     "file": "sources/assertions/lu/guichet_lu/declaration_succession.yml",
     "schema": "source_assertion.schema.json",
     "valid": true,
@@ -736,6 +741,11 @@ exports[`runValidate characterization against real graph > pins schema assignmen
   },
   {
     "file": "sources/assertions/lu/guichet_lu/inheritance_tax.yml",
+    "schema": "source_assertion.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/assertions/lu/legilux_lu/bail_habitation.yml",
     "schema": "source_assertion.schema.json",
     "valid": true,
   },
@@ -815,6 +825,11 @@ exports[`runValidate characterization against real graph > pins schema assignmen
     "valid": true,
   },
   {
+    "file": "sources/snapshots/guichet_lu_declaration_deces_2026_06_05.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
     "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
     "schema": "source_snapshot.schema.json",
     "valid": true,
@@ -841,6 +856,11 @@ exports[`runValidate characterization against real graph > pins schema assignmen
   },
   {
     "file": "sources/snapshots/guichet_lu_inheritance_tax_2026_06_10.yml",
+    "schema": "source_snapshot.schema.json",
+    "valid": true,
+  },
+  {
+    "file": "sources/snapshots/legilux_lu_bail_habitation_consolide_20240801.yml",
     "schema": "source_snapshot.schema.json",
     "valid": true,
   },
@@ -890,8 +910,8 @@ exports[`runValidate characterization against real graph > pins schema assignmen
 exports[`runValidate characterization against real graph > pins total file count and pass/fail breakdown 1`] = `
 {
   "invalid": 0,
-  "total": 176,
-  "valid": 176,
+  "total": 180,
+  "valid": 180,
 }
 `;
 
@@ -1036,6 +1056,11 @@ exports[`runValidate characterization against real graph > validates snapshot in
   },
   {
     "errorCount": 0,
+    "file": "sources/snapshots/legilux_lu_bail_habitation_consolide_20240801.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
     "file": "sources/snapshots/guichet_lu_inheritance_tax_2026_06_10.yml",
     "valid": true,
   },
@@ -1062,6 +1087,11 @@ exports[`runValidate characterization against real graph > validates snapshot in
   {
     "errorCount": 0,
     "file": "sources/snapshots/guichet_lu_declaration_succession_2026_06_05.yml",
+    "valid": true,
+  },
+  {
+    "errorCount": 0,
+    "file": "sources/snapshots/guichet_lu_declaration_deces_2026_06_05.yml",
     "valid": true,
   },
   {

--- a/packages/cli/src/commands/check-anchors.test.ts
+++ b/packages/cli/src/commands/check-anchors.test.ts
@@ -84,6 +84,8 @@ describe("runCheckAnchors characterization", () => {
         "assertion.guichet_lu.inheritance_tax.duties_vary_by_relationship_and_assets",
         "assertion.guichet_lu.inheritance_tax.tax_due_six_weeks_after_request",
         "assertion.guichet_lu.inheritance_tax.two_inheritance_tax_categories",
+        "assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation",
+        "assertion.legilux_lu.bail_habitation.tenant_death_lease_termination",
         "assertion.lu.acd_form100.email_not_accepted",
         "assertion.lu.acd_form100.model_100_required_for_assessment",
         "assertion.lu.acd_form100.myguichet_online_filing_available",

--- a/packages/cli/src/commands/check-anchors.test.ts
+++ b/packages/cli/src/commands/check-anchors.test.ts
@@ -17,7 +17,7 @@ describe("runCheckAnchors characterization", () => {
 
   it("pins the total result count", () => {
     // Will fail on first run — update with actual value
-    expect(results.length).toMatchInlineSnapshot(`77`);
+    expect(results.length).toMatchInlineSnapshot(`82`);
   });
 
   it("pins the error count", () => {
@@ -29,7 +29,7 @@ describe("runCheckAnchors characterization", () => {
     const notFound = results.filter((r) => !r.found).length;
     expect({ found, notFound }).toMatchInlineSnapshot(`
       {
-        "found": 77,
+        "found": 82,
         "notFound": 0,
       }
     `);
@@ -62,7 +62,10 @@ describe("runCheckAnchors characterization", () => {
         "assertion.guichet_lu.bereavement_leave.first_degree_relative_three_days",
         "assertion.guichet_lu.bereavement_leave.leave_taken_at_event",
         "assertion.guichet_lu.bereavement_leave.spouse_partner_death_three_days",
+        "assertion.guichet_lu.declaration_deces.medical_attestation_required",
         "assertion.guichet_lu.declaration_succession.inheritance_declaration_required",
+        "assertion.guichet_lu.declaration_succession.notary_recommended",
+        "assertion.guichet_lu.declaration_succession.wills_register_search",
         "assertion.guichet_lu.funeral_allowance.allowance_amount_current_index",
         "assertion.guichet_lu.funeral_allowance.death_certificate_extract_required",
         "assertion.guichet_lu.funeral_allowance.deceased_must_be_health_insured",

--- a/sources/assertions/lu/guichet_lu/declaration_deces.yml
+++ b/sources/assertions/lu/guichet_lu/declaration_deces.yml
@@ -1,0 +1,23 @@
+source_id: source.guichet_lu.declaration_deces
+source_snapshot_id: snapshot.guichet_lu.declaration_deces.2026_06_05
+assertions:
+  - id: assertion.guichet_lu.declaration_deces.medical_attestation_required
+    schema_version: "0.1.0"
+    claim_type: legal_rule
+    claim_text: >
+      Après le décès d'une personne, le médecin établit une attestation
+      médicale, dite déclaration de décès, retenant les causes du décès.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "le médecin établit une attestation médicale"
+    source_tier: official_guidance
+    record_valid_from: "2026-07-21"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-07-21T06:00:00Z"

--- a/sources/assertions/lu/guichet_lu/declaration_succession.yml
+++ b/sources/assertions/lu/guichet_lu/declaration_succession.yml
@@ -23,3 +23,44 @@ assertions:
     provenance:
       extraction_method: ai_assisted
       extracted_at: "2026-06-05T07:00:00Z"
+  - id: assertion.guichet_lu.declaration_succession.notary_recommended
+    schema_version: "0.1.0"
+    claim_type: official_guidance
+    claim_text: >
+      L'intervention d'un notaire pour la rédaction de la déclaration
+      n'est pas obligatoire, mais fortement recommandée, surtout dans
+      le cas d'une succession complexe.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: succession
+    anchor:
+      selector_type: text_quote
+      text_quote: "n\u2019est pas obligatoire, mais fortement recommand\u00e9e"
+    source_tier: official_guidance
+    record_valid_from: "2026-07-21"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-07-21T06:00:00Z"
+  - id: assertion.guichet_lu.declaration_succession.wills_register_search
+    schema_version: "0.1.0"
+    claim_type: official_guidance
+    claim_text: >
+      Les héritiers peuvent demander une recherche testamentaire dans
+      le registre des dispositions de dernière volonté auprès de l'AED.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: succession
+    anchor:
+      selector_type: text_quote
+      text_quote: "recherche testamentaire dans le registre des dispositions de dernière volonté"
+    source_tier: official_guidance
+    record_valid_from: "2026-07-21"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-07-21T06:00:00Z"

--- a/sources/assertions/lu/legilux_lu/bail_habitation.yml
+++ b/sources/assertions/lu/legilux_lu/bail_habitation.yml
@@ -1,0 +1,55 @@
+source_id: source.legilux_lu.bail_habitation
+source_snapshot_id: snapshot.legilux_lu.bail_habitation.consolide_20240801
+assertions:
+  - id: assertion.legilux_lu.bail_habitation.tenant_death_lease_continuation
+    schema_version: "0.1.0"
+    claim_type: legal_rule
+    claim_text: >
+      En cas de décès du locataire, le contrat de bail continue à durée
+      indéterminée au profit du conjoint survivant, au profit des descendants,
+      des ascendants ou du concubin, qui vivaient avec lui en communauté
+      domestique depuis au moins six mois à la date du décès et qui avaient
+      déclaré leur domicile à la commune dans le logement pendant cette période.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: housing
+    legal_pinpoint:
+      eli_uri: "http://data.legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1"
+      provision_ref:
+        article: "13"
+    anchor:
+      selector_type: text_quote
+      text_quote: "le contrat de bail continue"
+    source_tier: consolidated_legislation
+    record_valid_from: "2026-07-21"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-07-21T06:30:00Z"
+  - id: assertion.legilux_lu.bail_habitation.tenant_death_lease_termination
+    schema_version: "0.1.0"
+    claim_type: legal_rule
+    claim_text: >
+      A défaut de personnes remplissant les conditions prévues (conjoint,
+      descendants, ascendants, concubin cohabitant depuis 6 mois), le contrat
+      de bail est résilié de plein droit par le décès du locataire.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: housing
+    legal_pinpoint:
+      eli_uri: "http://data.legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1"
+      provision_ref:
+        article: "13"
+    anchor:
+      selector_type: text_quote
+      text_quote: "le contrat de bail est r\u00e9sili\u00e9 de plein droit"
+    source_tier: consolidated_legislation
+    record_valid_from: "2026-07-21"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: ai_assisted
+      extracted_at: "2026-07-21T06:30:00Z"

--- a/sources/register.yml
+++ b/sources/register.yml
@@ -277,3 +277,39 @@ sources:
     monitoring:
       active: false
     verified_at: null
+
+  - id: source.guichet_lu.declaration_deces
+    title: "Déclaration du décès d'un proche"
+    title_en: "Reporting the death of a loved one"
+    url: "https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/declaration-deces.html"
+    source_type: government_portal
+    jurisdiction: LU
+    publisher: "Guichet.lu (Luxembourg Government)"
+    languages: [fr]
+    domain: death_registration
+    life_event: bereavement
+    source_role: primary_guidance
+    monitoring:
+      active: false
+    verified_at: "2026-06-05"
+    verified_by: Talizdo
+
+  - id: source.legilux_lu.bail_habitation
+    title: "Loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation"
+    title_en: "Modified law of 21 September 2006 on residential leases"
+    url: "https://legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1/consolide/20240801"
+    eli_uri: "http://data.legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1"
+    source_type: legislation
+    jurisdiction: LU
+    publisher: "Service central de législation"
+    languages: [fr]
+    domain: housing
+    life_event: bereavement
+    source_role: primary_legislation
+    retrieval:
+      preferred_format: text/html
+      provider: legilux_casemates_filestore
+    monitoring:
+      active: false
+    verified_at: "2026-07-21"
+    verified_by: software.agent.v0.1

--- a/sources/snapshots/guichet_lu_declaration_deces_2026_06_05.yml
+++ b/sources/snapshots/guichet_lu_declaration_deces_2026_06_05.yml
@@ -1,0 +1,15 @@
+id: snapshot.guichet_lu.declaration_deces.2026_06_05
+schema_version: "0.1.0"
+source_id: source.guichet_lu.declaration_deces
+captured_at: "2026-06-05T18:37:16Z"
+capture_method: manual_download
+http_status: 200
+content_type: "text/html; charset=utf-8"
+content_hash: "sha256:3c8414302f0bbdca95a65c9797adc507713aca5d7ce3c33741ca57ac26c9fccc"
+archive_uri: "sources/snapshots/html/lu/guichet_lu/declaration-deces/declaration-deces_fr.html"
+page_url: "https://guichet.public.lu/fr/citoyens/sante/fin-vie/deces/declaration-deces.html"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2026-06-05"
+captured_by: contributor.Talizdo
+source_last_modified_at: null

--- a/sources/snapshots/html/lu/legilux_lu/bail-habitation/loi-2006-09-21-n1-consolide-20240801-fr.html
+++ b/sources/snapshots/html/lu/legilux_lu/bail-habitation/loi-2006-09-21-n1-consolide-20240801-fr.html
@@ -1,0 +1,1616 @@
+<?xml version="1.0" encoding="UTF-8"?><html xmlns="http://www.w3.org/1999/xhtml" xmlns:akoma="http://docs.oasis-open.org/legaldocml/ns/akn/3.0/CSD13" xmlns:scl="http://www.scl.lu" xmlns:m="http://www.w3.org/1998/Math/MathML"><head><meta xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions" content="text/html; charset=utf-8" http-equiv="content-type"/><meta xmlns:fo="http://www.w3.org/1999/XSL/Format" xmlns:axf="http://www.antennahouse.com/names/XSL/Extensions" content="" name="version"/><title>Journal officiel du Grand-Duché de Luxembourg</title><link rel="stylesheet" href="https://data.legilux.public.lu/resources/css/conso.css"/><link href="https://www.w3schools.com/w3css/4/w3.css" rel="stylesheet"/><link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"/><style id="legilux-styling">
+                    .img-center {
+                    display: flex;
+                    justify-content: center; /* centre horizontalement */
+                    align-items: center;     /* centre verticalement */
+                    }
+                </style></head><body class="rich-text rich-text-main"><p style="display: none;" aria-hidden="true">Le contenu de la version HTML du Journal officiel
+                            luxembourgeois est identique à la version PDF.
+                        </p><div style="margin-bottom:10px;" class="icon-bar__"><a onclick="toggleModsToc(document.getElementById('menuArrow'))" style="cursor:pointer;" href="#">
+                                    Visualiser la liste des modificateurs
+                                    <span style="text-decoration: none!important;">  </span><i class="fa fa-arrow-circle-right" id="menuArrow"> </i></a><br/><a onclick="toggleModsRef(document.getElementById('menuEye'))" style="cursor:pointer;" href="#">
+                                    Visualiser les informations de modifications
+                                    <span style="text-decoration: none!important;">  </span><i class="fa fa-eye" id="menuEye"> </i></a></div><div style="background: #eee; padding: 10px 15px; border-radius: 3px; margin-bottom: 20px; text-align: center;"><p style="font-size: 125%;"><b>Texte consolidé</b></p><br/><p>La consolidation consiste à intégrer dans un acte juridique ses modifications
+                                successives, elle a pour but d'améliorer la transparence du droit et de le rendre plus
+                                accessible.
+                            </p><br/><p><b>Ce texte consolidé a uniquement une <u>valeur documentaire</u>. Il importe de noter
+                                    qu’il n’a pas de valeur juridique.
+                                </b></p></div><div id="myModsTOC" style="display: none;"><div style="margin:25px 22px 50px 22px;"><p style="font-size: 125%; text-align: center;"><b>Liste des modificateurs</b></p><br/><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2008/10/22/n1/jo" style="cursor: pointer;">Loi du 22 octobre 2008 portant: 1. promotion de l'habitat et création d'un pacte logement avec les communes, 2. sur le droit d'emphytéose et le droit de superficie, 3. modification a) de la loi modifiée du 16 octobre 1934 concernant l'évaluation des biens et valeurs; b) de la loi modifiée du 1er décembre 1936 sur l'impôt foncier; c) de la loi modifiée du 25 février 1979 concernant l'aide au logement; d) de la loi modifiée du 10 décembre 1998 portant création de l'établissement public dénommé «Fonds d'assainissement de la Cité Syrdall»; e) de la loi modifiée du 30 juillet 2002 déterminant différentes mesures fiscales destinées à encourager la mise sur le marché et l'acquisition de terrains à bâtir et d'immeubles d'habitation; f) de la loi modifiée du 19 juillet 2004 concernant l'aménagement communal et le développement urbain; g) de la loi du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.</a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2015/09/02/n1/jo" style="cursor: pointer;">Loi du 2 septembre 2015 portant abolition des districts, modifiant 
+1. la loi communale modifiée du 13 décembre 1988; 
+2. le Code pénal; 
+3. la loi du 28 décembre 1883 concernant les associations syndicales pour l'exécution de travaux de drainage, d'irrigation, etc.; 
+4. la loi du 4 mars 1896, concernant l'expropriation par zône pour cause d'utilité publique; 
+5. la loi modifiée du 14 février 1955 concernant la réglementation de la circulation sur toutes les voies publiques; 
+6. la loi modifiée du 28 juin 1976 portant réglementation de la pêche dans les eaux intérieures; 
+7. la loi du 8 décembre 1981 sur les réquisitions en cas de conflit armé, de crise internationale grave ou de catastrophe; 
+8. la loi modifiée du 24 décembre 1985 fixant le statut général des fonctionnaires communaux; 
+9. la loi modifiée du 10 août 1993 relative aux parcs naturels; 
+10. la loi modifiée du 31 mai 1999 portant création d'un corps de police grand-ducale et d'une inspection générale de la police; 
+11. la loi du 23 février 2001 concernant les syndicats de communes; 
+12. la loi électorale modifiée du 18 février 2003; 
+13. la loi modifiée du 19 janvier 2004 concernant la protection de la nature et des re</a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2015/08/05/n3/jo" style="cursor: pointer;">Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.</a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_4" href="#mod_mod-start_pm5" style="cursor: pointer; display: none;">(
+                                                <sup>4</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_5" href="#mod_mod-start_pm6" style="cursor: pointer; display: none;">(
+                                                <sup>5</sup>
+                                                )
+                                            </a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2016/12/23/n11/jo" style="cursor: pointer;">Loi du 23 décembre 2016 portant mise en oeuvre de la réforme fiscale 2017 et portant modification  - de la loi modifiée du 4 décembre 1967 concernant l'impôt sur le revenu;  - de la loi modifiée du 16 octobre 1934 concernant l'mpôt sur la fortune;  - de la loi modifiée du 1er décembre 1936 concernant l'impôt commercial;  - de la loi modifiée du 24 décembre 1996 portant introduction d'une bonification d'impôt sur le revenu en cas d'embauchage de chômeurs;  - de la loi d'adaptation fiscale modifiée du 16 octobre 1934 («Steueranpassungsgesetz);  - de la loi générale des impôts modifiée du 22 mai 1931 («Abgabenordnung»);  - de la loi rectificative du 19 décembre 2014 concernant le budget des recettes et des dépenses de l'Etat pour l'exercice 2015;  - de la loi modifiée du 23 décembre 2005 portant introduction d'une retenue à la source libératoire sur certains intérêts produits par l'épargne mobilière;  - de la loi du 19 décembre 2008 ayant pour objet la coopération interadministrative et judiciaire et le renforcement des moyens de l'Administration des contributions directes, de l'Administration de l'enregistrement et des domaines, de l'Administration des douanes et accises et portant modification de  · la loi modifiée du 12 février 1979 concernant la taxe sur la valeur ajoutée; · la loi générale des impôts («Abgabenordnung»); · la loi modifiée du 17 avril 1964 portant réorganisation de l'Administration des contributions directes; · la loi modifiée du 20 mars 1970 portant réorganisation de l'Administration de l'enregistrement et des domaines; · la loi modifiée du 27 novembre 1933 concernant le recouvrement des contributions directes et des cotisations d'assurance sociale; - de la loi du 30 juillet 1983 portant création d'une taxe sur le loto; - de la loi modifiée du 12 février 1979 concernant la taxe sur la valeur ajoutée; - du Code pénal; - de la loi modifiée du 8 août 2000 sur l'entraide judiciaire internationale en matière pénale; - de la loi du 27 août 1997 portant approbation du Protocole additionnel à la Convention européenne d'entraide judiciaire en matière pénale, signé à Strasbourg, le 17 mars 1978; - de la loi du 27 juin 2016 concernant le soutien au développement durable; - de la loi modifiée du 22 frimaire an VII organique de l'enregistrement; - de la loi modifiée du 13 brumaire an VII organique du timbre; - de la loi modifiée du 27 décembre 1817 sur le droit de succession; - de la loi modifiée du 23 décembre 1913 concernant la révision de la législation qui régit les impôts dont le recouvrement est attribué à l'administration de l'enregistrement et des domaines; - de la loi modifiée du 7 août 1920, portant majoration des droits d'enregistrement, de timbre, de succession, etc.; - de la loi modifiée du 28 janvier 1948 tendant à assurer la juste et exacte perception des droits d'enregistrement et de succession; - de la loi modifiée du 13 juin 1984 portant révision de certaines dispositions législatives régissant la perception des droits d'enregistrement, de succession et de timbre; - de l'ordonnance royale grand-ducale du 23 septembre 1841 sur le timbre, l'enregistrement et les droits de succession; - de la loi modifiée du 19 juin 2013 relative à l'identification des personnes physiques; - de la loi modifiée du 25 février 1979 concernant l'aide au logement; - de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.</a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2017/08/02/a734/jo" style="cursor: pointer;">Loi du 2 août 2017 portant modification de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil.</a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_7" href="#mod_mod-start_pm8" style="cursor: pointer; display: none;">(
+                                                <sup>7</sup>
+                                                )
+                                            </a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2018/08/31/a823/jo" style="cursor: pointer;">Loi du 31 août 2018 1° du Code du travail ; 2° de la loi modifiée du 25 février 1979 concernant l'aide au logement ; 3° de la loi modifiée du 19 juillet 1991 portant création d'un Service de la formation des adultes et donnant un statut légal au Centre de langues Luxembourg ; 4° de la loi modifiée du 6 janvier 1996 sur la coopération au développement ; 5° de la loi modifiée du 31 mai 1999 portant création d'un fonds national de la recherche dans le secteur public ; 6° de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil ; 7° de la loi du 12 décembre 2016 portant création des sociétés d'impact sociétal.</a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_8" href="#mod_mod-start_pm9" style="cursor: pointer; display: none;">(
+                                                <sup>8</sup>
+                                                )
+                                            </a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2019/12/04/a907/jo" style="cursor: pointer;">Loi du 4 décembre 2019 portant création de l’Office national de l’accueil (ONA) et portant modification de : 1° la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° la loi modifiée du 16 décembre 2008 concernant l’intégration des étrangers au Grand-Duché de Luxembourg ; 3° la loi modifiée du 18 décembre 2015 relative à l’accueil des demandeurs de protection internationale et de protection temporaire. </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_9" href="#mod_mod-start_pm10" style="cursor: pointer; display: none;">(
+                                                <sup>9</sup>
+                                                )
+                                            </a></p><p class="richtext_p " style="padding-left:.6em; text-align: left;"><a target="_new" href="/eli/etat/leg/loi/2024/07/23/a311/jo" style="cursor: pointer;">Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil. </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_10" href="#mod_mod-start_pm11" style="cursor: pointer; display: none;">(
+                                                <sup>10</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_11" href="#mod_mod-start_pm12" style="cursor: pointer; display: none;">(
+                                                <sup>11</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_12" href="#mod_mod-start_pm13" style="cursor: pointer; display: none;">(
+                                                <sup>12</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_13" href="#mod_mod-start_pm14" style="cursor: pointer; display: none;">(
+                                                <sup>13</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_14" href="#mod_mod-start_pm15" style="cursor: pointer; display: none;">(
+                                                <sup>14</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_15" href="#mod_mod-start_pm16" style="cursor: pointer; display: none;">(
+                                                <sup>15</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_16" href="#mod_mod-start_pm17" style="cursor: pointer; display: none;">(
+                                                <sup>16</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_17" href="#mod_mod-start_pm18" style="cursor: pointer; display: none;">(
+                                                <sup>17</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_18" href="#mod_mod-start_pm19" style="cursor: pointer; display: none;">(
+                                                <sup>18</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_19" href="#mod_mod-start_pm20" style="cursor: pointer; display: none;">(
+                                                <sup>19</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_20" href="#mod_mod-start_pm21" style="cursor: pointer; display: none;">(
+                                                <sup>20</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_21" href="#mod_mod-start_pm22" style="cursor: pointer; display: none;">(
+                                                <sup>21</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_22" href="#mod_mod-start_pm23" style="cursor: pointer; display: none;">(
+                                                <sup>22</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_23" href="#mod_mod-start_pm24" style="cursor: pointer; display: none;">(
+                                                <sup>23</sup>
+                                                )
+                                            </a><span style="text-decoration: none!important;"> </span><a id="mod_toc_hand_24" href="#mod_mod-start_pm25" style="cursor: pointer; display: none;">(
+                                                <sup>24</sup>
+                                                )
+                                            </a></p><hr style="margin-top: 20px; margin-bottom: 20px; border: 0; border-top: 1px solid #eeeeee; display:block!important;"/></div></div><!--HTML generation v5.1. (13/11/2018)-->
+<div class="richtext_act  richtext_hierarchicalStructure">
+<h1 id="intituleAct" class="richtext_longTitle  richtext_h1">
+<p style="" class="richtext_p">Version consolidée applicable au 01/08/2024 : Loi du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil.</p>
+</h1><hr style="border: 0;height: 1px;background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));margin-top:15px;margin-bottom:15px;">​</hr><div id="toc" class="richtext_toc"><div style="margin-top:20px; display:block;"><a class="richtext_toc_link" href="#chapitre_ier_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre Ier.<span class="richtext_separatorheading">
+                    —
+                </span> Dispositions générales</div></a><a class="richtext_toc_link" href="#chapitre_ibis_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">
+Chapitre Ibis 
+<span class="richtext_separatorheading">
+                    —
+                </span> De la colocation</div></a><a class="richtext_toc_link" href="#chapitre_ii_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre II.<span class="richtext_separatorheading">
+                    —
+                </span> De la fixation du loyer et des charges</div></a><a class="richtext_toc_link" href="#chapitre_iii_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre III.<span class="richtext_separatorheading">
+                    —
+                </span> De la durée du contrat de bail</div></a><a class="richtext_toc_link" href="#chapitre_iv_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre IV.<span class="richtext_separatorheading">
+                    —
+                </span> De la protection des personnes condamnées à déguerpir de leur logement</div></a><a class="richtext_toc_link" href="#chapitre_v_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre V.<span class="richtext_separatorheading">
+                    —
+                </span> Du règlement des litiges</div></a><a class="richtext_toc_link" href="#chapitre_vi_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre VI.<span class="richtext_separatorheading">
+                    —
+                </span>Des missions incombant aux autorités communales</div></a><a class="richtext_toc_link" href="#chapitre_vii_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre VII.<span class="richtext_separatorheading">
+                    —
+                </span> Des mesures spéciales pour la sauvegarde des biens meubles des personnes condamnées à déguerpir</div></a><a class="richtext_toc_link" href="#chapitre_viii_heading">
+                            ​
+                            <div class="richtext_heading_toc_lvl1">Chapitre VIII.<span class="richtext_separatorheading">
+                    —
+                </span>Dispositions finales, abrogatoires et transitoires</div></a></div></div><hr style="border: 0;height: 1px;background-image: linear-gradient(to right, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75), rgba(0, 0, 0, 0));margin-top:15px;margin-bottom:15px;">​</hr>
+<div xmlns:xalan="http://xml.apache.org/xalan" xmlns:recueil="http://www.scl.lu/recueil" class="richtext_body  richtext_bodyType">
+<div id="chapitre_ier" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_ier">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_ier_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre I<sup class="richtext_sup richtext_inline">er</sup>. – Dispositions générales</span></p></div>
+
+
+<div id="art_1er" class="richtext_article" style=""><a style="color: black;" name="art_1er">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 1<sup class="richtext_sup richtext_inline">er</sup>.<span id="link_pm10"><span style="font-style: italic; display: none;" id="ref_text_art_1er"> (L du 04 décembre 2019)</span></span><span id="link_pm9"><span style="font-style: italic; display: none;" id="ref_text_art_1er"> (L du 31 août 2018)</span></span><span id="link_pm5"><span style="font-style: italic; display: none;" id="ref_text_art_1er"> (L du 05 août 2015)</span></span><span id="link_pm11"><span style="font-style: italic; display: none;" id="ref_text_art_1er"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">4</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_1" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Les baux à usage d’habitation sont régis par les articles 1713 à 1762-2 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> sous réserve des règles particulières instituées par la présente loi.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_2" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Sous réserve des dispositions des articles 16 à 18, la présente loi s’applique exclusivement à la location<span style="text-decoration: line-through; display: none;" id="mod_del_N104EB">
+<sup style="display: none;" id="mod_supStart_mod-start_pm11"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm11'); unHighlightMod('mod_mod-end_pm11'); unHighlightMod('link_pm11');" onmouseover="highlightMod('mod_mod-start_pm11'); highlightMod('mod_mod-end_pm11'); highlightMod('link_pm11');" id="mod_mod-start_pm11" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm11"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">10 &gt;</span></span></span>, par un contrat de bail écrit ou verbal</span>
+<span onmouseout="unHighlightMod('mod_mod-start_pm11'); unHighlightMod('mod_mod-end_pm11'); unHighlightMod('link_pm11');" onmouseover="highlightMod('mod_mod-start_pm11'); highlightMod('mod_mod-end_pm11'); highlightMod('link_pm11');" id="mod_mod-end_pm11" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm11"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">10 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm11"> </sup>
+, de logements à usage d’habitation à des personnes physiques, quelle que soit l’affectation stipulée dans le contrat de bail, sauf opposition justifiée par le bailleur en cas de réaffectation par le locataire en cours de contrat.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_3" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline"><sup style="display: none;" id="mod_supStart_mod-start_pm5"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm5'); unHighlightMod('mod_mod-end_pm5'); unHighlightMod('link_pm5');" onmouseover="highlightMod('mod_mod-start_pm5'); highlightMod('mod_mod-end_pm5'); highlightMod('link_pm5');" id="mod_mod-start_pm5" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil." id="mod_marker_start_mod-start_pm5"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.">4 &gt;</span></span></span>(3)</span>La loi ne s’applique pas: </p>
+<table width="100%" class="richtext_ol" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI">a)</td><td class="richtext_contentLI"><span class="richtext_li">aux immeubles affectés à un usage commercial, administratif, industriel, artisanal ou affectés à l’exercice d’une profession libérale;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">b)</td><td class="richtext_contentLI"><span class="richtext_li">aux résidences secondaires;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">c)</td><td class="richtext_contentLI"><span class="richtext_li">aux locaux ne formant pas l’accessoire du logement;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">d)</td><td class="richtext_contentLI"><span class="richtext_li">aux chambres d’hôtel;<sup style="display: none;" id="mod_supStart_mod-start_pm10"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm10'); unHighlightMod('mod_mod-end_pm10'); unHighlightMod('link_pm10');" onmouseover="highlightMod('mod_mod-start_pm10'); highlightMod('mod_mod-end_pm10'); highlightMod('link_pm10');" id="mod_mod-start_pm10" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 4 décembre 2019 portant création de l’Office national de l’accueil (ONA) et portant modification de : 1° la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° la loi modifiée du 16 décembre 2008 concernant l’intégration des étrangers au Grand-Duché de Luxembourg ; 3° la loi modifiée du 18 décembre 2015 relative à l’accueil des demandeurs de protection internationale et de protection temporaire." id="mod_marker_start_mod-start_pm10"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 4 décembre 2019 portant création de l’Office national de l’accueil (ONA) et portant modification de : 1° la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° la loi modifiée du 16 décembre 2008 concernant l’intégration des étrangers au Grand-Duché de Luxembourg ; 3° la loi modifiée du 18 décembre 2015 relative à l’accueil des demandeurs de protection internationale et de protection temporaire.">9 &gt;</span></span></span>
+</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">e)</td><td class="richtext_contentLI"><span class="richtext_li">aux structures d’hébergement réservées au logement provisoire de demandeurs de protection internationale, de réfugiés et de personnes pouvant bénéficier de la protection subsidiaire visés par la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2015/12/18/n15/jo" target="new">loi du 18 décembre 2015</a> relative à la protection internationale et à la protection temporaire ;<span onmouseout="unHighlightMod('mod_mod-start_pm10'); unHighlightMod('mod_mod-end_pm10'); unHighlightMod('link_pm10');" onmouseover="highlightMod('mod_mod-start_pm10'); highlightMod('mod_mod-end_pm10'); highlightMod('link_pm10');" id="mod_mod-end_pm10" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 4 décembre 2019 portant création de l’Office national de l’accueil (ONA) et portant modification de : 1° la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° la loi modifiée du 16 décembre 2008 concernant l’intégration des étrangers au Grand-Duché de Luxembourg ; 3° la loi modifiée du 18 décembre 2015 relative à l’accueil des demandeurs de protection internationale et de protection temporaire." id="mod_marker_end_mod-end_pm10"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 4 décembre 2019 portant création de l’Office national de l’accueil (ONA) et portant modification de : 1° la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° la loi modifiée du 16 décembre 2008 concernant l’intégration des étrangers au Grand-Duché de Luxembourg ; 3° la loi modifiée du 18 décembre 2015 relative à l’accueil des demandeurs de protection internationale et de protection temporaire.">9 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm10"> </sup>
+
+</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">f)</td><td class="richtext_contentLI"><span class="richtext_li">aux logements meublés ou non-meublés dans des structures d’hébergement spéciales telles que maisons de retraite, centres intégrés pour personnes âgées, centres de gériatrie, centres pour personnes handicapées, et notamment les logements meublés ou non-meublés dans les structures d’hébergement tombant sous la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1998/09/08/n4" target="new">loi modifiée du 8 septembre 1998</a> réglant les relations entre l’Etat et les organismes œuvrant dans les domaines social, familial et thérapeutique;<sup style="display: none;" id="mod_supStart_mod-start_pm9"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm9'); unHighlightMod('mod_mod-end_pm9'); unHighlightMod('link_pm9');" onmouseover="highlightMod('mod_mod-start_pm9'); highlightMod('mod_mod-end_pm9'); highlightMod('link_pm9');" id="mod_mod-start_pm9" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 31 août 2018 1° du Code du travail ; 2° de la loi modifiée du 25 février 1979 concernant l'aide au logement ; 3° de la loi modifiée du 19 juillet 1991 portant création d'un Service de la formation des adultes et donnant un statut légal au Centre de langues Luxembourg ; 4° de la loi modifiée du 6 janvier 1996 sur la coopération au développement ; 5° de la loi modifiée du 31 mai 1999 portant création d'un fonds national de la recherche dans le secteur public ; 6° de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil ; 7° de la loi du 12 décembre 2016 portant création des sociétés d'impact sociétal." id="mod_marker_start_mod-start_pm9"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 31 août 2018 1° du Code du travail ; 2° de la loi modifiée du 25 février 1979 concernant l'aide au logement ; 3° de la loi modifiée du 19 juillet 1991 portant création d'un Service de la formation des adultes et donnant un statut légal au Centre de langues Luxembourg ; 4° de la loi modifiée du 6 janvier 1996 sur la coopération au développement ; 5° de la loi modifiée du 31 mai 1999 portant création d'un fonds national de la recherche dans le secteur public ; 6° de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil ; 7° de la loi du 12 décembre 2016 portant création des sociétés d'impact sociétal.">8 &gt;</span></span></span>
+</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">g)</td><td class="richtext_contentLI"><span class="richtext_li">aux logements meublés ou non-meublés mis à disposition de personnes physiques à titre d’aide sociale par un promoteur public au sens de l’article 16, alinéa 1<sup class="richtext_sup richtext_inline">er</sup> , de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1979/02/25/n3/jo" target="new">loi modifiée du 25 février 1979</a> concernant l’aide au logement, un office social, une association sans but lucratif, une fondation ou une socié té d’impact socié tal régie par la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2016/12/12/n1/jo" target="new">loi modifiée du 12 décembre 2016</a> portant création des sociétés d’impact socié tal et dont le capital social est constitué à 100 pour cent de parts d’impact, œuvrant dans le domaine du logement.<span onmouseout="unHighlightMod('mod_mod-start_pm9'); unHighlightMod('mod_mod-end_pm9'); unHighlightMod('link_pm9');" onmouseover="highlightMod('mod_mod-start_pm9'); highlightMod('mod_mod-end_pm9'); highlightMod('link_pm9');" id="mod_mod-end_pm9" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 31 août 2018 1° du Code du travail ; 2° de la loi modifiée du 25 février 1979 concernant l'aide au logement ; 3° de la loi modifiée du 19 juillet 1991 portant création d'un Service de la formation des adultes et donnant un statut légal au Centre de langues Luxembourg ; 4° de la loi modifiée du 6 janvier 1996 sur la coopération au développement ; 5° de la loi modifiée du 31 mai 1999 portant création d'un fonds national de la recherche dans le secteur public ; 6° de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil ; 7° de la loi du 12 décembre 2016 portant création des sociétés d'impact sociétal." id="mod_marker_end_mod-end_pm9"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 31 août 2018 1° du Code du travail ; 2° de la loi modifiée du 25 février 1979 concernant l'aide au logement ; 3° de la loi modifiée du 19 juillet 1991 portant création d'un Service de la formation des adultes et donnant un statut légal au Centre de langues Luxembourg ; 4° de la loi modifiée du 6 janvier 1996 sur la coopération au développement ; 5° de la loi modifiée du 31 mai 1999 portant création d'un fonds national de la recherche dans le secteur public ; 6° de la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil ; 7° de la loi du 12 décembre 2016 portant création des sociétés d'impact sociétal.">8 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm9"> </sup>
+
+</span></td></tr></table>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Toutefois, pour les immeubles visés au point a), les dispositions prévues par le chapitre V concernant le règlement des litiges et celles prévues par le chapitre VIII concernant les dispositions finales, abrogatoires et transitoires sont applicables. Pour les structures d’hébergement et logements visés aux points e), et g), les dispositions prévues par le chapitre V concernant le règlement des litiges sont applicables.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les articles 3 à 11 et 15 ne s’appliquent pas aux logements locatifs prévus par les articles 27 à 30ter de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1979/02/25/n3" target="new">loi modifiée du 25 février 1979</a> concernant l’aide au logement. Toutefois, ils sont applicables aux logements locatifs désignés à l’article 28, alinéa 4, de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1979/02/25/n3/jo" target="new">loi modifiée du 25 février 1979</a> concernant l’aide au logement.<span onmouseout="unHighlightMod('mod_mod-start_pm5'); unHighlightMod('mod_mod-end_pm5'); unHighlightMod('link_pm5');" onmouseover="highlightMod('mod_mod-start_pm5'); highlightMod('mod_mod-end_pm5'); highlightMod('link_pm5');" id="mod_mod-end_pm5" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil." id="mod_marker_end_mod-end_pm5"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.">4 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm5"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="art_2" class="richtext_article" style=""><a style="color: black;" name="art_2">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Toute cession de bail portant sur des baux à usage d’habitation n’est interdite qu’en cas de stipulation contractuelle expresse dans le contrat de bail.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les dispositions des articles 3 à 11 s’appliquent également aux relations entre locataires principaux et sous<span style="font-weight: normal; font-style: normal;">-</span>locataires ou cessionnaires.</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_ibis" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_ibis">​</a><div style="font-size: 120%;font-weight: bold!important;" class="richtext_heading_chapter" id="chapitre_ibis_heading"><p style="font-size: 120%;font-weight: bold!important;"><span style="font-size: 120%;font-weight: bold!important;"><sup style="display: none;" id="mod_supStart_mod-start_pm12"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm12'); unHighlightMod('mod_mod-end_pm12'); unHighlightMod('link_pm12');" onmouseover="highlightMod('mod_mod-start_pm12'); highlightMod('mod_mod-end_pm12'); highlightMod('link_pm12');" id="mod_mod-start_pm12" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm12"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">11 &gt;</span></span></span>Chapitre I<i class="richtext_i richtext_inline">bis</i>-De la colocation</span></p></div>
+
+
+<div id="art_2bis" class="richtext_article" style=""><a style="color: black;" name="art_2bis">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2<i class="richtext_i richtext_inline">bis</i>.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La colocation désigne la location d’un même logement par plusieurs locataires, appelés colocataires, qui optent, avec l’accord exprès du bailleur, pour l’application des règles spécifiques de la colocation en signant au plus tard à la date de signature du contrat de bail un pacte de colocation tel que prévu par l’article 2<i class="richtext_i richtext_inline">ter</i>, et est formalisée par la conclusion par écrit d’un contrat de bail unique entre les locataires et le bailleur, dans lequel la date de signature dudit pacte est reprise. Le logement pris en location comprend au minimum une pièce d’habitation ou un local sanitaire qui soit commun à tous les colocataires.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La location consentie exclusivement à des époux ou à des partenaires liés par un partenariat tel que prévu par la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2004/07/09/n3/jo" target="new">loi modifiée du 9 juillet 2004</a> relative aux effets légaux de certains partenariats n’est pas à considérer comme une colocation.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les dispositions prévues par le présent chapitre sont d’ordre public.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Une colocation peut également être conclue si le bailleur habite lui-même dans l’immeuble dont une partie est mise en location via un contrat de bail. Dans cette hypothèse, le bailleur occupant, qui n’est pas lui-même un colocataire, indique dans le contrat de bail le montant de sa part dans les frais de la vie en colocation.</p>
+
+</div>
+</div>
+<div id="art_2ter" class="richtext_article" style=""><a style="color: black;" name="art_2ter">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2<i class="richtext_i richtext_inline">ter</i>.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_53" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Les colocataires établissent par écrit un pacte de colocation afin de formaliser les aspects de la vie en communauté et les modalités pratiques de cette forme de location.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_54" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Le pacte prévoit des dispositions réglant au minimum les points suivants :</p>
+<table width="100%" class="richtext_ol" style="margin-top: -2pt!important;width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI">1°</td><td class="richtext_contentLI"><span class="richtext_li">la répartition du loyer entre colocataires lorsque celle-ci n’est pas prévue par le contrat de bail ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">2°</td><td class="richtext_contentLI"><span class="richtext_li"> la répartition des charges communes entre colocataires ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">3°</td><td class="richtext_contentLI"><span class="richtext_li"> l’inventaire des biens meubles précisant leur propriétaire ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">4°</td><td class="richtext_contentLI"><span class="richtext_li"> les modalités de conclusion des contrats d’approvisionnement et d’assurance relatifs au bien loué ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">5°</td><td class="richtext_contentLI"><span class="richtext_li"> les modalités d’arrivée, de départ et de remplacement d’un colocataire, y compris la forme de notification du congé aux autres colocataires ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">6°</td><td class="richtext_contentLI"><span class="richtext_li"> les conditions de constitution et de récupération de la garantie locative ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">7°</td><td class="richtext_contentLI"><span class="richtext_li"> les modalités de résolution des conflits entre les colocataires.</span></td></tr></table>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le pacte prévoit en outre l’obligation de procéder à un état des lieux intermédiaire lors du départ anticipé d’un colocataire afin de déterminer les responsabilités de chacun et de ventiler les frais de réparation locative.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_55" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>En cas de départ anticipé d’un colocataire, une adaptation du pacte est signée par les autres colocataires.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">À l’arrivée d’un nouveau colocataire, celui-ci signe un avenant au pacte de colocation conjointement avec les autres colocataires.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_56" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Les obligations découlant du contrat de bail pour lequel ledit pacte ne prévoit pas leur répartition entre les différents colocataires sont à répartir à parts égales entre les différents colocataires.</p>
+
+</div>
+</div>
+</div>
+<div id="art_2quater" class="richtext_article" style=""><a style="color: black;" name="art_2quater">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2<i class="richtext_i richtext_inline">quater</i>.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les colocataires sont tenus solidairement vis-à-vis du bailleur des obligations qui résultent du contrat de bail.</p>
+
+</div>
+</div>
+<div id="art_2quinquies" class="richtext_article" style=""><a style="color: black;" name="art_2quinquies">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2<i class="richtext_i richtext_inline">quinquies</i>.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_57" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Lorsque l’ensemble des colocataires mettent fin au bail en même temps, le congé est signé par chacun d’entre eux et notifié au bailleur par lettre recommandée avec avis de réception. Le délai de résiliation est de trois mois.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_58" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Lorsqu’un colocataire souhaite se libérer de ses obligations avant le terme du bail, il le notifie simultanément au bailleur et à ses colocataires moyennant un préavis de trois mois. La notification au bailleur est faite par lettre recommandée avec avis de réception.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Ce colocataire est tenu, avant l’expiration de son préavis, de chercher un colocataire remplaçant, selon les modalités définies dans le pacte de colocation visé à l’article 2<i class="richtext_i richtext_inline">ter</i>. Les autres colocataires ou le bailleur peuvent également proposer un candidat remplaçant. À défaut d’avoir présenté un candidat remplaçant, le colocataire sortant doit pouvoir démontrer avoir effectué une recherche active et suffisante en vue de trouver un nouveau colocataire. La publication dans la quinzaine du début du préavis d’une annonce en vue de la recherche d’un colocataire remplaçant dans deux médias publiant des offres immobilières relatives au marché luxembourgeois est à considérer comme une recherche active et suffisante au sens du présent article.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_59" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Lorsque l’ensemble des parties marquent leur accord sur un nouveau colocataire, elles signent conjointement avec ce dernier un avenant au contrat de bail initial.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_60" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Lorsqu’au moins la moitié des colocataires signataires du bail ont donné leur congé dans un intervalle de trois mois, le bailleur peut mettre fin au contrat de bail dans un délai d’un mois à partir de la notification du dernier congé d’un colocataire concerné, et ce moyennant un délai de résiliation de trois mois, par lettre recommandée avec avis de réception, adressée à chaque colocataire.</p>
+
+</div>
+</div>
+</div>
+<div id="art_2sexies" class="richtext_article" style=""><a style="color: black;" name="art_2sexies">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 2<i class="richtext_i richtext_inline">sexies</i>.<span id="link_pm12"><span style="font-style: italic; display: none;" id="ref_text_art_2sexies"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le colocataire sortant est délié pour le futur de ses obligations résultant du contrat de bail ou du pacte de colocation :</p>
+<table width="100%" class="richtext_ol" style="margin-top: -2pt!important;width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI">1°</td><td class="richtext_contentLI"><span class="richtext_li">à la date de signature de l’avenant visé à l’article 2<i class="richtext_i richtext_inline">quinquies</i>, paragraphe 3 ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">2°</td><td class="richtext_contentLI"><span class="richtext_li"> à la date d’expiration du préavis de trois mois sous condition qu’il a démontré avoir effectué une recherche active et suffisante au sens de l’article 2<i class="richtext_i richtext_inline">quinquies</i>, paragraphe 2, alinéa 2 ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">3°</td><td class="richtext_contentLI"><span class="richtext_li"> ou au plus tard à l’expiration d’un délai de trois mois après la date d’expiration du préavis.</span></td></tr></table>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="margin-bottom: -10pt;" class="richtext_p  richtext_p">L’engagement de la personne qui s’est portée initialement caution pour le colocataire sortant s’éteint à la même date.<span onmouseout="unHighlightMod('mod_mod-start_pm12'); unHighlightMod('mod_mod-end_pm12'); unHighlightMod('link_pm12');" onmouseover="highlightMod('mod_mod-start_pm12'); highlightMod('mod_mod-end_pm12'); highlightMod('link_pm12');" id="mod_mod-end_pm12" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm12"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">11 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm12"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_ii" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_ii">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_ii_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre II. – De la fixation du loyer et des charges</span></p></div>
+
+
+<div id="art_3" class="richtext_article" style=""><a style="color: black;" name="art_3">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 3.<span id="link_pm13"><span id="link_pm14"><span style="font-style: italic; display: none;" id="ref_text_art_3"> (L du 23 juillet 2024)</span></span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">2</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_4" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>La location d’un logement à usage d’habitation ne peut rapporter au bailleur un revenu annuel dépassant un taux de 5 % du capital investi dans le logement.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">
+<sup style="display: none;" id="mod_supStart_mod-start_pm13"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm13'); unHighlightMod('mod_mod-end_pm13'); unHighlightMod('link_pm13');" onmouseover="highlightMod('mod_mod-start_pm13'); highlightMod('mod_mod-end_pm13'); highlightMod('link_pm13');" id="mod_mod-start_pm13" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm13"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">12 &gt;</span></span></span>Le montant de la somme des loyers perçus pour un logement de l’ensemble des colocataires conformément au chapitre I<i class="richtext_i richtext_inline">bis</i> ne peut être supérieur au montant du loyer maximal déterminé conformément à l’alinéa 1<sup class="richtext_sup richtext_inline">er</sup>.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le montant de la somme des loyers payés par les locataires dans le cadre d’une location à baux multiples d’un immeuble ou d’une partie d’immeuble comprenant deux ou plusieurs chambres ou logements loués individuellement à des locataires indépendants les uns des autres ne peut être supérieur à la limite du loyer annuel maximal prévu à l’alinéa 1<sup class="richtext_sup richtext_inline">er</sup>.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Dans le cas d’un logement meublé, le bailleur peut demander chaque mois, en plus du loyer proprement dit, un supplément de loyer pour le mobilier. Ce supplément de loyer, qui est indiqué séparément du loyer dans le contrat de bail, ne peut dépasser 1,5 pour cent du montant total des factures des meubles garnissant le logement loué. Uniquement les meubles dont les factures datent de moins de dix ans au jour de la conclusion du bail ou de l’adaptation du loyer peuvent être pris en considération pour ce supplément.<span onmouseout="unHighlightMod('mod_mod-start_pm13'); unHighlightMod('mod_mod-end_pm13'); unHighlightMod('link_pm13');" onmouseover="highlightMod('mod_mod-start_pm13'); highlightMod('mod_mod-end_pm13'); highlightMod('link_pm13');" id="mod_mod-end_pm13" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm13"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">12 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm13"> </sup>
+
+</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_5" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>A défaut d’accord entre parties, le capital investi est celui engagé:</p>
+<table width="100%" class="richtext_ul" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">dans la construction initiale du logement et de ses dépendances telles que garages, emplacements de stationnement, jardin, grenier et cave, qui sont mis à la disposition du locataire et dont le coût est établi au jour de leur achèvement;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">dans les travaux d’amélioration, dont le coût est établi au jour de l’achèvement des travaux, lesquels ne peuvent comporter des réparations locatives ou de menu entretien;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">dans le terrain sur lequel l’habitation est sise, dont le coût est fixé à celui du jour de son acquisition; le prix du terrain peut toutefois également être fixé forfaitairement par le bailleur à 20 % du capital investi.</span></td></tr></table>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_6" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Ce capital investi est réévalué au jour de la conclusion du bail ou au jour de l’adaptation du loyer par multiplication avec le coefficient correspondant du tableau des coefficients de réévaluation prévus par l’article 102, alinéa 6, de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1967/12/04/n1/jo" target="new">loi modifiée du 4 décembre 1967</a> concernant l’impôt sur le revenu.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Si la construction du logement remonte à quinze ans ou plus, le capital investi réévalué déterminé d’après les modalités formulées ci-avant, à l’exception du prix du terrain sur lequel l’habitation est construite, frais de l’acte compris, qui ne sont pas pris en compte pour le calcul de la décote, est diminué de 2 % par période de deux années supplémentaires, à moins que le bailleur ne prouve avoir investi des frais équivalents dans l’entretien ou la réparation du logement. Ces frais sont également réévalués selon les modalités prévues par l’alinéa 1<sup class="richtext_sup richtext_inline">er</sup>. Au cas où les frais investis n’atteignent pas le montant correspondant de la décote, ils sont compensés avec la décote. Au cas où ils excèdent la décote opérée, ils sont reportés sur les décotes ultérieures.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_7" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Dans le cas où le capital investi défini ci-avant ne peut pas être déterminé sur base de pièces justificatives et s’il y a désaccord entre le bailleur et le locataire sur le montant du loyer, la partie la plus diligente chargera un expert assermenté en bâtiment qui procédera à l’évaluation du capital investi, réévalué et décoté.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Toutefois, en cas d’aliénation à titre onéreux, le prix d’acquisition indiqué dans l’acte authentique translatif de propriété, et les frais de l’acte, sont présumés correspondre au jour de la signature de l’acte au capital investi, réévalué et décoté.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Dans le cas où la prédite évaluation ou la présomption prévue à l’alinéa 2 est contestée par la partie qui aura prouvé qu’elle ne saurait manifestement correspondre à la valeur marchande comparable, sans pour autant que cette partie ne puisse établir le véritable capital investi, la commission des loyers, saisie conformément à l’article 8, détermine le capital investi compte tenu de la valeur du terrain, du volume de l’immeuble loué, de la surface louée, de la qualité de l’équipement, de l’état d’entretien ou de réparation du logement, et de la finition du logement.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_8" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline"><sup style="display: none;" id="mod_supStart_mod-start_pm14"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm14'); unHighlightMod('mod_mod-end_pm14'); unHighlightMod('link_pm14');" onmouseover="highlightMod('mod_mod-start_pm14'); highlightMod('mod_mod-end_pm14'); highlightMod('link_pm14');" id="mod_mod-start_pm14" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm14"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">13 &gt;</span></span></span>(5)</span>Le loyer ou le supplément de loyer pour le mobilier de tout logement à usage d’habitation, fixés en vertu des dispositions qui précèdent du présent article, soit de l’accord des parties, soit par la commission des loyers, soit judiciairement, ne peuvent faire l’objet d’une adaptation que tous les deux ans.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Cette période de deux ans ne prend pas fin par suite d’un changement de bailleur. Elle prend fin de plein droit s’il y a changement de locataire sans préjudice des dispositions de l’article 13, alinéa 1<sup class="richtext_sup richtext_inline">er</sup>.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">La hausse du loyer ne peut pas dépasser 10 pour cent. Si, en cas d’une augmentation du loyer de plus de 10 pour cent, le locataire adresse une réclamation par lettre recommandée au bailleur, la part du loyer dépassant la hausse de 10 pour cent n’est pas due à partir du premier terme suivant la date de cette réclamation.<span onmouseout="unHighlightMod('mod_mod-start_pm14'); unHighlightMod('mod_mod-end_pm14'); unHighlightMod('link_pm14');" onmouseover="highlightMod('mod_mod-start_pm14'); highlightMod('mod_mod-end_pm14'); highlightMod('link_pm14');" id="mod_mod-end_pm14" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm14"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">13 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm14"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="art_4" class="richtext_article" style=""><a style="color: black;" name="art_4">​</a><p class=" richtext_num_article richtext_inline" style=""><sup style="display: none;" id="mod_supStart_mod-start_pm15"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm15'); unHighlightMod('mod_mod-end_pm15'); unHighlightMod('link_pm15');" onmouseover="highlightMod('mod_mod-start_pm15'); highlightMod('mod_mod-end_pm15'); highlightMod('link_pm15');" id="mod_mod-start_pm15" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm15"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">14 &gt;</span></span></span>Art. 4.<span id="link_pm15"><span style="font-style: italic; display: none;" id="ref_text_art_4"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Dans les cas où le bailleur offre un ou plusieurs services au locataire, le bailleur opère dans le contrat de bail une distinction entre le montant du loyer mensuel et le montant du coût mensuel de chaque autre service proposé au locataire.<span onmouseout="unHighlightMod('mod_mod-start_pm15'); unHighlightMod('mod_mod-end_pm15'); unHighlightMod('link_pm15');" onmouseover="highlightMod('mod_mod-start_pm15'); highlightMod('mod_mod-end_pm15'); highlightMod('link_pm15');" id="mod_mod-end_pm15" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm15"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">14 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm15"> </sup>
+
+</p>
+
+</div>
+</div>
+<div id="art_5" class="richtext_article" style=""><a style="color: black;" name="art_5">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 5.<span id="link_pm16"><span id="link_pm17"><span id="link_pm18"><span style="font-style: italic; display: none;" id="ref_text_art_5"> (L du 23 juillet 2024)</span></span></span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">3</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_9" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline"><sup style="display: none;" id="mod_supStart_mod-start_pm16"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm16'); unHighlightMod('mod_mod-end_pm16'); unHighlightMod('link_pm16');" onmouseover="highlightMod('mod_mod-start_pm16'); highlightMod('mod_mod-end_pm16'); highlightMod('link_pm16');" id="mod_mod-start_pm16" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm16"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">15 &gt;</span></span></span>(1)</span>La conclusion du bail ne peut être liée au paiement de sommes autres que le loyer. Sous peine de nullité, tout bail est établi par écrit, qui stipule au moins :</p>
+<table width="100%" class="richtext_ol" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI">1°</td><td class="richtext_contentLI"><span class="richtext_li">l’identité complète de toutes les parties contractantes ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">2°</td><td class="richtext_contentLI"><span class="richtext_li"> la date de prise d’effet du bail ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">3°</td><td class="richtext_contentLI"><span class="richtext_li"> la désignation de toutes les pièces et parties d’immeuble couvrant l’objet du bail, ainsi que l’adresse et la référence cadastrale de l’objet du bail ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">4°</td><td class="richtext_contentLI"><span class="richtext_li"> le montant du loyer sans les charges ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">5°</td><td class="richtext_contentLI"><span class="richtext_li"> le montant des acomptes sur les charges ou du forfait pour charges éventuelles ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">6°</td><td class="richtext_contentLI"><span class="richtext_li"> le supplément de loyer pour le mobilier, en cas d’un logement meublé ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">7°</td><td class="richtext_contentLI"><span class="richtext_li"> le montant de la garantie locative éventuellement stipulée ;</span></td></tr><tr class="richtext_elementLI" style=""><td class="richtext_numLI">8°</td><td class="richtext_contentLI"><span class="richtext_li"> l’indication que les parties contractantes ont la possibilité de saisir la commission des loyers conformément à l’article 8 en cas de litige sur la fixation du loyer.</span></td></tr></table>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas d’intervention d’un agent immobilier ou d’un autre tiers dans la location d’un logement à usage d’habitation, les frais et honoraires de ces personnes sont partagés par moitié entre le bailleur et le locataire.<span onmouseout="unHighlightMod('mod_mod-start_pm16'); unHighlightMod('mod_mod-end_pm16'); unHighlightMod('link_pm16');" onmouseover="highlightMod('mod_mod-start_pm16'); highlightMod('mod_mod-end_pm16'); highlightMod('link_pm16');" id="mod_mod-end_pm16" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm16"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">15 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm16"> </sup>
+
+</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_10" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Il est toutefois permis aux parties de convenir d’une garantie locative, qui ne pourra dépasser <sup style="display: none;" id="mod_supStart_mod-start_pm17"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm17'); unHighlightMod('mod_mod-end_pm17'); unHighlightMod('link_pm17');" onmouseover="highlightMod('mod_mod-start_pm17'); highlightMod('mod_mod-end_pm17'); highlightMod('link_pm17');" id="mod_mod-start_pm17" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm17"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">16 &gt;</span></span></span>deux<span onmouseout="unHighlightMod('mod_mod-start_pm17'); unHighlightMod('mod_mod-end_pm17'); unHighlightMod('link_pm17');" onmouseover="highlightMod('mod_mod-start_pm17'); highlightMod('mod_mod-end_pm17'); highlightMod('link_pm17');" id="mod_mod-end_pm17" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm17"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">16 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm17"> </sup>
+ mois de loyer, pour garantir le paiement du loyer ou des autres obligations découlant du contrat de bail.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de stipulation d’une garantie locative, un constat écrit et contradictoire des lieux doit être signé au plus tard le jour de l’entrée en jouissance des lieux par le locataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le bailleur ne peut refuser, même après la conclusion du bail, une garantie locative sous forme d’une garantie bancaire.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_61" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline"><sup style="display: none;" id="mod_supStart_mod-start_pm18"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm18'); unHighlightMod('mod_mod-end_pm18'); unHighlightMod('link_pm18');" onmouseover="highlightMod('mod_mod-start_pm18'); highlightMod('mod_mod-end_pm18'); highlightMod('link_pm18');" id="mod_mod-start_pm18" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm18"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">17 &gt;</span></span></span>(2<i class="richtext_i richtext_inline">bis</i>)</span>Lorsque à la fin du bail, l’état des lieux de sortie est conforme à l’état des lieux d’entrée, sauf usure et vétusté normale, et que le bailleur n’a pas de revendication en matière d’arriérés de loyer ou de dégâts locatifs, la moitié de la garantie locative est à restituer dans un délai maximal d’un mois à partir de la remise en mains propres, ou par lettre recommandée avec avis de réception, des clés au bailleur ou à son mandataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">La régularisation définitive et la restitution du solde de la garantie locative, déduction faite, le cas échéant, des sommes restant encore dues au bailleur, pour autant qu’elles sont dûment justifiées, sont effectuées au plus tard dans le mois qui suit soit la réception des décomptes relatifs aux charges locatives que le bailleur est tenu de demander auprès des différents services et administrations au plus tard un mois après la fin du bail soit l’approbation définitive des comptes annuels de l’immeuble lors de la prochaine assemblée générale des copropriétaires.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Peu importe le type de logement mis en location, si l’état des lieux d’entrée n’est pas conforme à l’état des lieux de sortie, sauf usure ou vétusté normale, ou en cas d’une contestation du bailleur, ce dernier peut retenir de la garantie locative non seulement les sommes qui lui restent encore dues mais également toute somme dont celui-ci pourrait être tenu, en lieu et place du locataire, sous réserve qu’elle soit dûment justifiée par le bailleur endéans le prédit délai maximal d’un mois par des pièces à l’appui.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">À défaut de restitution dans les délais prévus et à partir d’une mise en demeure par lettre recommandée avec avis de réception adressée par le locataire au bailleur ou à son mandataire, la partie du dépôt de garantie restant due au locataire est majorée d’une somme égale à 10 pour cent du loyer mensuel en principal, pour chaque période mensuelle commencée en retard. Cette majoration n’est pas due lorsque le défaut de restitution dans les délais résulte d’un motif imputable au locataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de transfert de propriété d’un immeuble loué en tout ou en partie, les garanties sont transférées de plein droit au nouveau propriétaire. Toute convention contraire n’a d’effet qu’entre les parties au transfert de propriété.<span onmouseout="unHighlightMod('mod_mod-start_pm18'); unHighlightMod('mod_mod-end_pm18'); unHighlightMod('link_pm18');" onmouseover="highlightMod('mod_mod-start_pm18'); highlightMod('mod_mod-end_pm18'); highlightMod('link_pm18');" id="mod_mod-end_pm18" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm18"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">17 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm18"> </sup>
+
+</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_11" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Le bailleur ne peut mettre à charge du locataire que les montants qu’il justifie avoir déboursés lui-même pour le compte du locataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Ne peuvent être mis à charge du locataire que les frais exposés pour la consommation d’énergie, pour l’entretien courant du logement et des parties communes, pour les menues réparations ainsi que les taxes liées à l’usage du logement.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le bailleur peut exiger le versement d’acomptes appropriés sur ces frais. Ces acomptes peuvent être adaptés aux frais réellement exposés pour compte du locataire au cours des exercices antérieurs.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les charges communes à plusieurs logements sont réparties annuellement selon un mode de computation à convenir entre les parties en cause.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Si les frais mis en compte résultent d’un décompte d’un immeuble soumis au statut de la copropriété approuvé en assemblée générale conformément à la législation relative au statut de la copropriété des immeubles bâtis, les positions de ce décompte à charge du locataire par application de la présente loi sont présumées justifiées et échues. La preuve contraire est admise.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de demande du locataire, le bailleur est tenu de lui communiquer une copie des extraits du règlement de copropriété concernant la destination de l’immeuble, la jouissance et l’usage des parties privatives et communes et précisant la quote-part afférente du lot loué dans chacune des catégories de charges.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_12" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Les acomptes sur charges peuvent également être fixés forfaitairement par les parties si ce forfait correspond à la consommation et aux charges normales du locataire. Il pourra être adapté au cours du bail.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Il est permis aux parties de convenir au cours du bail de modifier le régime des acomptes soit vers un régime forfaitaire soit du régime forfaitaire à un régime par acomptes.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_13" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(5)</span>Les clauses de valeur conventionnelles qui diffèrent du régime prévu par la présente loi perdront leur effet à partir du premier terme suivant la date d’une réclamation adressée par lettre recommandée au bailleur.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Toutes autres stipulations inscrites dans les contrats de bail et destinées à priver d’effet une disposition de la présente loi sont nulles de plein droit.</p>
+
+</div>
+</div>
+</div>
+<div class="richtext_article" style="display: none;del" id="mod_del__N10A5F"><a style="color: black;" name="art_6_20240801">​</a><p class=" richtext_num_article richtext_inline" style=""><sup style="display: none;" id="mod_supStart_mod-start_pm19"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm19'); unHighlightMod('mod_mod-end_pm19'); unHighlightMod('link_pm19');" onmouseover="highlightMod('mod_mod-start_pm19'); highlightMod('mod_mod-end_pm19'); highlightMod('link_pm19');" id="mod_mod-start_pm19" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm19"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">18 &gt;</span></span></span><span style="text-decoration: line-through; display: none;" id="mod_del_N10A8B">Art. 6.</span><span id="link_pm19"><span style="font-style: italic; display: none;" id="ref_text_art_6_20240801"> (L du 23 juillet 2024)</span></span></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10A95">Les articles 3 à 5 ne s’appliquent pas aux logements avec confort moderne, non-standard:</span> </p>
+<table width="100%" class="richtext_ol" style="width:100%!important;"><tr class="richtext_elementLI" id="mod_del_N10A9D" style="text-decoration: line-through; display: none;"><td class="richtext_numLI">a.</td><td class="richtext_contentLI"><span class="richtext_li" style="del">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10AA0">dont le loyer mensuel est supérieur à 269 euros, valeur au nombre cent de l’indice pondéré du coût de la vie au 1<sup class="richtext_sup richtext_inline">er</sup> janvier 1948; ou</span>
+</span></td></tr><tr class="richtext_elementLI" id="mod_del_N10AA7" style="text-decoration: line-through; display: none;margin-top: 3pt;"><td class="richtext_numLI">b.</td><td class="richtext_contentLI"><span class="richtext_li" style="del">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10AAA">dont le capital investi, fixé conformément à l’article 3, paragraphes (2), (3) et (4):</span>
+<table width="100%" class="richtext_ul" style="margin-top: 3pt!important;width:100%!important;"><tr class="richtext_elementLI" id="mod_del_N10AB3" style="text-decoration: line-through; display: none;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li" style="del">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10AB7">par m² de surface utile, calculée conformément aux dispositions prévues par la législation sur la publicité foncière en matière de copropriété, d’un logement faisant partie d’une copropriété est supérieur à 618 euros, valeur au nombre cent de l’indice des prix de la construction en 1970; ou</span>
+</span></td></tr><tr class="richtext_elementLI" id="mod_del_N10ABB" style="text-decoration: line-through; display: none;margin-top: 3pt;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li" style="del">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10ABF">par m² de surface utile d’habitation, calculée conformément aux dispositions prévues par la législation concernant l’aide au logement, des maisons unifamiliales est supérieur à 450 euros, valeur au nombre indice cent de l’indice des prix de la construction en 1970;</span>
+</span></td></tr></table> </span></td></tr></table>
+<p style="" class="richtext_p  richtext_p">
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10AC8">à condition que le contrat de bail stipule clairement qu’il s’agit d’un des logements visés au présent article et qu’il n’est pas soumis aux articles 3 à 5.<span onmouseout="unHighlightMod('mod_mod-start_pm19'); unHighlightMod('mod_mod-end_pm19'); unHighlightMod('link_pm19');" onmouseover="highlightMod('mod_mod-start_pm19'); highlightMod('mod_mod-end_pm19'); highlightMod('link_pm19');" id="mod_mod-end_pm19" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm19"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">18 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm19"> </sup>
+</span>
+
+</p>
+
+</div>
+</div>
+<div id="art_7" class="richtext_article" style=""><a style="color: black;" name="art_7">​</a><p class=" richtext_num_article richtext_inline" style=""><sup style="display: none;" id="mod_supStart_mod-start_pm8"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm8'); unHighlightMod('mod_mod-end_pm8'); unHighlightMod('link_pm8');" onmouseover="highlightMod('mod_mod-start_pm8'); highlightMod('mod_mod-end_pm8'); highlightMod('link_pm8');" id="mod_mod-start_pm8" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 2 août 2017 portant modification de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil." id="mod_marker_start_mod-start_pm8"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 2 août 2017 portant modification de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil.">7 &gt;</span></span></span><span style="font-weight: normal; font-style: normal;"><b style="font-weight: bold;">Art. 7.</b></span><span id="link_pm8"><span style="font-style: italic; display: none;" id="ref_text_art_7"> (L du 02 août 2017)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_14" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Dans les communes de 6.000 habitants et plus, il est institué une ou plusieurs commissions des loyers.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Plusieurs commissions des loyers sont instituées pour l’ensemble des communes de moins de 6.000 habitants. Un règlement grand-ducal détermine la zone de compétence territoriale et le siège de ces commissions des loyers.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_48" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Les missions de la commission des loyers, dénommée ci-après « commission », sont définies par les dispositions de la présente loi.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_49" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Chaque commission se compose d'un président et de deux assesseurs. Il y a autant de membres suppléants que de membres effectifs. Les membres effectifs et suppléants sont nommés pour une durée de six ans. Leurs mandats sont renouvelables.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">L'un des assesseurs est choisi parmi les bailleurs et l'autre parmi les locataires. Il en est de même de leurs suppléants respectifs.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les commissions sont renouvelées à la suite des élections générales des conseils communaux dans les trois mois qui suivent l’installation des conseillers élus. En cas de renouvellement intégral du conseil communal d’une commune de 6.000 habitants et plus par suite de dissolution ou de démission de tous ses membres, le nouveau conseil procède, dans les trois mois de son installation, au renouvellement de la commission.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Pour les communes de 6.000 habitants et plus, les membres effectifs et suppléants sont désignés par le conseil communal. Le président de chaque commission et son suppléant sont choisis pour autant que possible parmi les membres du conseil communal.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Pour les communes de moins de 6.000 habitants, le président de la commission est désigné par le ministre ayant le Logement dans ses attributions parmi les fonctionnaires qu’il a sous ses ordres. Les membres assesseurs effectifs et suppléants des commissions sont désignés par un vote par correspondance sur base de bulletins de vote établis par le ministre ayant l’Intérieur dans ses attributions sur proposition des conseils communaux concernés.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Jusqu’au premier jour du quatrième mois qui suit celui des élections générales des conseils communaux, ceux-ci proposent au ministre ayant l’Intérieur dans ses attributions des candidats dans les formes établies par les articles 18, 19, 32, 33 et 34 de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1988/12/13/n1/jo" target="new">loi communale modifiée du 13 décembre 1988</a>. Chaque conseil communal concerné a le choix soit de proposer un candidat aux fonctions de membre effectif respectivement de membre suppléant parmi les personnes qui sont bailleurs et un autre candidat aux fonctions de membre effectif respectivement de membre suppléant parmi les personnes qui sont locataires, chaque fois domiciliés sur le territoire d’une des communes faisant partie de la zone de compétence territoriale de la commission, soit de renoncer à toute proposition de candidat. Si un seul et même candidat est proposé pour un poste de membre de la commission, celui-ci est déclaré élu par le ministre ayant l’Intérieur dans ses attributions. Les propositions tardives ne sont pas prises en compte.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le ministre ayant l’Intérieur dans ses attributions inscrit sur des bulletins de vote les candidats qui lui sont proposés par les conseils communaux et les transmet aux communes dans un délai de quinze jours au plus tard à partir du premier jour du quatrième mois. Le ministre ayant l’Intérieur dans ses attributions transmet à chaque commune autant de bulletins de vote munis des nom et prénoms des candidats proposés et d’enveloppes électorales que le conseil communal compte de membres, estampillés et portant l’indication du ministère de l’Intérieur et du poste de membre à la commission à laquelle le vote doit pourvoir.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le collège des bourgmestre et échevins soit envoie sous pli recommandé avec accusé de réception, soit remet contre récépissé à chaque conseiller communal un bulletin de vote et une enveloppe électorale.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les conseillers communaux remplissent les bulletins de vote et les placent dans les enveloppes électorales qu’ils transmettent aussitôt au collège des bourgmestre et échevins. Celles-ci sont recueillies par le collège des bourgmestre et échevins pour être transmises ensemble par envoi recommandé au ministre ayant l’Intérieur dans ses attributions dans un délai de quinze jours à partir de la réception des bulletins de vote et des enveloppes électorales. Les enveloppes transmises de manière tardive ne sont pas prises en compte, la date de l’envoi recommandé faisant foi.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le ministre ayant l’Intérieur dans ses attributions installe un bureau de vote composé de fonctionnaires qu’il a sous ses ordres, dont un assure la fonction de président. Le bureau de vote procède au dépouillement du scrutin dès réception des bulletins de vote des conseillers communaux des communes faisant partie de la zone de compétence territoriale d’une commission. </p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Chaqueconseil communalpeutdésigner,parmi ses membresnoncandidats,unobservateurquiassiste aux opérations de dépouillement.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les candidats sont élus à la majorité simple. En cas de partage des voix, il est procédé par tirage au sort par le président du bureau de vote.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le ministre ayant l’Intérieur dans ses attributions communique au ministre ayant le Logement dans ses attributions et aux communes concernées les résultats du scrutin sous forme d’un relevé des membres élus aussitôt que les opérations de dépouillement sont clôturées. Le relevé des membres élus vaut titre d’admission à la commission concernée.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Si le conseil communal d’une commune de moins de 6.000 habitants faisant partie de la zone de compétence territoriale d’une commission n’est pas installé jusqu’au 31 décembre de l’année des élections générales des conseils communaux, le ministre ayant l’Intérieur dans ses attributions suspend l’établissement des bulletins de vote en attendant que tous les conseils communaux aient proposé un candidat dans le délai d’un mois à partir de la date d’installation du dernier conseil communal sans préjudice des dispositions de l’alinéa 5.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Lorsqu’un assesseur perd sa qualité respectivement de bailleur ou de locataire, il est de plein droit démissionnaire de la commission. Il est pourvu à son remplacement dans les formes et selon la procédure de désignation.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les présidents et les membres assesseurs des commissions peuvent être remplacés. Le remplacement d’un membre d’une commission d’une commune de 6.000 habitants et plus est fait par délibération du conseil communal. Le remplacement du président d’une commission regroupant plusieurs communes de moins de 6.000 habitants est fait par le ministre ayant le Logement dans ses attributions. Le remplacement d’un assesseur est opéré sur proposition d’une des communes de la zone de compétence territoriale de la commission. Cette proposition est notifiée au ministre ayant l’Intérieur dans ses attributions, au ministre ayant le Logement dans ses attributions et aux autres communes concernées. Dans le délai d’un mois à partir de la notification, les conseils communaux proposent des candidats pour le remplacement, qui a lieu selon la procédure de désignation. </p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de vacance d’un poste de membre effectif ou suppléant d’une commission par suite de décès, de démission ou pour toute autre cause, il est pourvu au remplacement du poste vacant dans le délai de trois mois selon la procédure de désignation. Le remplaçant achève le terme du mandat de celui qu’il remplace.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_50" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Dans les communes de 6.000 habitants et plus, le lieu de réunion de la commission est un local approprié mis à disposition par l’administration communale concernée. Pour chaque commission regroupant des communes de moins de 6.000 habitants, un local approprié est mis à disposition par l’administration communale du lieu du siège de la commission.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_51" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(5)</span>Dans les communes de 6.000 habitants et plus, le secrétaire de la commission est désigné par le conseil communal parmi les fonctionnaires communaux.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Pour les autres commissions, le ministre ayant le Logement dans ses attributions désigne le secrétaire parmi les fonctionnaires qu’il a sous ses ordres. </p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_52" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(6)</span>Dans les communes de 6.000 habitants et plus, les indemnités revenant aux membres et au secrétaire de la commission ainsi que les autres frais de fonctionnement de la commission sont à charge de la commune.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Pour les autres commissions, les indemnités revenant aux membres et au secrétaire de la commission ainsi que les autres frais de fonctionnement sont répartis de façon égale entre les communes concernées.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les montants des indemnités revenant aux membres et au secrétaire de la commission sont fixés par règlement grand-ducal. <span onmouseout="unHighlightMod('mod_mod-start_pm8'); unHighlightMod('mod_mod-end_pm8'); unHighlightMod('link_pm8');" onmouseover="highlightMod('mod_mod-start_pm8'); highlightMod('mod_mod-end_pm8'); highlightMod('link_pm8');" id="mod_mod-end_pm8" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 2 août 2017 portant modification de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil." id="mod_marker_end_mod-end_pm8"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 2 août 2017 portant modification de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil.">7 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm8"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="art_8" class="richtext_article" style=""><a style="color: black;" name="art_8">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 8.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La partie qui se croira fondée en vertu des dispositions de la présente loi à demander une augmentation ou une réduction du loyer devra d’abord notifier son intention à l’autre partie par écrit, sous peine d’irrecevabilité de la requête devant la commission. Si un accord n’a pu être obtenu endéans un mois, le réclamant pourra adresser une requête au collège des bourgmestre et échevins de la commune du lieu de situation du logement. Le collège des bourgmestre et échevins transmettra sans délai la requête à la commission compétente.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Chaque requête précisera l’objet de la demande. Elle ne sera pas recevable pendant les six premiers mois du bail.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les parties seront convoquées par la commission par lettre recommandée avec accusé de réception qui contiendra outre les jour, heure et lieu pour se présenter devant la commission une copie de la requête introductive de la partie requérante. La convocation sera faite au moins à huitaine. Si une partie n’est pas touchée personnellement, la commission des loyers reconvoquera les parties à quinzaine, le tout sous peine de nullité. La deuxième convocation est valablement faite à domicile.</p>
+
+</div>
+</div>
+<div id="art_9" class="richtext_article" style=""><a style="color: black;" name="art_9">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 9.<span id="link_pm20"><span style="font-style: italic; display: none;" id="ref_text_art_9"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_20" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Les parties comparaîtront en personne ou par fondé de pouvoir devant la commission aux jour, heure et lieu indiqués dans la convocation et présenteront leurs observations.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_21" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>La commission pourra s’entourer de tous les renseignements qu’elle jugera convenir avant de déterminer le loyer. Elle pourra notamment prendre inspection des lieux loués.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Exceptionnellement, la commission pourra se faire assister par un expert. Les frais de cette intervention seront avancés par la partie requérante et ventilés entre les parties dans la décision de la commission ou, en cas de recours, par le tribunal saisi en tenant compte de l’issue de la procédure.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_22" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>La commission s’efforcera de concilier les parties.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">S’il y a conciliation, il sera dressé procès-verbal des conditions de l’arrangement. Ce procès-verbal sera signé par les parties ou leurs fondés de pouvoir et par le président de la commission.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de non-conciliation ou de non-comparution de l’une des parties, la commission déterminera le loyer dû et/ou les avances sur charges d’après les règles établies par les articles 3 à 5.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_23" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>En cas de détermination du loyer, le procès-verbal contiendra l’évaluation du logement par rapport aux critères légaux et réglementaires et le montant du loyer.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Le procès-verbal sera signé par les membres de la commission et une copie sera notifiée aux parties par lettre recommandée dans le plus bref délai avec indication des voies et du délai de recours ainsi que de la manière dans laquelle il doit être présenté, faute de quoi le délai pour introduire un recours contre la décision conformément à l’article 10 ne court pas.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_24" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline"><sup style="display: none;" id="mod_supStart_mod-start_pm20"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm20'); unHighlightMod('mod_mod-end_pm20'); unHighlightMod('link_pm20');" onmouseover="highlightMod('mod_mod-start_pm20'); highlightMod('mod_mod-end_pm20'); highlightMod('link_pm20');" id="mod_mod-start_pm20" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm20"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">19 &gt;</span></span></span>(5)</span>La commission rend sa décision dans un délai de trois mois à partir de la transmission de la requête à la commission. Si la commission ne peut pas ou plus siéger au vu d’une vacance de poste d’un des assesseurs de la commission ou si aucune décision n’est rendue endéans ce délai, le requérant pourra saisir directement le juge de paix.<span onmouseout="unHighlightMod('mod_mod-start_pm20'); unHighlightMod('mod_mod-end_pm20'); unHighlightMod('link_pm20');" onmouseover="highlightMod('mod_mod-start_pm20'); highlightMod('mod_mod-end_pm20'); highlightMod('link_pm20');" id="mod_mod-end_pm20" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm20"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">19 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm20"> </sup>
+
+</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_25" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(6)</span>Les parties peuvent convenir de charger la commission d’une mission d’arbitrage auquel cas la décision s’imposera aux parties et sera susceptible d’exécution directe.</p>
+
+</div>
+</div>
+</div>
+<div id="art_10" class="richtext_article" style=""><a style="color: black;" name="art_10">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 10.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Contre la détermination du loyer par la commission, il est ouvert une action devant le juge de paix du lieu de la situation du logement. Cette action devra être formée, à peine de déchéance, dans le mois de la notification du procès-verbal de la commission. Elle sera introduite, instruite et jugée conformément à la procédure prévue aux articles 19 à 25. La copie du procès-verbal de la commission sera jointe à la requête.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si aucun recours n’est introduit suite à la notification de la décision de la commission dans les délais fixés, il est présumé d’une manière irréfragable que la décision de la commission est acceptée de part et d’autre.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La décision du juge de paix pourra être frappée d’opposition ou d’appel dans les formes et délais prévus aux articles 23 et 25.</p>
+
+</div>
+</div>
+<div id="art_11" class="richtext_article" style=""><a style="color: black;" name="art_11">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 11.<span id="link_pm21"><span style="font-style: italic; display: none;" id="ref_text_art_11"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La détermination du loyer par la commission des loyers ou par le juge ne peut produire ses effets qu’à partir du premier terme venant à échoir après la date à laquelle le collège des bourgmestre et échevins compétent a été saisi de la requête conformément à l’article 8.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">
+<sup style="display: none;" id="mod_supStart_mod-start_pm21"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm21'); unHighlightMod('mod_mod-end_pm21'); unHighlightMod('link_pm21');" onmouseover="highlightMod('mod_mod-start_pm21'); highlightMod('mod_mod-end_pm21'); highlightMod('link_pm21');" id="mod_mod-start_pm21" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm21"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">20 &gt;</span></span></span>
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10DA8">Lorsque, en application des dispositions de la présente loi, le loyer est augmenté de plus de 10% suite à une décision de la commission des loyers ou sur un recours en justice, la hausse s’applique par tiers annuels. Le locataire aura toutefois le droit de dénoncer le bail, nonobstant toute convention contraire, moyennant un délai de résiliation de trois mois.</span>
+<span onmouseout="unHighlightMod('mod_mod-start_pm21'); unHighlightMod('mod_mod-end_pm21'); unHighlightMod('link_pm21');" onmouseover="highlightMod('mod_mod-start_pm21'); highlightMod('mod_mod-end_pm21'); highlightMod('link_pm21');" id="mod_mod-end_pm21" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm21"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">20 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm21"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_iii" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_iii">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_iii_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre III. – De la durée du contrat de bail</span></p></div>
+
+
+<div id="art_12" class="richtext_article" style=""><a style="color: black;" name="art_12">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 12.<span id="link_pm22"><span id="link_pm23"><span style="font-style: italic; display: none;" id="ref_text_art_12"> (L du 23 juillet 2024)</span></span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">2</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_26" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Le contrat de bail peut être conclu à durée déterminée ou indéterminée. <sup style="display: none;" id="mod_supStart_mod-start_pm22"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm22'); unHighlightMod('mod_mod-end_pm22'); unHighlightMod('link_pm22');" onmouseover="highlightMod('mod_mod-start_pm22'); highlightMod('mod_mod-end_pm22'); highlightMod('link_pm22');" id="mod_mod-start_pm22" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm22"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">21 &gt;</span></span></span>
+<span style="text-decoration: line-through; display: none;" id="mod_del_N10DFC">En l’absence d’un écrit, il est présumé conclu à durée indéterminée.<span onmouseout="unHighlightMod('mod_mod-start_pm22'); unHighlightMod('mod_mod-end_pm22'); unHighlightMod('link_pm22');" onmouseover="highlightMod('mod_mod-start_pm22'); highlightMod('mod_mod-end_pm22'); highlightMod('link_pm22');" id="mod_mod-end_pm22" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm22"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">21 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm22"> </sup>
+</span>
+
+</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_27" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>
+<sup style="display: none;" id="mod_supStart_mod-start_pm23"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm23'); unHighlightMod('mod_mod-end_pm23'); unHighlightMod('link_pm23');" onmouseover="highlightMod('mod_mod-start_pm23'); highlightMod('mod_mod-end_pm23'); highlightMod('link_pm23');" id="mod_mod-start_pm23" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm23"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">22 &gt;</span></span></span>Tout contrat de bail visé par la présente loi, qui vient à cesser pour n’importe quelle cause, est prorogé à durée indéterminée à moins que<span onmouseout="unHighlightMod('mod_mod-start_pm23'); unHighlightMod('mod_mod-end_pm23'); unHighlightMod('link_pm23');" onmouseover="highlightMod('mod_mod-start_pm23'); highlightMod('mod_mod-end_pm23'); highlightMod('link_pm23');" id="mod_mod-end_pm23" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm23"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">22 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm23"> </sup>
+: </p>
+<table width="100%" class="richtext_ol" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI" style="width:5mm;">a.</td><td class="richtext_contentLI"><span class="richtext_li">le bailleur déclare avoir besoin des lieux loués pour les occuper lui-même ou pour les faire occuper de manière effective par un parent ou allié jusqu’au troisième degré inclusivement;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">b.</td><td class="richtext_contentLI"><span class="richtext_li">le locataire ne remplisse pas ses obligations;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">c.</td><td class="richtext_contentLI"><span class="richtext_li">il existe d’autres motifs graves et légitimes à établir par le bailleur; le transfert de propriété du logement ne vaut pas motif grave et légitime.</span></td></tr></table>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_28" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Par dérogation à l’article 1736 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a>, le délai de résiliation dans les cas prévus au paragraphe (2), point a, est de six mois. La lettre de résiliation doit être écrite, motivée et accompagnée, le cas échéant, de pièces afférentes et s’effectuer par voie de lettre recommandée à la poste avec avis de réception. Elle doit mentionner, sous peine de nullité, le texte du présent paragraphe.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Dans les trois mois de l’avis de réception à la poste, le locataire peut, sous peine de forclusion, demander une prolongation du délai de résiliation au juge de paix. En l’absence de cette demande, le bailleur peut demander au juge de paix une décision autorisant le déguerpissement forcé du locataire après l’écoulement du délai de résiliation de six mois. Toutefois, le locataire pourra encore introduire une demande en sursis à l’exécution de la décision, conformément aux articles 16 à 18. Dans ce cas, le déguerpissement du logement par le locataire doit impérativement avoir lieu au plus tard quinze mois après la date d’envoi de la lettre de résiliation du bail. La décision autorisant le déguerpissement forcé du locataire ne sera pas susceptible d’opposition ou d’appel.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">En cas de demande de prolongation du délai de résiliation, les parties seront convoquées dans les deux mois à l’audience. Sauf si la demande est sérieusement contestable ou contestée, le juge de paix accordera une prolongation du délai au locataire à condition que celui-ci justifie avant l’expiration du délai initial de six mois, par voie de pièces, soit être en train de construire ou de transformer un logement lui appartenant, soit avoir loué un logement en construction ou en transformation, soit avoir fait des démarches utiles et étendues en vue de la recherche d’un nouveau logement. La prolongation du délai ne pourra en aucun cas dépasser de douze mois la date d’expiration du délai initial de six mois. La faveur du sursis, prévue aux articles 16 à 18, ne sera plus applicable. La décision accordant ou refusant la prolongation du délai vaudra de droit titre exécutoire en vue d’un déguerpissement forcé du locataire après l’écoulement du délai. Elle n’est pas susceptible d’opposition ou d’appel.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_29" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Lorsqu’un logement a été mis, même à titre gratuit, à la disposition d’une personne uniquement en raison d’un contrat de travail intervenu entre parties, le déguerpissement de l’occupant peut être ordonné par le juge de paix si l’employeur prouve que le contrat de travail a pris fin.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Au cas où l’occupant reste en possession du logement après la cessation du contrat de travail, il est tenu de payer une indemnité d’occupation du logement à fixer conformément aux dispositions de l’article 3.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_30" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(5)</span>Par dérogation à l’article 1743 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a>, l’acquéreur d’un logement loué en tout ou en partie ne peut expulser le locataire dont le bail n’a pas date certaine avant son acte d’acquisition, mais qui avait été mis en possession des lieux avant cette date à moins que l’une des conditions définies au paragraphe (2) ne soit réalisée.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_31" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(6)</span>L’acquéreur d’un logement loué qui veut occuper le logement lui-même ou par un parent ou allié jusqu’au troisième degré inclusivement, doit envoyer au locataire une lettre recommandée de résiliation du contrat de bail dans les trois mois de l’acquisition du logement.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Dans ce cas, les dispositions prévues au paragraphe (3) sont applicables, sauf que le déguerpissement du logement par le locataire doit impérativement avoir lieu au plus tard douze mois après la date d’envoi de la lettre de résiliation du bail.</p>
+
+</div>
+</div>
+</div>
+<div id="art_13" class="richtext_article" style=""><a style="color: black;" name="art_13">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 13.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">En cas d’abandon du domicile par le locataire ou en cas de décès du locataire, le contrat de bail continue à durée indéterminée:</p>
+<table width="100%" class="richtext_ul" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">au profit du conjoint ayant cohabité avec le locataire ou du partenaire ayant fait une déclaration de partenariat avec le locataire et ayant vécu en couple avec celui-ci;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">au profit des descendants, des ascendants ou du concubin, qui vivaient avec lui en communauté domestique depuis au moins six mois à la date de l’abandon du domicile ou du décès et qui avaient déclaré leur domicile à la commune dans le logement pendant cette période.</span></td></tr></table>
+<p style="" class="richtext_p  richtext_p">En cas de demandes multiples, le juge se prononce en fonction des intérêts en présence.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les droits du bailleur contre le locataire ayant abandonné le logement ne sont pas affectés par ces dispositions.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">A défaut de personnes remplissant les conditions prévues au présent article, le contrat de bail est résilié de plein droit par le décès du locataire.</p>
+
+</div>
+</div>
+<div id="art_14" class="richtext_article" style=""><a style="color: black;" name="art_14">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 14.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Sauf cas de force majeure, l’ancien locataire a droit à des dommages-intérêts si, dans les trois mois qui suivent son départ, les lieux ne sont pas occupés aux fins invoquées comme motif de la résiliation du bail soit dans l’acte de dénonciation du bail, soit dans la requête introductive d’instance, soit dans le jugement.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le délai de trois mois est suspendu pendant la durée des travaux de rénovation et de transformation entrepris de manière effective.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si le tribunal constate que le motif invoqué pour empêcher la prorogation légale était dolosif, le locataire a droit à des dommages-intérêts qui ne peuvent être inférieurs au montant des loyers d’une année.</p>
+
+</div>
+</div>
+<div id="art_15" class="richtext_article" style=""><a style="color: black;" name="art_15">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 15.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le locataire dont le bail court depuis au moins dix-huit ans bénéficie d’un droit de préemption sur le logement loué, à moins que celui-ci ne fasse l’objet d’une vente par adjudication publique ou qu’il ne soit cédé à un membre de la famille du bailleur parent ou allié jusqu’au troisième degré inclusivement ou qu’il ne fasse l’objet d’une cession gratuite.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le bailleur adresse au locataire par voie de lettre recommandée l’offre de vente. Dans cette offre, le bailleur doit avertir le locataire qu’il a le droit de faire une contre-proposition. Le locataire dispose d’un mois pour user de son droit et pour faire éventuellement une contre-proposition. Son silence vaut refus de l’offre. Si le locataire a formulé une demande en obtention d’un prêt auprès d’un établissement financier établi au Grand<span style="font-weight: normal; font-style: normal;">-</span>Duché, ce délai est prorogé d’un mois. Le logement ne peut être vendu à un tiers qu’à un prix supérieur à celui offert par le locataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le droit de préemption peut uniquement être exercé si le locataire a loué tout l’immeuble, respectivement si l’appartement qu’il a loué est placé sous le régime de la copropriété.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">En cas de vente du logement à un tiers acheteur en dépit du droit de préemption existant dans le chef du locataire, le locataire lésé peut réclamer des dommages-intérêts au vendeur qui ne pourront être inférieurs au montant des loyers d’une année.</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_iv" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_iv">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_iv_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre IV. – De la protection des personnes condamnées à déguerpir de leur logement</span></p></div>
+
+
+<div id="art_16" class="richtext_article" style=""><a style="color: black;" name="art_16">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 16.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le juge de paix, siégeant en matière de bail à loyer, peut ordonner à la requête de la partie condamnée au déguerpissement, qu’il s’agisse d’un locataire ou d’un occupant sans droit ni titre, qu’il sera sursis à l’exécution de la décision.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le sursis ne pourra dépasser trois mois, mais il pourra être prorogé à deux reprises, chaque fois pour une durée maximum de trois mois. Le sursis ne sera accordé que si, en raison des circonstances, le requérant paraît mériter cette faveur et qu’il prouve avoir effectué des démarches utiles et étendues pour trouver un nouveau logement, à moins que le sursis ne soit incompatible avec le besoin personnel de l’autre partie.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le juge de paix fixe la contrepartie pécuniaire due par la partie condamnée à déguerpir pendant la durée du sursis en raison de son maintien provisoire dans les lieux, en tenant compte du dommage qui en résulte pour le bailleur.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si après une condamnation au déguerpissement en première instance, l’appel de la partie condamnée à déguerpir est déclaré irrecevable ou nul, ou si le déguerpissement est confirmé en instance d’appel, quel que soit le délai accordé par le juge d’appel à la partie condamnée au déguerpissement, cette partie ne pourra plus introduire une demande en sursis à l’exécution de la décision.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Toute demande en sursis ou en prorogation de sursis est irrecevable s’il s’est écoulé un délai supérieur à un an entre le jour de l’introduction de la procédure judiciaire et l’expiration du délai de déguerpissement fixé dans le jugement prononçant la condamnation ou dans l’ordonnance accordant un précédent sursis.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Par dérogation à l’alinéa qui précède et sous réserve des dispositions prévues par l’article 12, paragraphes (3) et (6), toute demande en sursis ou en prorogation de sursis est encore irrecevable à l’expiration du délai de douze mois à partir de la date où l’acquéreur d’un immeuble loué a informé le locataire par lettre recommandée, respectivement à l’expiration du délai de quinze mois à partir de la date où le bailleur a informé le locataire par lettre recommandée, qu’il veut occuper l’immeuble lui-même ou par un de ses parents ou alliés jusqu’au troisième degré inclusivement.</p>
+
+</div>
+</div>
+<div id="art_17" class="richtext_article" style=""><a style="color: black;" name="art_17">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 17.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La demande en sursis sera formée par simple requête à déposer au greffe de la justice de paix. Les parties seront convoquées pour la première audience utile.</p>
+<p style="" class="richtext_p  richtext_p">La décision sur la demande sera constatée par simple note au plumitif. Cette décision n’est susceptible d’aucun recours.</p>
+
+</div>
+</div>
+<div id="art_18" class="richtext_article" style=""><a style="color: black;" name="art_18">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 18.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si le délai de déguerpissement accordé à l’occupant par la décision est supérieur à quinze jours, la demande en sursis est à introduire, à peine de déchéance, au plus tard trois jours avant l’expiration de ce délai. La demande en prolongation du sursis est à introduire, à peine de déchéance, au plus tard trois jours avant l’expiration du sursis. Il y sera statué incessamment. Néanmoins, la demande aura un effet suspensif.</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_v" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_v">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_v_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre V. – Du règlement des litiges</span></p></div>
+
+
+<div id="art_19" class="richtext_article" style=""><a style="color: black;" name="art_19">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 19.<span id="link_pm24"><span style="font-style: italic; display: none;" id="ref_text_art_19"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le juge de paix est compétent, même si le titre est contesté, pour connaître de toutes les contestations <sup style="display: none;" id="mod_supStart_mod-start_pm24"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm24'); unHighlightMod('mod_mod-end_pm24'); unHighlightMod('link_pm24');" onmouseover="highlightMod('mod_mod-start_pm24'); highlightMod('mod_mod-end_pm24'); highlightMod('link_pm24');" id="mod_mod-start_pm24" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm24"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">23 &gt;</span></span></span>entre bailleurs, locataires ou colocataires<span onmouseout="unHighlightMod('mod_mod-start_pm24'); unHighlightMod('mod_mod-end_pm24'); unHighlightMod('link_pm24');" onmouseover="highlightMod('mod_mod-start_pm24'); highlightMod('mod_mod-end_pm24'); highlightMod('link_pm24');" id="mod_mod-end_pm24" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm24"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">23 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm24"> </sup>
+ relatives à l’existence et à l’exécution des baux d’immeubles.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le juge de paix compétent est celui de la situation du logement faisant l’objet du bail en litige.</p>
+
+</div>
+</div>
+<div id="art_20" class="richtext_article" style=""><a style="color: black;" name="art_20">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 20.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La demande portée devant le juge de paix conformément à l’article 3, 3° du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/procedure_civile" target="new">Nouveau Code de procédure civile</a> sera formée par simple requête sur papier libre à déposer au greffe de la justice de paix en autant d’exemplaires qu’il y a de parties en cause.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La requête énoncera les nom, prénom, profession et domicile des parties. Elle indiquera sommairement les moyens invoqués à l’appui de la demande et précisera l’objet de celle-ci.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La date du dépôt de la demande est marquée par les soins du greffier sur un registre de papier non timbré tenu au greffe. Ce registre sera coté et paraphé par le juge de paix. Le greffier y inscrira également la date des lettres recommandées prévues par la présente loi.</p>
+
+</div>
+</div>
+<div id="art_21" class="richtext_article" style=""><a style="color: black;" name="art_21">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 21.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le greffier convoquera les parties par lettre recommandée à la poste avec avis de réception. Il y joindra une copie de la requête pour chaque défendeur. La lettre indiquera les nom, prénom, profession et domicile du demandeur, l’objet de la demande, le jour et l’heure de l’audience fixée pour les débats par le juge de paix au délai minimum de huit jours. La convocation contiendra en outre et à peine de nullité les mentions prescrites à l’article 80 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/procedure_civile" target="new">Nouveau Code de procédure civile</a>.</p>
+
+</div>
+</div>
+<div id="art_22" class="richtext_article" style=""><a style="color: black;" name="art_22">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 22.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Pour l’instruction et le jugement des affaires, la procédure ordinaire prévue en matière de justice de paix, pour autant qu’il n’y est pas dérogé par les dispositions de la présente loi, sera suivie.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Lorsqu’il y a lieu à enquête ou expertise, le greffier citera les témoins et les experts par lettre recommandée avec avis de réception. La lettre précisera l’objet de l’enquête ou de l’expertise.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Dans les quinze jours du prononcé, le greffier notifiera aux parties par lettre recommandée une copie sur papier libre du jugement.</p>
+
+</div>
+</div>
+<div id="art_23" class="richtext_article" style=""><a style="color: black;" name="art_23">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 23.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si l’une des parties ne comparaît ni en personne, ni par mandataire, le juge de paix statuera conformément aux dispositions des articles 74 à 89 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/procedure_civile" target="new">Nouveau Code de procédure civile</a>. La partie défaillante pourra faire opposition, par déclaration au greffe, dans les quinze jours de la notification prévue à l’article 22, alinéa 3. Dans ce cas, la convocation se fera conformément aux dispositions de l’article 21.</p>
+
+</div>
+</div>
+<div id="art_24" class="richtext_article" style=""><a style="color: black;" name="art_24">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 24.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le juge de paix peut prendre par ordonnance toutes mesures provisoires, et notamment fixer le loyer provisoire. Sont applicables les articles 15, 16 et 17 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/procedure_civile" target="new">Nouveau Code de procédure civile</a>.</p>
+
+</div>
+</div>
+<div id="art_25" class="richtext_article" style=""><a style="color: black;" name="art_25">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 25.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">L’appel sera porté devant le tribunal d’arrondissement. Il devra être interjeté, sous peine de nullité, dans un délai de quarante jours à partir de la notification du jugement s’il est contradictoire et, si le jugement est rendu par défaut, dans un délai de quarante jours à partir du jour où l’opposition ne sera plus recevable. La procédure ordinaire prévue en matière commerciale s’applique tant pour l’introduction de l’appel que pour l’instruction et le jugement de l’affaire.</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_vi" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_vi">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_vi_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre VI. – Des missions incombant aux autorités communales</span></p></div>
+
+
+<div id="art_26" class="richtext_article" style=""><a style="color: black;" name="art_26">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 26.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les administrations communales ont la mission d’assurer dans la mesure du possible le logement de toutes les personnes qui ont leur domicile sur le territoire de la commune.</p>
+
+</div>
+</div>
+<div id="art_27" class="richtext_article" style=""><a style="color: black;" name="art_27">​</a><p class=" richtext_num_article richtext_inline" style=""><sup style="display: none;" id="mod_supStart_mod-start_pm6"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm6'); unHighlightMod('mod_mod-end_pm6'); unHighlightMod('link_pm6');" onmouseover="highlightMod('mod_mod-start_pm6'); highlightMod('mod_mod-end_pm6'); highlightMod('link_pm6');" id="mod_mod-start_pm6" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil." id="mod_marker_start_mod-start_pm6"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.">5 &gt;</span></span></span>Art. 27.<span id="link_pm6"><span style="font-style: italic; display: none;" id="ref_text_art_27"> (L du 05 août 2015)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le conseil communal peut, par règlement communal, obliger les propriétaires des immeubles et parties d’immeubles non occupés destinés à servir de logement sis sur le territoire de la commune à les déclarer à l’administration communale dans le délai fixé par ledit conseil.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les infractions aux dispositions de l’alinéa précédent sont punies d’une peine d’amende comprise entre 1 et 250 euros.<span onmouseout="unHighlightMod('mod_mod-start_pm6'); unHighlightMod('mod_mod-end_pm6'); unHighlightMod('link_pm6');" onmouseover="highlightMod('mod_mod-start_pm6'); highlightMod('mod_mod-end_pm6'); highlightMod('link_pm6');" id="mod_mod-end_pm6" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil." id="mod_marker_end_mod-end_pm6"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 5 août 2015 modifiant la loi modifiée du 21 septembre 2006 sur le bail à usage d'habitation et modifiant certaines dispositions du Code civil.">5 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm6"> </sup>
+
+</p>
+
+</div>
+</div>
+<div id="art_28" class="richtext_article" style=""><a style="color: black;" name="art_28">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 28.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Chaque commune est autorisée à demander annuellement auprès des bailleurs, donnant en location un ou plusieurs logements sis sur le territoire de la commune, respectivement auprès des locataires d’un logement sis sur le territoire de la commune, des renseignements relatifs au montant du loyer et des charges locatives à payer au bailleur ainsi qu’au type et à la surface en m² du logement loué.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Ces renseignements peuvent être utilisés pour l’établissement d’un cadastre des loyers afin de connaître le niveau moyen des loyers demandés pour les différents types de logements dans une commune ou dans une partie de celle-ci.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La demande de renseignements est faite moyennant un formulaire mis à la disposition des bailleurs, respectivement des locataires, par les autorités communales. Elle doit être retournée, dûment remplie et signée par chaque bailleur ou locataire destinataire aux autorités communales dans le délai indiqué sur le formulaire, faute de quoi le destinataire défaillant pourra être puni à une amende dont le montant est fixé par règlement communal conformément aux dispositions de la loi communale.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">En cas de demande du ministre ayant le Logement dans ses attributions, les résultats des renseignements récoltés dans une commune donnée sont communiqués au ministre par les autorités communales.</p>
+
+</div>
+</div>
+</div>
+<div id="chapitre_vii" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_vii">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_vii_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre VII. – Des mesures spéciales pour la sauvegarde des biens meubles<br/>des personnes condamnées à déguerpir</span></p></div>
+
+
+<div id="art_29" class="richtext_article" style=""><a style="color: black;" name="art_29">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 29.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_35" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>En cas d’expulsion forcée d’une personne condamnée à déguerpir des lieux qu’elle occupe, les biens meubles se trouvant dans ces lieux sont transportés, aux frais de la personne expulsée qui doit en faire l’avance, au lieu qu’elle désigne.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_36" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Si la personne expulsée ne désigne aucun lieu de dépôt, si elle refuse ou si elle n’est pas à même de faire l’avance des frais de transport, l’huissier chargé de l’exécution du jugement de déguerpissement fait transporter les biens meubles aux frais de la personne expulsée, avancés par la commune du lieu d’expulsion en cas de demande de l’huissier, dans le local visé à l’article 30.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_37" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>L’huissier de justice dresse, aux frais de la personne expulsée, un procès-verbal contenant l’inventaire des biens transportés et la description sommaire de leur état. Il remet une copie du procès-verbal à la personne expulsée et à l’administration communale concernée.</p>
+
+</div>
+</div>
+</div>
+<div id="art_30" class="richtext_article" style=""><a style="color: black;" name="art_30">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 30.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_38" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>La commune prend en charge, dans un local approprié, l’entreposage des biens meubles des personnes expulsées dans les conditions de l’article 29, paragraphe (2). Elle peut faire détruire les biens périssables, insalubres ou dangereux et refuser d’entreposer les biens dont la conservation causerait des difficultés ou des frais anormaux.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_39" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Le dépôt dans le local visé à l’alinéa qui précède peut être assujetti au paiement d’une redevance à fixer par la commune.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_40" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Sauf convention écrite contraire entre la commune et la personne expulsée, les biens entreposés doivent être retirés dans un délai de trois mois à partir de la date du dépôt, contre paiement des frais de transport avancés par la commune et des redevances de dépôt redues. La commune peut renoncer à exiger de la personne expulsée le paiement de ces frais et redevances.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_41" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(4)</span>Après l’expiration de ce délai, la commune adresse, par lettre recommandée, à la personne expulsée une sommation de retirer ses biens. Si par suite un délai de trois mois s’est écoulé sans que ni la personne expulsée ni la partie saisissante ne se soient manifestées auprès de l’administration communale, la commune peut adresser, par lettre recommandée, à la personne expulsée et à la partie saisissante une ultime sommation de retirer les biens dans un délai de quinze jours, avec l’indication que, faute d’y obtempérer, il est présumé d’une manière irréfragable que tant la personne expulsée que la partie saisissante ont renoncé à réclamer la délivrance des biens entreposés. La commune est alors autorisée à procéder à la vente des biens se trouvant dans le local de dépôt, sinon à en disposer autrement.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_42" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(5)</span>La commune retient sur le produit de la vente les frais et autres dépenses mentionnés au paragraphe (3). Le solde est versé à la caisse des consignations. Le propriétaire des effets et meubles ou ses ayants droit pourront en obtenir le versement pendant une période de dix ans. Passé ce délai, il est acquis à la commune.</p>
+
+</div>
+</div>
+</div>
+</div>
+<div id="chapitre_viii" class="richtext_chapter richtext_chapter" style=""><a style="color: black;" name="chapitre_viii">​</a><div style="font-size: 120%;text-align: center;font-weight: bold!important;" class="richtext_heading_chapter richtext_heading" id="chapitre_viii_heading"><p style="font-size: 120%;text-align: center;font-weight: bold!important;"><span style="font-size: 120%;text-align: center;font-weight: bold!important;">Chapitre VIII. – Dispositions finales, abrogatoires et transitoires</span></p></div>
+
+
+<div id="art_31" class="richtext_article" style=""><a style="color: black;" name="art_31">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 31.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Dans le livre III du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civi</a>l, le chapitre II «Du louage des choses» du titre VIII est modifié comme suit: </p>
+<table width="100%" class="richtext_ol" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI" style="width:5mm;">1°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">L’article 1762-5, alinéa 2, du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> aura désormais la teneur suivante:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">«Ceux-ci sont choisis par les parties ou sinon désignés à la requête de la partie la plus diligente par le juge de paix de la situation de l’immeuble». </p>
+
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">2°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">Un nouvel article 1762-8 est inséré au <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a>, lequel aura la teneur suivante:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 1762-8.</u></p>
+
+<div class="richtext_paragraph richtext_paragraph" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Le preneur commerçant, industriel, artisan ou fermier, dont le bail vient à cesser pourra demander deux sursis successifs, chacun de six mois au maximum. Ces demandes seront déposées au greffe de la justice de paix, à peine de déchéance, deux mois au plus tard avant l’expiration du bail ou du premier sursis.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Si le délai-congé conventionnel est égal ou inférieur à deux mois, la demande en sursis peut encore être déposée dans les huit jours de la notification du congé.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Si le premier sursis accordé par le juge est égal ou inférieur à deux mois, la demande en obtention d’un deuxième sursis devra être déposée au plus tard huit jours avant l’expiration du premier sursis.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les demandes en sursis sont dispensées du préliminaire de conciliation. Le juge de paix saisi aura compétence pour fixer le loyer pendant la durée des sursis. Le sursis sera refusé si le bailleur prouve qu’il a besoin de l’immeuble pour l’exploiter lui-même ou pour le faire exploiter par ses descendants ou pour d’autres causes graves et légitimes.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>En cas de décès d’un preneur, titulaire d’un contrat de bail commercial, artisanal ou à ferme, le contrat de bail est maintenu dans le chef du repreneur à condition que le repreneur maintienne l’exploitation commerciale, artisanale ou agricole et qu’il ait un lien de famille jusqu’au cinquième degré inclusivement avec le preneur défunt, sinon qu’il soit le conjoint ou le concubin du preneur défunt.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Sont à considérer dans l’application du présent article comme locaux à usage commercial ou industriel les immeubles dont le bail prévoit expressément pareille affectation, ceux qui sont destinés par leur nature à l’exercice d’un commerce ou d’une industrie et ceux dans lesquels cette activité est exercé à titre principal.».</p>
+
+</div>
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">3°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="margin-bottom: 3pt;" class="richtext_p">Il est inséré une section III libellé <span class="richtext_embeddedText richtext_quoteText"><span class="richtext_openingQuoteText">​</span> « Section III. – Des règles particulières aux baux commerciaux » <span class="richtext_closingQuoteText">​</span></span>. Elle comprendra les articles 1762-3 à 1762-8.</p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">4°</td><td class="richtext_contentLI"><span class="richtext_li">La section III <span class="richtext_embeddedText richtext_quoteText"><span class="richtext_openingQuoteText">​</span> « Des règles particulières aux baux à ferme » <span class="richtext_closingQuoteText">​</span></span>, comprenant les articles 1763 à 1778, deviendra la section IV du titre VIII.</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">5°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">L’article 1736 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> est modifié comme suit:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 1736.</u></p>
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Si le bail a été fait sans écrit ou si le contrat est stipulé à durée indéterminée, l’une des parties ne pourra donner congé à l’autre qu’en observant les délais fixés par l’usage des lieux.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le délai de résiliation d’un contrat de bail d’habitation est de trois mois, sauf clause contraire dans le contrat de bail écrit prévoyant un délai supérieur à trois mois.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le délai de résiliation pour un contrat de bail commercial ou un contrat de bail mixte est de six mois, sauf clause contraire prévue dans le contrat de bail écrit.». </p>
+
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">6°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">L’article 1758 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> aura désormais la teneur suivante:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 1758.</u></p>
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le bail d’un logement est censé être fait à durée indéterminée s’il n’est pas spécifié dans le contrat de bail écrit pour quelle durée les parties ont voulu se lier.».</p>
+
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">7°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">L’article 1761 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> est remplacé comme suit:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 1761.</u></p>
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le bailleur ne peut résilier le contrat de bail à durée déterminée, encore qu’il déclare vouloir occuper par lui-même la maison louée, s’il n’y a eu convention contraire.».</p>
+
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="width:5mm;">8°</td><td class="richtext_contentLI"><span class="richtext_li"> <p style="" class="richtext_p">L’article 1762 du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> est modifié comme suit:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 1762.</u></p>
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">S’il a été convenu dans le contrat de bail à durée déterminée ou à durée indéterminée que le bailleur pourrait venir occuper la maison, il est tenu de notifier d’avance un congé soit aux époques déterminées par le contrat de bail, soit moyennant congé notifié dans les délais prévus à l’article 1736.». </p>
+
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p> </span></td></tr></table>
+
+</div>
+</div>
+<div id="art_32" class="richtext_article" style=""><a style="color: black;" name="art_32">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 32.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_43" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>L’article 37 de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1982/06/18/n1/jo" target="new">loi modifiée du 18 juin 1982</a> portant réglementation du bail à ferme est à modifier comme suit:<table width="100%" class="richtext_embeddedStructurequote" style="width:100%!important;"><tr><td rowspan="2">​
+                    </td><td rowspan="2">
+<div id="" class="richtext_article" style=""><p class=" richtext_num_article richtext_inline" style="font-weight: normal!important;">«<u class="richtext_u richtext_inline">Art. 37.</u></p>
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les articles 20 à 25 de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1/jo" target="new">loi du 21 septembre 2006</a> sur le bail à usage d’habitation et modifiant certaines dispositions du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a> sont applicables en matière de bail à ferme.».</p>
+
+</div>
+</div>
+</td><td>​
+                    </td></tr><tr><td>​
+                    </td></tr><tr><td>​
+                    </td><td>​
+                    </td><td>​
+                    </td></tr></table> </p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_44" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Dans tous les textes de loi et de règlement, la référence à la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1955/02/14/n1/jo" target="new">loi du 14 février 1955</a> portant modification et coordination des dispositions légales et réglementaires en matière de bail à loyer s’entend comme référence aux dispositions de la présente loi.</p>
+
+</div>
+</div>
+</div>
+<div id="art_33" class="richtext_article" style=""><a style="color: black;" name="art_33">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 33.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les dispositions prévues par les articles 31 et 32 sont applicables aux contrats en cours à partir de la date d’entrée en vigueur de la présente loi. Elles s’appliquent aux demandes pendantes devant les commissions des loyers ou devant les juridictions au moment de l’entrée en vigueur de la présente loi.</p>
+
+</div>
+</div>
+<div id="art_33bis" class="richtext_article" style=""><a style="color: black;" name="art_33bis">​</a><p class=" richtext_num_article richtext_inline" style=""><sup style="display: none;" id="mod_supStart_mod-start_pm25"> </sup><span onmouseout="unHighlightMod('mod_mod-start_pm25'); unHighlightMod('mod_mod-end_pm25'); unHighlightMod('link_pm25');" onmouseover="highlightMod('mod_mod-start_pm25'); highlightMod('mod_mod-end_pm25'); highlightMod('link_pm25');" id="mod_mod-start_pm25" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_start_mod-start_pm25"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">24 &gt;</span></span></span>Art. 33<i class="richtext_i richtext_inline">bis</i>.<span id="link_pm25"><span style="font-style: italic; display: none;" id="ref_text_art_33bis"> (L du 23 juillet 2024)</span></span><a style="background-color: #007DAD; color: white; margin-left: 5px; padding: 7px; border-radius: 4px; text-decoration: none; display: none;" id="mod_count_0" href="#">
+                Modifications
+                <span class="badge">1</span></a></p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_62" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Les articles 2<i class="richtext_i richtext_inline">bis</i> à 2<i class="richtext_i richtext_inline">sexies</i> de la présente loi ne sont applicables qu’aux contrats de bail de colocation conclus après l’entrée en vigueur de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2024/07/23/a311/jo" target="new">loi du 23 juillet 2024</a> modifiant la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2006/09/21/n1/jo" target="new">loi modifiée du 21 septembre 2006</a> sur le bail à usage d’habitation et modifiant certaines dispositions du <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/code/civil" target="new">Code civil</a>.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_63" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>L’article 3, paragraphes 1<sup class="richtext_sup richtext_inline">er</sup>, alinéas 2 à 4, et 5, alinéa 3, de la présente loi n’est applicable qu’à partir de la prochaine adaptation du loyer pour les contrats de bail à usage d’habitation conclus avant l’entrée en vigueur de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2024/07/23/a311/jo" target="new">loi précitée du 23 juillet 2024</a>.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les articles 4, 5, paragraphe 1<sup class="richtext_sup richtext_inline">er</sup>, alinéa 1<sup class="richtext_sup richtext_inline">er</sup>, deuxième phrase, et alinéa 2, 12, paragraphe 1<sup class="richtext_sup richtext_inline">er</sup>, et 31, de la présente loi, ne sont applicables qu’aux contrats de bail à usage d’habitation conclus après l’entrée en vigueur de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2024/07/23/a311/jo" target="new">loi précitée du 23 juillet 2024</a>.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p">Les articles 5, paragraphes 1<sup class="richtext_sup richtext_inline">er</sup> et 2, 12, paragraphe 1<sup class="richtext_sup richtext_inline">er</sup>, deuxième phrase, et 31 de la présente loi continuent à s’appliquer dans leur teneur ayant existé avant l’entrée en vigueur de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2024/07/23/a311/jo" target="new">loi précitée du 23 juillet 2024</a> aux baux verbaux et aux contrats de bail à usage d’habitation conclus avant l’entrée en vigueur de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/2024/07/23/a311/jo" target="new">loi précitée du 23 juillet 2024</a>.<span onmouseout="unHighlightMod('mod_mod-start_pm25'); unHighlightMod('mod_mod-end_pm25'); unHighlightMod('link_pm25');" onmouseover="highlightMod('mod_mod-start_pm25'); highlightMod('mod_mod-end_pm25'); highlightMod('link_pm25');" id="mod_mod-end_pm25" style="text-decoration: none; display: none; cursor: pointer;"><span style="display: inline-block; text-decoration: none!important; border-radius: 5px;                              font-weight: normal; font-size: 15px; background-color: #EAF2FF; border: rgb(0, 125, 173)solid 1px;                              padding-left:4px; padding-right:4px; margin-left: 3px; margin-right: 3px; display: none;" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil." id="mod_marker_end_mod-end_pm25"><span style="cursor:pointer; text-decoration: none; display: inline-block" title="Loi du 23 juillet 2024 portant modification : 1° de la loi modifiée du 21 septembre 2006 sur le bail à usage d’habitation et modifiant certaines dispositions du Code civil ; 2° de l’article 1714 du Code civil.">24 &lt;</span></span></span><sup style="display: none;" id="mod_supEnd_mod-end_pm25"> </sup>
+
+</p>
+
+</div>
+</div>
+</div>
+<div id="art_34" class="richtext_article" style=""><a style="color: black;" name="art_34">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 34.</p>
+
+
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_45" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(1)</span>Sont abrogées:</p>
+<table width="100%" class="richtext_ul" style="width:100%!important;"><tr class="richtext_elementLI" style=""><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1955/02/14/n1/jo" target="new">loi modifiée du 14 février 1955</a> portant modification et coordination des dispositions légales et réglementaires en matière de baux à loyer;</span></td></tr><tr class="richtext_elementLI" style="margin-top: 3pt;"><td class="richtext_numLI" style="">–</td><td class="richtext_contentLI"><span class="richtext_li">les articles IV et V de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1987/08/27/n1/jo" target="new">loi du 27 août 1987</a> portant réforme de la législation sur les baux à loyer.</span></td></tr></table>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_46" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(2)</span>Par dérogation au paragraphe (1), premier tiret, l’article 6 de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1955/02/14/n1/jo" target="new">loi modifiée du 14 février 1955</a> restera d’application aussi longtemps que le règlement grand-ducal prévu à l’article 7, paragraphes (1) et (6), de la présente loi n’est pas entré en vigueur.</p>
+
+</div>
+</div>
+<div class="richtext_paragraph richtext_paragraph" id="paragraph_47" style="">
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p"><span style="padding-right:5px; " class=" richtext_num_paragraph richtext_inline">(3)</span>Par dérogation au paragraphe (1), les contrats de bail conclus avant l’entrée en vigueur de la loi et portant sur des logements de luxe visés par l’article 5 de la <a style="cursor: pointer;" href="http://data.legilux.public.lu/eli/etat/leg/loi/1955/02/14/n1/jo" target="new">loi modifiée du 14 février 1955</a> portant modification et coordination des dispositions légales et réglementaires en matière de baux à loyer continuent à courir jusqu’à l’expiration du bail.</p>
+
+</div>
+</div>
+</div>
+<div id="art_35" class="richtext_article" style=""><a style="color: black;" name="art_35">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 35.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Les loyers convenus avant l’entrée en vigueur de la loi ne peuvent être adaptés au niveau résultant de l’application de la présente loi qu’après une notification écrite au locataire.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Le locataire occupant un logement en vertu d’un contrat de bail conclu avant l’entrée en vigueur de la présente loi dispose d’un délai de réflexion de trois mois, à partir de la demande en augmentation du loyer du bailleur en application des dispositions introduites par la présente loi, pour dénoncer le contrat de bail. S’il dénonce le contrat de bail, aucune adaptation du loyer ne peut lui être imposée.</p>
+
+</div>
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">Lorsque le locataire ne dénonce pas le contrat de bail et si l’augmentation du loyer demandée dépasse 10 %, la hausse s’applique par tiers annuels.</p>
+
+</div>
+</div>
+<div id="art_36" class="richtext_article" style=""><a style="color: black;" name="art_36">​</a><p class=" richtext_num_article richtext_inline" style="">Art. 36.</p>
+
+
+<div class="richtext_alinea">
+
+<p style="" class="richtext_p  richtext_p">La présente loi entre en vigueur le premier jour du mois qui suit sa publication au Mémorial.</p>
+
+</div>
+</div>
+</div>
+</div></div>
+<script src="https://data.legilux.public.lu/resources/js/consolidation.js" type="text/javascript"> </script></body></html>

--- a/sources/snapshots/legilux_lu_bail_habitation_consolide_20240801.yml
+++ b/sources/snapshots/legilux_lu_bail_habitation_consolide_20240801.yml
@@ -1,0 +1,15 @@
+id: snapshot.legilux_lu.bail_habitation.consolide_20240801
+schema_version: "0.1.0"
+source_id: source.legilux_lu.bail_habitation
+captured_at: "2026-07-21T06:28:00Z"
+capture_method: http_get
+http_status: 200
+content_type: "text/html"
+content_hash: "sha256:15f5a8e9cb1cbb9b52244821ee60b8dd56b9f3d6980cdd5cda283f5fc98bacdd"
+archive_uri: "sources/snapshots/html/lu/legilux_lu/bail-habitation/loi-2006-09-21-n1-consolide-20240801-fr.html"
+page_url: "http://data.legilux.public.lu/filestore/eli/etat/leg/loi/2006/09/21/n1/consolide/20240801/fr/html/eli-etat-leg-loi-2006-09-21-n1-consolide-20240801-fr-html.html"
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2026-07-21"
+captured_by: software.agent.v0.1
+source_last_modified_at: "2024-08-01T15:22:37Z"


### PR DESCRIPTION
Closes no issue (recreation of PR #185 for review).

- graph/task_templates/bereavement/lu/claim_funeral_allowance.yml: Remove reference to demoted/unbacked funeral allowance 2-year deadline.
- graph/task_templates/bereavement/lu/notify_ccss_business_matters.yml: Remove reference to demoted/unbacked CCSS 8-day deadline.
- packages/cli/src/commands/check-anchors.test.ts: Include missing assertions in test file.
- packages/cli/src/commands/__snapshots__/export-web.test.ts.snap: Update export count snapshot.

Code + tests.