### PR TITLE
Use shared contact email in publiccode.yml

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -116,7 +116,7 @@ maintenance:
   type: internal
   contacts:
     - name: Tommi Rihola
-      email: tommi@clarvia.org
+      email: opensource@clarvia.org
       affiliation: CLARVIA ASBL
 
 intendedAudience:


### PR DESCRIPTION
Changes personal email to shared project address.

- `publiccode.yml`: tommi@clarvia.org -> opensource@clarvia.org

Docs only.