### PR TITLE
docs: clarify Lex privacy boundary vs client-side checklist

### DIFF
--- a/DPG.md
+++ b/DPG.md
@@ -74,11 +74,13 @@ The repository integrates and targets alignment with the following standards:
 
 ## Privacy and data protection
 
-Clarvia Graph does not require personal bereavement case data to be submitted to operate the public workflow infrastructure. Phase one is based on official sources, structured source metadata, workflow definitions, and non-personal administrative guidance.
+Clarvia Graph’s core data and static checklist do not require personal case information to be submitted to Clarvia. They operate using official sources, structured metadata, workflow definitions, and client-side condition evaluation.
 
-- **Client-side evaluation**: Circumstance and conditional rules are evaluated client-side in the user's browser or local application via `@clarvia/generator`.
-- **No data harvesting**: Personal circumstances, dates, or identities do not need to be sent to Clarvia servers for the core workflow logic. The graph/data layer is designed to avoid collecting personal case files.
-- **Privacy review**: Any future feature involving personal data or server-side synchronization must go through privacy and security impact review before deployment.
+* **Client-side checklist evaluation**: Circumstance and conditional rules are evaluated in the user’s browser or local application through `@clarvia/generator`.
+* **Lex service boundary**: Lex is a separate automated email service. It processes email addresses, message content, thread history, and recipient information as needed to provide and continue responses.
+* **Data minimisation**: Lex users are asked not to include names or other identifying information about living people in their questions and to share only what is necessary.
+* **Privacy information**: Personal-data handling by Lex and other Clarvia services is described in Clarvia’s existing [Privacy & Cookie Policy](https://clarvia.org/en/privacy).
+* **Privacy review**: Features involving personal data or server-side processing must undergo privacy and security review before deployment.
 
 ## Do no harm and safety boundaries
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Every checklist item traces back to an official source. No legal consequence pub
 - **Three-valued logic**: Conditions evaluate to `true`, `false`, or `unknown` — never hides uncertainty
 - **Cross-border**: Jurisdiction roles (death_place, habitual_residence, work_state, asset_situs) compose layered checklists
 - **Static exports**: Consumer apps load generated JSON at build time — no runtime API dependency
-- **Privacy-first**: Client-side condition evaluation, no user data sent to servers
+- **Privacy-first checklist**: Checklist conditions are evaluated client-side, so personal circumstances are not sent to Clarvia’s servers for checklist generation. Separate services such as Lex process information as described in Clarvia’s [Privacy & Cookie Policy](https://clarvia.org/en/privacy).
 - **Public/private fence**: Production secrets and live Lex prompts stay out of this repository (see [`docs/MONOREPO.md`](docs/MONOREPO.md))
 
 ## Software quality and reproducibility

--- a/docs/FOUNDATION.md
+++ b/docs/FOUNDATION.md
@@ -38,7 +38,7 @@ For the full data model, see the [JSON Schema definitions](../schemas/v0.1).
 - **Three-valued logic** — conditions evaluate to `true`, `false`, or `unknown`; uncertainty is never hidden
 - **Cross-border composition** — jurisdiction roles (death place, habitual residence, work state, asset situs) compose layered checklists
 - **Static exports** — consumer apps load generated JSON at build time with no runtime API dependency
-- **Privacy-first** — condition evaluation happens client-side; no user data is sent to servers
+- **Privacy-first checklist** — condition evaluation happens client-side, so personal circumstances are not sent to Clarvia’s servers for checklist generation. This does not apply to separate communication services such as Lex.
 
 ---
 

--- a/services/lex/README.md
+++ b/services/lex/README.md
@@ -2,7 +2,7 @@
 
 [![Lex email CI](https://github.com/clarvia-org/clarvia-graph/actions/workflows/validate-lex-email.yml/badge.svg)](https://github.com/clarvia-org/clarvia-graph/actions/workflows/validate-lex-email.yml)
 
-Automated bereavement and end-of-life information service for `lex@clarvia.org`. People email a question; Lex replies with an LLM-generated answer plus an application-composed continuation note and approved footer.
+Automated bereavement and end-of-life information service for `lex@clarvia.org`. People email a question; Lex replies with an LLM-generated answer plus an application-composed continuation note and approved footer. Production personal-data handling is described in Clarvia’s [Privacy & Cookie Policy](https://clarvia.org/en/privacy).
 
 > **Monorepo path:** [`services/lex/`](https://github.com/clarvia-org/clarvia-graph/tree/main/services/lex) inside [`clarvia-graph`](https://github.com/clarvia-org/clarvia-graph).  
 > **Not this package:** legislation data lives at repo-root [`lex/`](../../lex/).  


### PR DESCRIPTION
## Summary
- Narrow README and FOUNDATION privacy claims to the client-side checklist.
- Rewrite DPG privacy section to separate graph/checklist from Lex.
- Point `services/lex/README.md` at the public Privacy & Cookie Policy.
- No application, config, form, brochure, or privacy-policy code changes.

## Test plan
- [ ] Skim the four markdown diffs for wording accuracy
- [ ] Confirm `apps/web/public/brochure.html` is untouched