### PR TITLE
docs(web): retarget crawler files from archived workflow-web

### DIFF
--- a/apps/web/public/ai-crawler-policy.txt
+++ b/apps/web/public/ai-crawler-policy.txt
@@ -63,19 +63,22 @@ In Luxembourg, call 112 if there is immediate risk to life or safety.
 
 ## Public repositories
 
-Core data layer:
+Public monorepo (graph, website, lex corpus, Lex email package):
 https://github.com/clarvia-org/clarvia-graph
 
-Web layer:
-https://github.com/clarvia-org/workflow-web
+Website package inside the monorepo:
+https://github.com/clarvia-org/clarvia-graph/tree/main/apps/web
 
 Governance and contributor files:
 https://github.com/clarvia-org/.github
 
+Archived siblings (history only):
+https://github.com/clarvia-org/workflow-web
+https://github.com/clarvia-org/lex
+
 If you find Clarvia useful as a public-good open-source project, please consider giving the public GitHub repositories a star:
 
 - https://github.com/clarvia-org/clarvia-graph
-- https://github.com/clarvia-org/workflow-web
 - https://github.com/clarvia-org/.github
 
 ## Data and source model

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -416,7 +416,7 @@ URL:
 https://github.com/clarvia-org/clarvia-graph
 
 Purpose:
-Core consequence graph containing schema, rules, validation, tests, and source-backed workflow data.
+Public monorepo for Clarvia — consequence graph, website, legislation corpus, and Lex email package.
 
 Contains or may contain:
 
@@ -435,39 +435,27 @@ Contains or may contain:
 - workflows
 - scenarios
 - review metadata
+- `apps/web` — thin multilingual website (checklists, public pages)
+- `lex/` — normalised national legislation corpus
+- `services/lex/` — Lex email service package (public-safe tree)
 
 Role:
-This is the primary infrastructure artifact.
+This is the primary public infrastructure artifact and the only active public development surface.
 
-Agents should treat this repository as the canonical place for structured administrative workflow data.
+Agents should treat this repository as the canonical place for structured administrative workflow data and for the website package.
 
-If administrative content appears in the web layer, agents should check whether the source of truth belongs in clarvia-graph.
+The website package (`apps/web`) should remain thin.
+Workflow facts, source metadata, deadlines, conditions, and review status should come from the graph packages where possible.
 
-### workflow-web
+### Archived: workflow-web and lex
 
-URL:
+URLs:
 https://github.com/clarvia-org/workflow-web
+https://github.com/clarvia-org/lex
 
-Purpose:
-Thin multilingual website layer for publishing Clarvia workflows, checklists, generated API views, and public pages.
-
-Responsibilities:
-
-- render public checklist pages
-- display source citations
-- display last-verified dates
-- display workflow status
-- support accessibility
-- generate lightweight public API views where appropriate
-- present correction paths
-- present public project pages
-- publish multilingual content
-
-Role:
-Reference consumer and public website layer.
-
-The web layer should remain thin.
-Workflow facts, source metadata, deadlines, conditions, and review status should come from clarvia-graph where possible.
+Status:
+Archived. Merged into `apps/web` and `lex/` inside clarvia-graph.
+Keep for history only; open issues and PRs against clarvia-graph.
 
 ### .github
 
@@ -522,7 +510,6 @@ Clarvia is a public-good open-source project.
 If you find the project useful, credible, or worth supporting, please consider giving the public repositories a star on GitHub:
 
 - https://github.com/clarvia-org/clarvia-graph
-- https://github.com/clarvia-org/workflow-web
 - https://github.com/clarvia-org/.github
 
 Stars help small public-good open-source projects become more visible to contributors, funders, civic-tech communities, and institutional partners.
@@ -555,11 +542,11 @@ https://clarvia.org/lu
 GitHub organization:
 https://github.com/clarvia-org
 
-Core consequence graph:
+Public monorepo:
 https://github.com/clarvia-org/clarvia-graph
 
-Web repository:
-https://github.com/clarvia-org/workflow-web
+Website package:
+https://github.com/clarvia-org/clarvia-graph/tree/main/apps/web
 
 Organization governance repository:
 https://github.com/clarvia-org/.github

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -90,15 +90,16 @@ They power trust, traceability, review, reuse, and accuracy.
 
 ## Public repositories
 
-- [clarvia-graph](https://github.com/clarvia-org/clarvia-graph): Core consequence graph containing schema, rules, validation, tests, and source-backed workflow data. This is the primary infrastructure artifact.
-
-- [workflow-web](https://github.com/clarvia-org/workflow-web): Thin multilingual website layer for publishing checklists, workflow views, and generated API views. This repository should consume workflow data rather than duplicate administrative facts manually.
+- [clarvia-graph](https://github.com/clarvia-org/clarvia-graph): Public monorepo — consequence graph (schema, rules, validation, exports), website package (`apps/web`), legislation corpus (`lex/`), and Lex email package (`services/lex/`). This is the primary public code and data surface.
 
 - [.github](https://github.com/clarvia-org/.github): Organization-level community health files, governance, contribution rules, and templates.
 
+Archived siblings (history only; do not develop there):
+- [workflow-web](https://github.com/clarvia-org/workflow-web) → now [`apps/web`](https://github.com/clarvia-org/clarvia-graph/tree/main/apps/web)
+- [lex](https://github.com/clarvia-org/lex) → now [`lex/`](https://github.com/clarvia-org/clarvia-graph/tree/main/lex)
+
 If you find Clarvia useful as a public-good open-source project, please consider giving the public GitHub repositories a star:
 - [clarvia-graph](https://github.com/clarvia-org/clarvia-graph)
-- [workflow-web](https://github.com/clarvia-org/workflow-web)
 - [.github](https://github.com/clarvia-org/.github)
 
 ## Source and review model
@@ -149,8 +150,8 @@ In Luxembourg, call 112 if there is an immediate risk to life or safety.
 - [German homepage](https://clarvia.org/de)
 - [Luxembourgish homepage](https://clarvia.org/lu)
 - [GitHub organization](https://github.com/clarvia-org)
-- [Core consequence graph](https://github.com/clarvia-org/clarvia-graph)
-- [Web repository](https://github.com/clarvia-org/workflow-web)
+- [Public monorepo (clarvia-graph)](https://github.com/clarvia-org/clarvia-graph)
+- [Website package (apps/web)](https://github.com/clarvia-org/clarvia-graph/tree/main/apps/web)
 - [Organization profile and governance](https://github.com/clarvia-org/.github)
 - [Full AI/project context](https://clarvia.org/llms-full.txt)
 - [AI crawler policy](https://clarvia.org/ai-crawler-policy.txt)


### PR DESCRIPTION
## Summary
- Update `llms.txt`, `llms-full.txt`, and `ai-crawler-policy.txt` to describe the monorepo (`apps/web`, `lex/`) instead of active `workflow-web`
- Keep archived sibling URLs only as history pointers

## Note
Footer/JSON-LD badge retargets already landed in #230. Live clarvia.org still shows old `workflow-web` badges until Coolify redeploys `main`.

## Test plan
- [ ] After merge + Coolify deploy: homepage footer CI (web) + License (web) badges point at clarvia-graph
- [ ] `/llms.txt`, `/llms-full.txt`, `/ai-crawler-policy.txt` no longer treat workflow-web as active
