### PR TITLE
lex: dialogue repair — drop non-material facts, conversation-aware exceptional gating

### DIFF
--- a/services/lex/app/llm/research_validation.py
+++ b/services/lex/app/llm/research_validation.py
@@ -8,7 +8,10 @@ from collections.abc import Collection
 from urllib.parse import urlparse
 
 from app.llm.research_schema import LexResearchBrief
-from app.llm.scenario_validation import validate_no_unsupported_scenarios
+from app.llm.scenario_validation import (
+    exceptional_scenario_hits,
+    validate_no_unsupported_scenarios,
+)
 from app.llm.url_normalize import (
     is_http_or_https_url,
     match_search_url,
@@ -201,8 +204,9 @@ def _research_retry_instruction(code: str) -> str:
             "supported by its cited source. Remove unsupported contact details."
         ),
         "user_fact_not_grounded": (
-            "The previous research brief included user_facts that are not present in "
-            "the cleaned conversation. Keep only facts stated by the user."
+            "The previous research brief included material user_facts that are not "
+            "present in the cleaned conversation. Keep only facts stated by the user; "
+            "do not invent places, accidents, or other material claims."
         ),
         "deferred_topic_in_immediate_actions": (
             "The previous research brief put later administrative topics into "
@@ -212,7 +216,8 @@ def _research_retry_instruction(code: str) -> str:
         ),
         "unsupported_exceptional_scenario": (
             "The previous research brief introduced police, emergency services, or "
-            "another exceptional scenario unsupported by user_facts. Remove it."
+            "another exceptional scenario unsupported by the conversation or "
+            "user_facts. Remove it unless the user already described that situation."
         ),
         "missing_field_already_known": (
             "The previous research brief listed a missing_field that is already known "
@@ -374,6 +379,19 @@ def _fact_tokens(fact: str) -> list[str]:
     ]
 
 
+def fact_is_material(fact: str) -> bool:
+    """True when an ungegrounded fact must not be silently dropped.
+
+    Material means place/jurisdiction claims (``_MATERIAL_CLAIM_TOKENS``) or
+    exceptional-scenario invention claims (accident/police/…). This is not a
+    content-safety refusal layer.
+    """
+    tokens = set(_fact_tokens(fact))
+    if tokens & _MATERIAL_CLAIM_TOKENS:
+        return True
+    return bool(exceptional_scenario_hits(fact))
+
+
 def _fact_grounded(fact: str, conversation_text: str) -> bool:
     folded = conversation_text.casefold()
     fact_lower = fact.casefold()
@@ -404,6 +422,28 @@ def _fact_grounded(fact: str, conversation_text: str) -> bool:
     return False
 
 
