### PR TITLE
lex: global validation — search-grounded URLs, no em-dash hard fail

### DIFF
--- a/services/lex/app/email/composition.py
+++ b/services/lex/app/email/composition.py
@@ -90,9 +90,6 @@ def validate_response_body(body_markdown: str) -> str:
             "Response body must end with 'Lex.' on its own line."
         )
 
-    if "\u2014" in body:
-        raise EmailCompositionError("Response body contains an em dash.")
-
     for fragment in _FORBIDDEN_BODY_FRAGMENTS:
         if fragment.casefold() in body.casefold():
             raise EmailCompositionError(

--- a/services/lex/app/email/parsing.py
+++ b/services/lex/app/email/parsing.py
@@ -23,12 +23,10 @@ _TRUNCATION_MARKER = "[Earlier thread messages omitted due to length.]"
 
 _RELEVANCE_RE = re.compile(
     r"(?i)\b("
-    r"luxembourg|belgium|france|germany|netherlands|portugal|spain|italy|"
-    r"lu\b|be\b|fr\b|de\b|"
     r"mother|father|spouse|husband|wife|partner|son|daughter|parent|brother|"
     r"sister|family|relative|"
     r"died|death|dying|deceased|hospice|palliative|funeral|burial|cremation|"
-    r"repatriation|certificate|declaration|commune|guichet|notary|"
+    r"repatriation|certificate|declaration|commune|notary|"
     r"nationality|citizen|passport|residence|resident|"
     r"bank|pension|estate|inheritance|will|asset|property|"
     r"already|completed|done|obtained|contacted|arranged"

--- a/services/lex/app/llm/research_schema.py
+++ b/services/lex/app/llm/research_schema.py
@@ -37,7 +37,7 @@ MissingField = Literal[
 ]
 
 CountryCode = Annotated[str, Field(pattern=r"^([A-Z]{2}|ZZ)$")]
-HttpsUrl = Annotated[str, Field(min_length=9, max_length=2000, pattern=r"^https://")]
+HttpsUrl = Annotated[str, Field(min_length=9, max_length=2000, pattern=r"^https?://")]
 
 JurisdictionRole = Literal[
     "death_location",
@@ -381,7 +381,7 @@ LEX_RESEARCH_BRIEF_JSON_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "minLength": 9,
                         "maxLength": 2000,
-                        "pattern": "^https://",
+                        "pattern": "^https?://",
                     },
                     "phone": {
                         "anyOf": [
@@ -424,7 +424,7 @@ LEX_RESEARCH_BRIEF_JSON_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "minLength": 9,
                         "maxLength": 2000,
-                        "pattern": "^https://",
+                        "pattern": "^https?://",
                     },
                 },
             },

--- a/services/lex/app/llm/research_validation.py
+++ b/services/lex/app/llm/research_validation.py
@@ -9,7 +9,11 @@ from urllib.parse import urlparse
 
 from app.llm.research_schema import LexResearchBrief
 from app.llm.scenario_validation import validate_no_unsupported_scenarios
-from app.llm.url_normalize import normalize_source_url, normalize_source_url_set
+from app.llm.url_normalize import (
+    is_http_or_https_url,
+    match_search_url,
+    same_site_host,
+)
 
 _LOG = logging.getLogger(__name__)
 
@@ -21,31 +25,12 @@ _DEFERRED_TOPIC_RE = re.compile(
     r")\b"
 )
 
-# Host match (same search host, different language/path) is allowed only here.
-# Do not accept an unrelated page merely because it shares an arbitrary domain.
-_TRUSTED_HOST_SUFFIXES: tuple[str, ...] = (
-    ".public.lu",
-    ".etat.lu",
-    ".europa.eu",
-    ".gouv.fr",
-    ".service-public.fr",
-    ".belgium.be",
-    ".fgov.be",
-    ".bund.de",
-    ".gov.uk",
-    ".gov",
-)
-_TRUSTED_HOSTS_EXACT: frozenset[str] = frozenset(
-    {
-        "guichet.public.lu",
-        "legilux.public.lu",
-        "ccss.lu",
-        "cnap.lu",
-        "cns.lu",
-        "adell.lu",
-        "guichet.etat.lu",
-    }
-)
+_MISSING_FIELD_JURISDICTION_ROLE: dict[str, str] = {
+    "death_country": "death_location",
+    "residence_country": "habitual_residence",
+    "care_country": "care_location",
+    "asset_country": "asset_location",
+}
 
 _FACT_STOPWORDS: frozenset[str] = frozenset(
     {
@@ -171,8 +156,6 @@ _MATERIAL_CLAIM_TOKENS: frozenset[str] = frozenset(
 )
 _SAFE_NON_ENGLISH_PARAPHRASE: frozenset[str] = _FACT_STOPWORDS | frozenset(
     {
-        "luxembourg",
-        "luxembourgish",
         "commune",
         "certificate",
         "medical",
@@ -210,8 +193,8 @@ def _research_retry_instruction(code: str) -> str:
         ),
         "unsupported_contact_website": (
             "The previous research brief used a contact website that is not related "
-            "to its cited source. Use the organisation homepage matching the source "
-            "host, or a trusted institutional host."
+            "to its cited source or web-search results. Use a same-site organisation "
+            "URL from the search evidence."
         ),
         "unsupported_phone_or_email": (
             "The previous research brief included a phone number or email that is not "
@@ -257,23 +240,77 @@ def _hostname(url: str) -> str:
     return (host or "").lower().rstrip(".")
 
 
-def _is_trusted_institutional_host(hostname: str | None) -> bool:
-    if not hostname:
-        return False
-    host = hostname.lower().rstrip(".")
-    if host in _TRUSTED_HOSTS_EXACT:
-        return True
-    return any(
-        host == suffix[1:] or host.endswith(suffix) for suffix in _TRUSTED_HOST_SUFFIXES
-    )
+def _resolve_contact_website(
+    website: str,
+    *,
+    source_url: str | None,
+    search_urls: Collection[str] | None,
+) -> str | None:
+    """Return a search-grounded http(s) website to emit, or None."""
+    if not is_http_or_https_url(website):
+        return None
+    web_host = _hostname(website)
+    if not web_host:
+        return None
+
+    candidates: list[str] = []
+    if search_urls:
+        matched = match_search_url(website, search_urls)
+        if matched:
+            return matched
+        candidates.extend(
+            url for url in search_urls if same_site_host(_hostname(url), web_host)
+        )
+    if source_url and same_site_host(_hostname(source_url), web_host):
+        if search_urls:
+            source_match = match_search_url(source_url, search_urls)
+            if source_match:
+                candidates.append(source_match)
+        candidates.append(source_url)
+    if not candidates:
+        return None
+    # Prefer https search URLs when available.
+    https = [url for url in candidates if url.lower().startswith("https://")]
+    return https[0] if https else candidates[0]
 
 
-def _same_site_host(left: str, right: str) -> bool:
-    a = left.lower().rstrip(".")
-    b = right.lower().rstrip(".")
-    if not a or not b:
-        return False
-    return a == b or a.endswith("." + b) or b.endswith("." + a)
+def _canonicalise_brief_urls(
+    brief: LexResearchBrief,
+    *,
+    web_search_source_urls: Collection[str] | None,
+) -> None:
+    """Rewrite source/contact URLs to matched search URLs when evidence exists."""
+    if web_search_source_urls is None:
+        return
+    search_list = list(web_search_source_urls)
+    new_sources = []
+    for source in brief.sources:
+        matched = match_search_url(source.url, search_list)
+        if matched is None:
+            raise ResearchValidationError(
+                "unsupported_source_url",
+                "Source URL was not returned by web search.",
+            )
+        new_sources.append(source.model_copy(update={"url": matched}))
+    brief.sources = new_sources
+
+    sources_by_id = {source.id: source for source in brief.sources}
+    new_contacts = []
+    for contact in brief.contacts:
+        source = sources_by_id.get(contact.source_id)
+        source_url = source.url if source is not None else None
+        resolved = _resolve_contact_website(
+            contact.website,
+            source_url=source_url,
+            search_urls=search_list,
+        )
+        if resolved is None:
+            raise ResearchValidationError(
+                "unsupported_contact_website",
+                "Contact website is not related to its cited source.",
+            )
+        new_contacts.append(contact.model_copy(update={"website": resolved}))
+    brief.contacts = new_contacts
 
 
 def _renumber_brief_ids(brief: LexResearchBrief) -> None:
@@ -367,22 +404,6 @@ def _fact_grounded(fact: str, conversation_text: str) -> bool:
     return False
 
 
-def _contact_website_allowed(website: str, *, source_url: str | None) -> bool:
-    """Soft guard: HTTPS host must be trusted or same-site as the cited source."""
-    if not website.lower().startswith("https://"):
-        return False
-    web_host = _hostname(website)
-    if not web_host:
-        return False
-    if _is_trusted_institutional_host(web_host):
-        return True
-    if source_url:
-        source_host = _hostname(source_url)
-        if source_host and _same_site_host(web_host, source_host):
-            return True
-    return False
-
-
 def validate_research_brief(
     brief: LexResearchBrief,
     *,
@@ -445,8 +466,6 @@ def validate_research_brief(
         if action.action.casefold() in completed_folded:
             raise ResearchValidationError("completed_action_repeated")
 
-    conversation_folded = conversation_text.casefold()
-    facts_folded = "\n".join(brief.user_facts).casefold()
     # Grounding needs enough conversation context to be meaningful.
     if len(conversation_text.strip()) >= 30:
         for fact in brief.user_facts:
@@ -454,16 +473,12 @@ def validate_research_brief(
                 raise ResearchValidationError("user_fact_not_grounded")
 
     for field in brief.missing_fields:
-        if field == "death_country" and (
-            "luxembourg" in facts_folded
-            or "belgium" in facts_folded
-            or "luxembourg" in conversation_folded
-            or "belgium" in conversation_folded
+        role = _MISSING_FIELD_JURISDICTION_ROLE.get(field)
+        if role and any(
+            jurisdiction.role == role and jurisdiction.country_code != "ZZ"
+            for jurisdiction in brief.jurisdictions
         ):
             raise ResearchValidationError("missing_field_already_known")
-        # residence_country is intentionally NOT checked here — the model
-        # correctly distinguishes death location from residence. A user who
-        # says "died in Luxembourg" may live in France or Germany.
 
     if brief.action == "answer":
         _require(
@@ -515,32 +530,9 @@ def validate_research_brief(
                     "Focused follow-up actions must address current_question.",
                 )
 
-        if web_search_source_urls is not None:
-            allowed = normalize_source_url_set(frozenset(web_search_source_urls))
-            allowed_hosts = frozenset(
-                host for url in web_search_source_urls if (host := _hostname(url))
-            )
-            for source in brief.sources:
-                exact_match = normalize_source_url(source.url) in allowed
-                source_host = _hostname(source.url)
-                host_match = source_host in allowed_hosts and _is_trusted_institutional_host(
-                    source_host
-                )
-                _require(
-                    exact_match or host_match,
-                    "unsupported_source_url",
-                    "Source URL was not returned by web search.",
-                )
-            for contact in brief.contacts:
-                # Contact websites are often org homepages, not search hits.
-                # Soft guard: trusted institutional host or same-site as cited source.
-                source = sources_by_id.get(contact.source_id)
-                source_url = source.url if source is not None else None
-                _require(
-                    _contact_website_allowed(contact.website, source_url=source_url),
-                    "unsupported_contact_website",
-                    "Contact website is not related to its cited source.",
-                )
+        _canonicalise_brief_urls(
+            brief, web_search_source_urls=web_search_source_urls
+        )
 
     elif brief.action == "clarify":
         _require(

--- a/services/lex/app/llm/schema.py
+++ b/services/lex/app/llm/schema.py
@@ -39,7 +39,7 @@ ContactKind = Literal[
 ]
 
 CountryCode = Annotated[str, Field(pattern=r"^([A-Z]{2}|ZZ)$")]
-HttpsUrl = Annotated[str, Field(min_length=9, max_length=2000, pattern=r"^https://")]
+HttpsUrl = Annotated[str, Field(min_length=9, max_length=2000, pattern=r"^https?://")]
 
 
 class LexJurisdiction(BaseModel):
@@ -189,7 +189,7 @@ LEX_RESPONSE_JSON_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "minLength": 9,
                         "maxLength": 2000,
-                        "pattern": "^https://",
+                        "pattern": "^https?://",
                     },
                     "phone": {
                         "anyOf": [
@@ -224,7 +224,7 @@ LEX_RESPONSE_JSON_SCHEMA: dict[str, Any] = {
                         "type": "string",
                         "minLength": 9,
                         "maxLength": 2000,
-                        "pattern": "^https://",
+                        "pattern": "^https?://",
                     },
                 },
             },

--- a/services/lex/app/llm/url_normalize.py
+++ b/services/lex/app/llm/url_normalize.py
@@ -1,17 +1,31 @@
-"""Normalise HTTPS URLs for web-search source-set comparison."""
+"""Normalise and match HTTPS/HTTP URLs against the web-search evidence set."""
 
 from __future__ import annotations
 
+from collections.abc import Collection, Sequence
 from urllib.parse import urlparse, urlunparse
 
 
+def _hostname(url: str) -> str:
+    host = urlparse(url.strip()).hostname
+    return (host or "").lower().rstrip(".")
+
+
+def same_site_host(left: str, right: str) -> bool:
+    a = left.lower().rstrip(".")
+    b = right.lower().rstrip(".")
+    if not a or not b:
+        return False
+    return a == b or a.endswith("." + b) or b.endswith("." + a)
+
+
 def normalize_source_url(url: str) -> str:
-    """Return a canonical form for membership checks against search sources."""
+    """Return a canonical http(s) URL string (scheme preserved)."""
     parsed = urlparse(url.strip())
-    scheme = parsed.scheme.lower()
-    if scheme == "http":
-        scheme = "https"
-    host = (parsed.hostname or "").lower()
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return url.strip()
+    host = (parsed.hostname or "").lower().rstrip(".")
     port = parsed.port
     if port and not (
         (scheme == "https" and port == 443) or (scheme == "http" and port == 80)
@@ -29,4 +43,81 @@ def normalize_source_url_set(urls: frozenset[str] | set[str]) -> frozenset[str]:
     return frozenset(normalize_source_url(url) for url in urls)
 
 
-__all__ = ["normalize_source_url", "normalize_source_url_set"]
+def url_compare_key(url: str) -> str:
+    """Scheme-flexible key: host + path + query (http/https equivalent)."""
+    parsed = urlparse(normalize_source_url(url))
+    host = (parsed.hostname or "").lower().rstrip(".")
+    path = parsed.path or ""
+    if path.endswith("/") and path != "/":
+        path = path.rstrip("/")
+    return f"{host}|{path}|{parsed.query}"
+
+
+def prefer_https_url(candidates: Sequence[str]) -> str:
+    """Prefer an https URL when search returned both schemes for the same resource."""
+    https = [url for url in candidates if url.lower().startswith("https://")]
+    return https[0] if https else candidates[0]
+
+
+def match_search_url(cited: str, search_urls: Collection[str]) -> str | None:
+    """Return the search URL to emit for a cited URL, or None if ungrounded.
+
+    Match order:
+    1. Scheme-flexible exact (host + path + query)
+    2. Same-site search URL with the closest path (language/path variants)
+    On success, prefer https when search returned an https sibling.
+    """
+    if not cited.strip() or not search_urls:
+        return None
+    normalised_cited = normalize_source_url(cited)
+    scheme = (urlparse(normalised_cited).scheme or "").lower()
+    if scheme not in {"http", "https"}:
+        return None
+
+    normalised_search = [normalize_source_url(url) for url in search_urls]
+    key = url_compare_key(normalised_cited)
+    exact = [url for url in normalised_search if url_compare_key(url) == key]
+    if exact:
+        return prefer_https_url(exact)
+
+    cited_host = _hostname(normalised_cited)
+    if not cited_host:
+        return None
+    same_site = [
+        url for url in normalised_search if same_site_host(_hostname(url), cited_host)
+    ]
+    if not same_site:
+        return None
+
+    cited_path = urlparse(normalised_cited).path.rstrip("/") or "/"
+
+    def path_score(url: str) -> tuple[int, int]:
+        path = urlparse(url).path.rstrip("/") or "/"
+        # Higher shared prefix length is better; shorter residual is better.
+        common = 0
+        for left, right in zip(cited_path, path, strict=False):
+            if left != right:
+                break
+            common += 1
+        return (common, -abs(len(path) - len(cited_path)))
+
+    same_site_sorted = sorted(same_site, key=path_score, reverse=True)
+    best_score = path_score(same_site_sorted[0])
+    best = [url for url in same_site_sorted if path_score(url) == best_score]
+    return prefer_https_url(best)
+
+
+def is_http_or_https_url(url: str) -> bool:
+    scheme = (urlparse(url.strip()).scheme or "").lower()
+    return scheme in {"http", "https"} and bool(_hostname(url))
+
+
+__all__ = [
+    "same_site_host",
+    "url_compare_key",
+    "normalize_source_url",
+    "normalize_source_url_set",
+    "prefer_https_url",
+    "match_search_url",
+    "is_http_or_https_url",
+]

--- a/services/lex/app/llm/validation.py
+++ b/services/lex/app/llm/validation.py
@@ -11,7 +11,7 @@ import re
 from collections.abc import Collection
 
 from app.llm.schema import LexResponse
-from app.llm.url_normalize import normalize_source_url, normalize_source_url_set
+from app.llm.url_normalize import match_search_url
 
 _SIGN_OFF_RE = re.compile(r"(?:^|\n)Lex\.\s*$")
 _CITATION_RE = re.compile(r"\[(\d+)\]")
@@ -106,7 +106,6 @@ def _validate_body_text(body: str) -> None:
         "missing_sign_off",
         "body_markdown must end with 'Lex.' on its own line.",
     )
-    _require("\u2014" not in body, "em_dash", "body_markdown contains an em dash.")
     _require(
         _CODE_FENCE_RE.search(body) is None,
         "code_fence",
@@ -211,19 +210,25 @@ def _validate_search_evidence(
         "An answer requires a completed web_search_call.",
     )
 
-    normalised = normalize_source_url_set(frozenset(web_search_source_urls))
+    search_list = list(web_search_source_urls)
     for source in response.sources:
+        matched = match_search_url(source.url, search_list)
         _require(
-            normalize_source_url(source.url) in normalised,
+            matched is not None,
             "unsupported_source_url",
             "A source URL was not returned by web search.",
         )
+        if matched is not None and matched != source.url:
+            source.url = matched
     for contact in response.contacts:
+        matched = match_search_url(contact.website, search_list)
         _require(
-            normalize_source_url(contact.website) in normalised,
+            matched is not None,
             "unsupported_contact_website",
             "A contact website was not returned by web search.",
         )
+        if matched is not None and matched != contact.website:
+            contact.website = matched
 
 
 def _validate_action_rules(response: LexResponse) -> None:

--- a/services/lex/app/llm/writer_validation.py
+++ b/services/lex/app/llm/writer_validation.py
@@ -268,10 +268,6 @@ def validate_written_response(
         if any(
             token in lowered
             for token in (
-                "luxembourg",
-                "belgium",
-                "france",
-                "germany",
                 "monday",
                 "tuesday",
                 "wednesday",
@@ -297,9 +293,11 @@ def validate_written_response(
         ).casefold():
             if "certificate" in body_folded and "commune" in body_folded and "burial" in body_folded:
                 raise WriterValidationError("focused_follow_up_dump")
-        facts_blob = "\n".join(brief.user_facts).casefold()
         if re.search(r"(?i)\b(which country|what country|where (?:did|does)|do you live)\b", body):
-            if "luxembourg" in facts_blob or "belgium" in facts_blob:
+            if any(
+                jurisdiction.country_code != "ZZ"
+                for jurisdiction in brief.jurisdictions
+            ):
                 raise WriterValidationError("asks_known_user_fact")
         _ = latest_user_message
 

--- a/services/lex/app/services/model_pipeline.py
+++ b/services/lex/app/services/model_pipeline.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from app.domain.ports import LlmGenerationResult, LlmPort
 from app.llm.schema import LexContact, LexResponse, LexSource
-from app.llm.url_normalize import normalize_source_url, normalize_source_url_set
+from app.llm.url_normalize import match_search_url
 from app.llm.validation import LexValidationError, validate_lex_response
 
 _CITATION_RE = re.compile(r"\[(\d+)\]")
@@ -75,18 +75,6 @@ def run_model_pipeline(
         )
         return first
     except LexValidationError as first_error:
-        # If normalize left a forbidden dash, strip again hard before retrying.
-        if first_error.code == "em_dash":
-            first = _force_strip_em_dash(first)
-            try:
-                validate_lex_response(
-                    first.response,
-                    web_search_source_urls=first.web_search_source_urls,
-                    web_search_calls=first.web_search_calls,
-                )
-                return first
-            except LexValidationError:
-                pass
         force_search = _should_force_search_on_retry(first_error, first)
         second = llm.generate(
             system_prompt=system_prompt,
@@ -94,7 +82,6 @@ def run_model_pipeline(
             force_web_search=force_search,
         )
         second = _normalize_model_response(second)
-        second = _force_strip_em_dash(second)
         try:
             validate_lex_response(
                 second.response,
@@ -106,45 +93,6 @@ def run_model_pipeline(
             raise ModelPipelineFailure(
                 second_error.code, attempt_count=2
             ) from second_error
-
-
-def _force_strip_em_dash(result: LlmGenerationResult) -> LlmGenerationResult:
-    """Last-resort removal of U+2014 from body and contact notes."""
-    response = result.response
-    body = response.body_markdown.replace("\u2014", " - ")
-    contacts = [
-        contact.model_copy(
-            update={"note": contact.note.replace("\u2014", " - ")}
-        )
-        for contact in response.contacts
-    ]
-    sources = [
-        source.model_copy(
-            update={
-                "title": source.title.replace("\u2014", " - "),
-                "publisher": source.publisher.replace("\u2014", " - "),
-            }
-        )
-        for source in response.sources
-    ]
-    if (
-        body == response.body_markdown
-        and contacts == list(response.contacts)
-        and sources == list(response.sources)
-    ):
-        return result
-    return LlmGenerationResult(
-        response=response.model_copy(
-            update={
-                "body_markdown": body,
-                "contacts": contacts,
-                "sources": sources,
-            }
-        ),
-        openai_response_id=result.openai_response_id,
-        web_search_source_urls=result.web_search_source_urls,
-        web_search_calls=result.web_search_calls,
-    )
 
 
 def _normalize_model_response(result: LlmGenerationResult) -> LlmGenerationResult:
@@ -171,9 +119,11 @@ def _normalize_model_response(result: LlmGenerationResult) -> LlmGenerationResul
     ]
 
     if response.action == "answer" and result.web_search_source_urls:
-        allowed = normalize_source_url_set(result.web_search_source_urls)
         body, sources, contacts = _repair_search_evidence(
-            body, sources, contacts, allowed
+            body,
+            sources,
+            contacts,
+            search_urls=list(result.web_search_source_urls),
         )
 
     body_folded = body.casefold()
@@ -215,16 +165,19 @@ def _normalize_model_response(result: LlmGenerationResult) -> LlmGenerationResul
 
 
 def _normalize_dashes(text: str) -> str:
-    """Replace dash-like Unicode so validation never sees U+2014."""
+    """Normalise awkward hyphen variants; leave em dashes in place."""
     import unicodedata
 
     pieces: list[str] = []
     for char in text:
-        if char in {"-", "_"}:
+        if char in {"-", "_", "\u2014"}:
             pieces.append(char)
             continue
         category = unicodedata.category(char)
         name = unicodedata.name(char, "")
+        if "EM DASH" in name:
+            pieces.append(char)
+            continue
         is_dash_like = (
             category == "Pd"
             or char in _DASH_CHARS
@@ -234,31 +187,32 @@ def _normalize_dashes(text: str) -> str:
             or name == "MINUS SIGN"
         )
         if is_dash_like:
-            if ord(char) >= 0x2014 or "EM DASH" in name or "HORIZONTAL BAR" in name:
+            if "HORIZONTAL BAR" in name or ord(char) >= 0x2015:
                 pieces.append(" - ")
             else:
                 pieces.append("-")
         else:
             pieces.append(char)
-    # Final hard strip of the forbidden code point.
-    return "".join(pieces).replace("\u2014", " - ")
+    return "".join(pieces)
 
 
 def _repair_search_evidence(
     body: str,
     sources: list[LexSource],
     contacts: list[LexContact],
-    allowed: frozenset[str],
+    *,
+    search_urls: list[str],
 ) -> tuple[str, list[LexSource], list[LexContact]]:
-    """Drop/remap sources and contacts that cite URLs outside the search set."""
+    """Rewrite or drop sources/contacts using search-grounded URLs."""
     kept_sources: list[LexSource] = []
     old_to_new: dict[int, int] = {}
     for source in sources:
-        if normalize_source_url(source.url) not in allowed:
+        matched = match_search_url(source.url, search_urls)
+        if matched is None:
             continue
         new_id = len(kept_sources) + 1
         old_to_new[source.id] = new_id
-        kept_sources.append(source.model_copy(update={"id": new_id}))
+        kept_sources.append(source.model_copy(update={"id": new_id, "url": matched}))
 
     # Remap citation markers; drop markers whose sources were removed.
     def _rewrite_marker(match: re.Match[str]) -> str:
@@ -276,17 +230,17 @@ def _repair_search_evidence(
         new_source_id = old_to_new.get(contact.source_id)
         if new_source_id is None:
             continue
-        website = contact.website
-        if normalize_source_url(website) not in allowed:
+        website = match_search_url(contact.website, search_urls)
+        if website is None:
             website = source_by_new[new_source_id].url
-        if normalize_source_url(website) not in allowed:
+        if match_search_url(website, search_urls) is None:
             continue
         kept_contacts.append(
             contact.model_copy(
                 update={
                     "id": len(kept_contacts) + 1,
                     "source_id": new_source_id,
-                    "website": website,
+                    "website": match_search_url(website, search_urls) or website,
                 }
             )
         )

--- a/services/lex/tests/unit/test_email_composition.py
+++ b/services/lex/tests/unit/test_email_composition.py
@@ -189,9 +189,8 @@ def test_missing_sign_off_rejected() -> None:
         validate_response_body("No sign off here.")
 
 
-def test_em_dash_rejected() -> None:
-    with pytest.raises(EmailCompositionError):
-        validate_response_body("Body with em dash \u2014 here.\n\nLex.")
+def test_em_dash_allowed() -> None:
+    validate_response_body("Body with em dash \u2014 here.\n\nLex.")
 
 
 def test_forbidden_footer_fragment_in_body_rejected() -> None:

--- a/services/lex/tests/unit/test_lex_schema.py
+++ b/services/lex/tests/unit/test_lex_schema.py
@@ -46,7 +46,30 @@ def test_body_markdown_length_bounds() -> None:
         make_answer_response(body_markdown="x" * 18_001)
 
 
-def test_source_url_must_be_https() -> None:
+def test_source_url_allows_http() -> None:
+    response = LexResponse.model_validate(
+        {
+            "response_version": "lex_response_v1",
+            "action": "answer",
+            "language": "en",
+            "jurisdictions": [],
+            "body_markdown": "Body [1].\n\nLex.",
+            "contacts": [],
+            "sources": [
+                {
+                    "id": 1,
+                    "title": "t",
+                    "publisher": "p",
+                    "url": "http://insecure.example",
+                }
+            ],
+            "research_status": "adequate",
+        }
+    )
+    assert response.sources[0].url.startswith("http://")
+
+
+def test_source_url_rejects_non_web_scheme() -> None:
     with pytest.raises(ValidationError):
         LexResponse.model_validate(
             {
@@ -61,7 +84,7 @@ def test_source_url_must_be_https() -> None:
                         "id": 1,
                         "title": "t",
                         "publisher": "p",
-                        "url": "http://insecure.example",
+                        "url": "javascript:alert(1)",
                     }
                 ],
                 "research_status": "adequate",

--- a/services/lex/tests/unit/test_lex_validation.py
+++ b/services/lex/tests/unit/test_lex_validation.py
@@ -54,11 +54,13 @@ def test_missing_sign_off() -> None:
     _assert_code(exc, "missing_sign_off")
 
 
-def test_em_dash_rejected() -> None:
-    resp = make_answer_response(body_markdown="Text \u2014 more [1].\n\nLex.")
-    with pytest.raises(LexValidationError) as exc:
-        validate_lex_response(resp)
-    _assert_code(exc, "em_dash")
+def test_em_dash_allowed() -> None:
+    resp = make_answer_response(
+        body_markdown=(
+            "Text \u2014 more. Contact the Commune office [1].\n\nLex."
+        )
+    )
+    validate_lex_response(resp)
 
 
 def test_code_fence_rejected() -> None:

--- a/services/lex/tests/unit/test_model_pipeline.py
+++ b/services/lex/tests/unit/test_model_pipeline.py
@@ -43,8 +43,12 @@ def test_provider_neutrality_allows_does_not_recommend_disclaimer() -> None:
         system_prompt="prompt",
         runtime_envelope="envelope",
     )
-    assert "\u2014" not in result.response.body_markdown
-    assert " - " in result.response.body_markdown
+    assert "\u2014" in result.response.body_markdown
+    validate_lex_response(
+        result.response,
+        web_search_source_urls=frozenset({"https://guichet.public.lu"}),
+        web_search_calls=1,
+    )
 
 
 def test_pipeline_injects_contact_names_missing_from_body() -> None:
@@ -107,19 +111,19 @@ def test_pipeline_repairs_unsupported_contact_website() -> None:
     )
 
 
-def test_pipeline_strips_em_dash_from_injected_contact_names() -> None:
+def test_pipeline_preserves_em_dash_in_contact_names() -> None:
     response = make_answer_response()
     contact = response.contacts[0].model_copy(
         update={"name": "Commune\u2014office"}
     )
-    body = response.body_markdown.replace("Commune office", "the local office")
-    broken = response.model_copy(
+    body = response.body_markdown.replace("Commune office", "Commune\u2014office")
+    dashed = response.model_copy(
         update={"body_markdown": body, "contacts": [contact]}
     )
     llm = FakeLlmAdapter(
         responses=[
             generation_result_from_response(
-                broken,
+                dashed,
                 source_urls=frozenset({"https://guichet.public.lu"}),
             )
         ]
@@ -129,8 +133,8 @@ def test_pipeline_strips_em_dash_from_injected_contact_names() -> None:
         system_prompt="prompt",
         runtime_envelope="envelope",
     )
-    assert "\u2014" not in result.response.body_markdown
-    assert "\u2014" not in result.response.contacts[0].name
+    assert "\u2014" in result.response.body_markdown
+    assert "\u2014" in result.response.contacts[0].name
     validate_lex_response(
         result.response,
         web_search_source_urls=frozenset({"https://guichet.public.lu"}),

--- a/services/lex/tests/unit/test_openai_adapter.py
+++ b/services/lex/tests/unit/test_openai_adapter.py
@@ -33,7 +33,7 @@ def test_extract_urls_from_nested_web_search_payload() -> None:
     }
     urls = extract_web_search_source_urls(payload)
     assert "https://guichet.public.lu/guide" in urls
-    assert "https://example.lu/page" in urls
+    assert "http://example.lu/page" in urls
     assert count_web_search_calls(payload) == 1
 
 

--- a/services/lex/tests/unit/test_research_validation_followups.py
+++ b/services/lex/tests/unit/test_research_validation_followups.py
@@ -1,14 +1,18 @@
-"""Unit tests for research-validation follow-ups (trusted hosts, grounding, IDs)."""
+"""Unit tests for research-validation follow-ups (search grounding, IDs)."""
 
 from __future__ import annotations
 
 import pytest
-from app.llm.research_schema import ResearchContact, ResearchSource
+from app.llm.research_schema import (
+    ResearchContact,
+    ResearchJurisdiction,
+    ResearchSource,
+)
 from app.llm.research_validation import ResearchValidationError, validate_research_brief
 from tests.unit.test_two_pass import _brief
 
 
-def test_trusted_host_allows_language_path_variant() -> None:
+def test_same_site_language_path_variant_emits_search_url() -> None:
     brief = _brief(
         sources=[
             ResearchSource(
@@ -63,23 +67,103 @@ def test_trusted_host_allows_language_path_variant() -> None:
             ),
         ],
     )
+    search_en = "https://guichet.public.lu/en/citoyens/famille/deces.html"
     validate_research_brief(
         brief,
-        web_search_source_urls=frozenset(
-            {
-                "https://guichet.public.lu/en/citoyens/famille/deces.html",
-                "https://fpf.lu",
-            }
-        ),
+        web_search_source_urls=frozenset({search_en, "https://fpf.lu"}),
         web_search_calls=1,
         conversation_text=(
             "My mother is in Haus Omega hospice in Luxembourg with only a few days "
             "remaining. What should we prepare after she dies?"
         ),
     )
+    assert brief.sources[0].url == search_en
+    assert brief.contacts[0].website == search_en
+    assert brief.contacts[1].website == "https://fpf.lu"
+    assert brief.contacts[2].website == "https://fpf.lu"
 
 
-def test_untrusted_host_match_rejected() -> None:
+def test_http_and_non_lu_host_grounded_in_search() -> None:
+    search_http = "http://www.moh.gov.zw/palliative-care"
+    brief = _brief(
+        jurisdictions=[
+            ResearchJurisdiction(
+                country_code="ZW", subdivision=None, role="care_location"
+            )
+        ],
+        user_facts=[
+            "Mother is in palliative care in Harare, Zimbabwe",
+            "Only a few days of expected life remaining",
+        ],
+        sources=[
+            ResearchSource(
+                id=1,
+                title="Palliative care guidance",
+                publisher="Ministry of Health",
+                url="https://www.moh.gov.zw/palliative-care",
+            ),
+            ResearchSource(
+                id=2,
+                title="Funeral guidance",
+                publisher="City of Harare",
+                url="http://www.hararecity.co.zw/funerals",
+            ),
+        ],
+        contacts=[
+            ResearchContact(
+                id=1,
+                name="Ministry of Health",
+                kind="support_service",
+                country_code="ZW",
+                website="http://www.moh.gov.zw",
+                phone=None,
+                email=None,
+                commercial=False,
+                note="National guidance",
+                source_id=1,
+            ),
+            ResearchContact(
+                id=2,
+                name="City funeral desk A",
+                kind="funeral_provider",
+                country_code="ZW",
+                website="http://www.hararecity.co.zw/funerals",
+                phone=None,
+                email=None,
+                commercial=False,
+                note="Local orientation",
+                source_id=2,
+            ),
+            ResearchContact(
+                id=3,
+                name="City funeral desk B",
+                kind="funeral_provider",
+                country_code="ZW",
+                website="http://www.hararecity.co.zw/funerals",
+                phone=None,
+                email=None,
+                commercial=False,
+                note="Local orientation",
+                source_id=2,
+            ),
+        ],
+    )
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset(
+            {search_http, "http://www.hararecity.co.zw/funerals"}
+        ),
+        web_search_calls=1,
+        conversation_text=(
+            "My mother is in palliative care in Harare, Zimbabwe with only a few days "
+            "remaining. What should we prepare after she dies?"
+        ),
+    )
+    assert brief.sources[0].url == search_http
+    assert brief.contacts[0].website == search_http
+
+
+def test_ungrounded_host_rejected() -> None:
     brief = _brief(
         sources=[
             ResearchSource(
@@ -100,7 +184,7 @@ def test_untrusted_host_match_rejected() -> None:
         validate_research_brief(
             brief,
             web_search_source_urls=frozenset(
-                {"https://medium.com/other-post", "https://fpf.lu"}
+                {"https://example.org/other-post", "https://fpf.lu"}
             ),
             web_search_calls=1,
             conversation_text=(

--- a/services/lex/tests/unit/test_two_pass_coverage.py
+++ b/services/lex/tests/unit/test_two_pass_coverage.py
@@ -19,7 +19,7 @@ from app.domain.ports import StructuredLlmResult
 from app.infrastructure.openai import FakeLlmAdapter
 from app.llm.clarify_decline import render_clarification_body
 from app.llm.deterministic_renderer import render_research_brief_fallback
-from app.llm.research_schema import ResearchImmediateAction
+from app.llm.research_schema import ResearchImmediateAction, ResearchJurisdiction
 from app.llm.research_validation import ResearchValidationError, validate_research_brief
 from app.llm.writer_schema import LexWrittenResponse
 from app.llm.writer_validation import WriterValidationError, validate_written_response
@@ -473,7 +473,16 @@ def test_research_focused_follow_up_and_missing_field_conflicts() -> None:
 
     with pytest.raises(ResearchValidationError) as exc:
         validate_research_brief(
-            _brief(missing_fields=["death_country"]),
+            _brief(
+                missing_fields=["death_country"],
+                jurisdictions=[
+                    ResearchJurisdiction(
+                        country_code="LU",
+                        subdivision="Luxembourg",
+                        role="death_location",
+                    )
+                ],
+            ),
             web_search_source_urls=_URLS,
             web_search_calls=1,
             conversation_text="Death was in Luxembourg at the hospice.",


### PR DESCRIPTION
## Summary
- Remove em-dash hard fails so valid bodies are not rejected.
- Replace trusted-host allowlist with search-set grounding: match cited http(s) URLs, emit the matched search URL (prefer https when both exist).
- Neutralize LU/BE/FR/DE special cases in research/writer validation and parsing relevance; keep `Europe/Luxembourg` only as ops rate-limit TZ.

## Test plan
- [x] `services/lex` unit tests (`pytest tests/unit`)
- [ ] Redeploy Lex after merge (image bake)
- [ ] Smoke: non-LU http search hit validates; em-dash body allowed