+def _repair_user_facts(brief: LexResearchBrief, conversation_text: str) -> None:
+    """Drop ungegrounded non-material facts; raise on ungegrounded material facts."""
+    if len(conversation_text.strip()) < 30:
+        return
+    kept: list[str] = []
+    dropped_non_material: list[str] = []
+    for fact in brief.user_facts:
+        if _fact_grounded(fact, conversation_text):
+            kept.append(fact)
+            continue
+        if fact_is_material(fact):
+            raise ResearchValidationError("user_fact_not_grounded")
+        dropped_non_material.append(fact)
+    if dropped_non_material:
+        _LOG.info(
+            "Dropped %s ungegrounded non-material user_facts: %s",
+            len(dropped_non_material),
+            dropped_non_material,
+        )
+    brief.user_facts = kept
+
+
 def validate_research_brief(
     brief: LexResearchBrief,
     *,
@@ -428,7 +468,6 @@ def validate_research_brief(
 
     source_id_set = set(source_ids)
     contact_id_set = set(contact_ids)
-    sources_by_id = {source.id: source for source in brief.sources}
     for contact in brief.contacts:
         _require(
             contact.source_id in source_id_set,
@@ -449,6 +488,9 @@ def validate_research_brief(
                 "Action references a missing contact.",
             )
 
+    # Repair facts before exceptional gating so drops cannot erase conversation truth.
+    _repair_user_facts(brief, conversation_text)
+
     action_blob = "\n".join(
         f"{item.action}\n{item.explanation}" for item in brief.immediate_actions
     )
@@ -456,6 +498,7 @@ def validate_research_brief(
         text=action_blob,
         safety_status=brief.safety_status,
         user_facts=brief.user_facts,
+        conversation_text=conversation_text,
     )
     if scenario_code:
         raise ResearchValidationError(scenario_code)
@@ -465,12 +508,6 @@ def validate_research_brief(
     for action in brief.immediate_actions:
         if action.action.casefold() in completed_folded:
             raise ResearchValidationError("completed_action_repeated")
-
-    # Grounding needs enough conversation context to be meaningful.
-    if len(conversation_text.strip()) >= 30:
-        for fact in brief.user_facts:
-            if not _fact_grounded(fact, conversation_text):
-                raise ResearchValidationError("user_fact_not_grounded")
 
     for field in brief.missing_fields:
         role = _MISSING_FIELD_JURISDICTION_ROLE.get(field)
@@ -554,4 +591,8 @@ def validate_research_brief(
         brief.contacts = []
 
 
-__all__ = ["ResearchValidationError", "validate_research_brief"]
+__all__ = [
+    "ResearchValidationError",
+    "fact_is_material",
+    "validate_research_brief",
+]

--- a/services/lex/app/llm/scenario_validation.py
+++ b/services/lex/app/llm/scenario_validation.py
@@ -101,14 +101,28 @@ def facts_support_exceptional_scenario(user_facts: Sequence[str]) -> bool:
     return bool(exceptional_scenario_hits(joined))
 
 
+def conversation_supports_exceptional_scenario(conversation_text: str) -> bool:
+    """True when the cleaned conversation already establishes an exceptional scenario."""
+    return bool(exceptional_scenario_hits(conversation_text or ""))
+
+
 def validate_no_unsupported_scenarios(
     *,
     text: str,
     safety_status: str,
     user_facts: Sequence[str],
+    conversation_text: str = "",
 ) -> str | None:
-    """Return an error code when exceptional scenarios are invented."""
+    """Return an error code when exceptional scenarios are invented.
+
+    Support is ``conversation ∪ user_facts`` (plus ``immediate_risk``). Conversation
+    is always consulted so repaired/dropped facts cannot erase user-stated accidents.
+    This is anti-hallucination for ordinary bereavement — not a second content-safety
+    stack on top of the LLM provider guardrails.
+    """
     if safety_status == "immediate_risk":
+        return None
+    if conversation_supports_exceptional_scenario(conversation_text):
         return None
     if facts_support_exceptional_scenario(user_facts):
         return None
@@ -121,5 +135,6 @@ def validate_no_unsupported_scenarios(
 __all__ = [
     "exceptional_scenario_hits",
     "facts_support_exceptional_scenario",
+    "conversation_supports_exceptional_scenario",
     "validate_no_unsupported_scenarios",
 ]

--- a/services/lex/app/llm/writer_validation.py
+++ b/services/lex/app/llm/writer_validation.py
@@ -172,6 +172,7 @@ def validate_written_response(
     brief: LexResearchBrief,
     *,
     latest_user_message: str = "",
+    conversation_text: str = "",
 ) -> None:
     body = written.body_markdown
     action_ids = {action.id for action in brief.immediate_actions}
@@ -224,6 +225,7 @@ def validate_written_response(
         text=body,
         safety_status=brief.safety_status,
         user_facts=brief.user_facts,
+        conversation_text=conversation_text or latest_user_message,
     )
     if scenario_code:
         raise WriterValidationError(scenario_code)

--- a/services/lex/app/pipeline/two_pass.py
+++ b/services/lex/app/pipeline/two_pass.py
@@ -205,6 +205,7 @@ def run_two_pass_pipeline(
         settings=settings,
         system_prompt=writer_prompt,
         latest_user_message=cleaned.latest_user_message,
+        conversation_text=cleaned.conversation_text,
         relevant_history=relevant,
         brief=brief,
     )
@@ -303,6 +304,7 @@ def _run_writer_with_retry(
     settings: object,
     system_prompt: str,
     latest_user_message: str,
+    conversation_text: str,
     relevant_history: list,
     brief: LexResearchBrief,
 ) -> tuple[LexWrittenResponse, bool, str | None]:
@@ -332,6 +334,7 @@ def _run_writer_with_retry(
                 written,
                 brief,
                 latest_user_message=latest_user_message,
+                conversation_text=conversation_text,
             )
             return written, False, result.openai_response_id
         except WriterValidationError as exc:

--- a/services/lex/tests/unit/test_research_validation_followups.py
+++ b/services/lex/tests/unit/test_research_validation_followups.py
@@ -5,11 +5,24 @@ from __future__ import annotations
 import pytest
 from app.llm.research_schema import (
     ResearchContact,
+    ResearchImmediateAction,
     ResearchJurisdiction,
     ResearchSource,
 )
-from app.llm.research_validation import ResearchValidationError, validate_research_brief
+from app.llm.research_validation import (
+    ResearchValidationError,
+    fact_is_material,
+    validate_research_brief,
+)
 from tests.unit.test_two_pass import _brief
+
+
+def test_fact_is_material_place_and_exceptional() -> None:
+    assert fact_is_material("The family owns a vineyard in Chile")
+    assert fact_is_material("There was a car accident last night")
+    assert not fact_is_material(
+        "Relatives are coordinating privately about paperwork tonight"
+    )
 
 
 def test_same_site_language_path_variant_emits_search_url() -> None:
@@ -353,3 +366,139 @@ def test_non_contiguous_ids_are_renumbered() -> None:
     assert brief.contacts[0].source_id == 1
     assert brief.contacts[1].source_id == 2
     assert [action.id for action in brief.immediate_actions] == ["A1", "A2", "A3"]
+
+
+def test_drops_ungrounded_non_material_user_facts() -> None:
+    conversation = (
+        "My mother is in Haus Omega hospice in Luxembourg with only a few days "
+        "remaining. What should we prepare after she dies?"
+    )
+    brief = _brief(
+        user_facts=[
+            "Mother lives in Haus Omega hospice in Luxembourg",
+            "Relatives are coordinating privately about paperwork tonight",
+        ]
+    )
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset(
+            {"https://guichet.public.lu", "https://fpf.lu"}
+        ),
+        web_search_calls=1,
+        conversation_text=conversation,
+    )
+    assert brief.user_facts == [
+        "Mother lives in Haus Omega hospice in Luxembourg",
+    ]
+
+
+def test_accident_in_conversation_allows_exceptional_actions_without_fact_copy() -> None:
+    conversation = (
+        "A luxembourgish/polish couple had a car accident in germany last evening. "
+        "The husband died on the spot. What should we do first for the children "
+        "in Luxembourg?"
+    )
+    brief = _brief(
+        situation_stage="recent_death",
+        user_facts=[
+            "Luxembourgish husband died after a crash in Germany",
+            "Children are currently in Luxembourg",
+        ],
+        immediate_actions=[
+            ResearchImmediateAction(
+                id="A1",
+                action="Contact the police station handling the accident for the reference number",
+                explanation="German police hold the case file for the crash.",
+                timing="now",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[1],
+                contact_ids=[],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A2",
+                action="Ask Luxembourg child support services about temporary care",
+                explanation="Children need a lawful care arrangement.",
+                timing="now",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[1],
+                contact_ids=[1],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A3",
+                action="Contact the Luxembourg consular service in Germany",
+                explanation="Consular help after a death abroad.",
+                timing="now",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[1],
+                contact_ids=[],
+                required=True,
+            ),
+        ],
+    )
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset(
+            {"https://guichet.public.lu", "https://fpf.lu"}
+        ),
+        web_search_calls=1,
+        conversation_text=conversation,
+    )
+
+
+def test_hospice_still_rejects_invented_police_actions() -> None:
+    conversation = (
+        "My mother is in Haus Omega hospice in Luxembourg with only a few days "
+        "remaining. What should we prepare after she dies?"
+    )
+    brief = _brief(
+        immediate_actions=[
+            ResearchImmediateAction(
+                id="A1",
+                action="Call the police to report the expected death",
+                explanation="Invented exceptional step.",
+                timing="now",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[1],
+                contact_ids=[],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A2",
+                action="Prepare identity documents for the death declaration",
+                explanation="The commune will need ID documents soon after death.",
+                timing="before_death",
+                handled_by=["family"],
+                documents=["ID cards"],
+                source_ids=[1],
+                contact_ids=[],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A3",
+                action="Compare funeral directors or use a recognised directory",
+                explanation="A funeral director can handle many formalities.",
+                timing="next_few_days",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[2],
+                contact_ids=[2, 3],
+                required=True,
+            ),
+        ]
+    )
+    with pytest.raises(ResearchValidationError) as exc:
+        validate_research_brief(
+            brief,
+            web_search_source_urls=frozenset(
+                {"https://guichet.public.lu", "https://fpf.lu"}
+            ),
+            web_search_calls=1,
+            conversation_text=conversation,
+        )
+    assert exc.value.code == "unsupported_exceptional_scenario"

--- a/services/lex/tests/unit/test_two_pass.py
+++ b/services/lex/tests/unit/test_two_pass.py
@@ -276,6 +276,20 @@ def test_genuine_immediate_risk_allowed() -> None:
     )
 
 
+def test_conversation_accident_supports_exceptional_without_user_facts() -> None:
+    assert (
+        validate_no_unsupported_scenarios(
+            text="Contact the police station handling the accident for the file number.",
+            safety_status="ordinary",
+            user_facts=["Children are currently in Luxembourg"],
+            conversation_text=(
+                "They had a car accident in Germany last night and the husband died."
+            ),
+        )
+        is None
+    )
+
+
 def test_fake_structured_adapter_supports_two_schemas() -> None:
     brief = _brief()
     written = LexWrittenResponse(


### PR DESCRIPTION
## Summary
- Drop ungegrounded **non-material** `user_facts` (log) instead of hard-failing; still retry on ungegrounded **material** place/exceptional claims via `fact_is_material()`.
- Exceptional-scenario support is `conversation ∪ user_facts` (plus `immediate_risk`), so dropping facts cannot erase a user-stated accident.
- Pass cleaned conversation into writer validation. Does **not** double-engineer LLM content-safety refusals.

## Test plan
- [x] `pytest tests/unit` in `services/lex`
- [ ] Replay car-crash style fixture after deploy: must not die solely on paraphrase facts
- [ ] Hospice case still rejects invented police actions

## Follow-ups
- PR2: research dialogue ladder with explicit `action=clarify` when answer cannot stand
- PR3: soft URL strip, continue-dialogue copy, sparse→second-turn eval