### PR TITLE
lex: research dialogue ladder — clarify before technical failure

### DIFF
--- a/services/lex/app/llm/research_degrade.py
+++ b/services/lex/app/llm/research_degrade.py
@@ -1,0 +1,180 @@
+"""Last-resort research degrade so Lex keeps the dialogue open."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from app.llm.research_schema import LexResearchBrief, MissingField
+from app.llm.research_validation import (
+    ResearchValidationError,
+    _fact_grounded,
+    validate_research_brief,
+)
+
+_LOG = logging.getLogger(__name__)
+
+_DEFAULT_CLARIFY_FIELDS: tuple[MissingField, ...] = (
+    "death_country",
+    "subdivision",
+    "other",
+)
+
+
+def _infer_missing_fields(
+    brief: LexResearchBrief,
+    conversation_text: str,
+) -> list[MissingField]:
+    """Pick concrete clarify asks from gaps — dialogue fuel for the next turn."""
+    fields: list[MissingField] = []
+    known_roles = {
+        jurisdiction.role
+        for jurisdiction in brief.jurisdictions
+        if jurisdiction.country_code != "ZZ"
+    }
+    if "death_location" not in known_roles:
+        fields.append("death_country")
+    if "habitual_residence" not in known_roles:
+        fields.append("residence_country")
+    if "care_location" not in known_roles and re.search(
+        r"(?i)\b(child|children|hospice|hospital|palliative)\b",
+        conversation_text,
+    ):
+        fields.append("care_country")
+    if re.search(r"(?i)\b(accident|germany|france|abroad|border)\b", conversation_text):
+        if "subdivision" not in fields:
+            fields.append("subdivision")
+    if not fields:
+        fields.append("other")
+    # Cap to schema max_length 5; prefer the first useful asks.
+    return fields[:3]
+
+
+def _drop_all_ungrounded_facts(
+    brief: LexResearchBrief, conversation_text: str
+) -> list[str]:
+    """Last-resort: drop every ungegrounded fact, including material ones."""
+    if len(conversation_text.strip()) < 30:
+        return []
+    kept: list[str] = []
+    dropped: list[str] = []
+    for fact in brief.user_facts:
+        if _fact_grounded(fact, conversation_text):
+            kept.append(fact)
+        else:
+            dropped.append(fact)
+    brief.user_facts = kept
+    return dropped
+
+
+def _to_clarify_brief(
+    brief: LexResearchBrief, conversation_text: str
+) -> LexResearchBrief:
+    fields = list(brief.missing_fields) or _infer_missing_fields(
+        brief, conversation_text
+    )
+    if not fields:
+        fields = ["other"]
+    return brief.model_copy(
+        update={
+            "action": "clarify",
+            "research_status": "insufficient",
+            "immediate_actions": [],
+            "sources": [],
+            "contacts": [],
+            "later_topics": [],
+            "missing_fields": fields[:5],
+            "off_topic_label": None,
+        }
+    )
+
+
+def _answer_can_stand(
+    brief: LexResearchBrief,
+    *,
+    conversation_text: str,
+    web_search_source_urls: frozenset[str] | None,
+    web_search_calls: int | None,
+) -> bool:
+    if brief.action != "answer":
+        return False
+    try:
+        validate_research_brief(
+            brief,
+            web_search_source_urls=web_search_source_urls,
+            web_search_calls=web_search_calls,
+            conversation_text=conversation_text,
+        )
+        return True
+    except ResearchValidationError:
+        return False
+
+
+def degrade_failed_research_brief(
+    brief: LexResearchBrief,
+    *,
+    conversation_text: str,
+    last_error: str,
+    web_search_source_urls: frozenset[str] | None = None,
+    web_search_calls: int | None = None,
+) -> LexResearchBrief | None:
+    """Turn a failed research brief into a sendable answer or clarify turn.
+
+    Returns None only when even clarify cannot be formed. Does not invent URLs
+    or restore answer content that failed validation.
+    """
+    working = brief.model_copy(deep=True)
+    dropped = _drop_all_ungrounded_facts(working, conversation_text)
+    if dropped:
+        _LOG.info(
+            "Degrade dropped %s ungegrounded user_facts (last_error=%s): %s",
+            len(dropped),
+            last_error,
+            dropped,
+        )
+
+    if working.action in {"clarify", "decline"}:
+        try:
+            validate_research_brief(
+                working,
+                web_search_source_urls=web_search_source_urls,
+                web_search_calls=web_search_calls,
+                conversation_text=conversation_text,
+            )
+            _LOG.info("Degrade kept action=%s after repair", working.action)
+            return working
+        except ResearchValidationError:
+            if working.action == "decline":
+                return None
+            # Fall through to forced clarify reshape.
+
+    if _answer_can_stand(
+        working,
+        conversation_text=conversation_text,
+        web_search_source_urls=web_search_source_urls,
+        web_search_calls=web_search_calls,
+    ):
+        _LOG.info("Degrade restored action=answer after fact repair")
+        return working
+
+    # Explicit clarify — writer must not invent this action.
+    clarify = _to_clarify_brief(working, conversation_text)
+    try:
+        validate_research_brief(
+            clarify,
+            web_search_source_urls=None,
+            web_search_calls=None,
+            conversation_text=conversation_text,
+        )
+        _LOG.info(
+            "Degrade set action=clarify missing_fields=%s (last_error=%s)",
+            clarify.missing_fields,
+            last_error,
+        )
+        return clarify
+    except ResearchValidationError as exc:
+        _LOG.info("Degrade could not form clarify: %s", exc.code)
+        return None
+
+
+__all__ = ["degrade_failed_research_brief"]

--- a/services/lex/app/pipeline/two_pass.py
+++ b/services/lex/app/pipeline/two_pass.py
@@ -17,6 +17,7 @@ from app.domain.ports import LlmPort
 from app.llm.clarify_decline import render_clarification_body, render_decline_body
 from app.llm.deterministic_renderer import render_research_brief_fallback
 from app.llm.prompt_loader import load_prompt
+from app.llm.research_degrade import degrade_failed_research_brief
 from app.llm.research_schema import (
     LEX_RESEARCH_BRIEF_JSON_SCHEMA,
     RESEARCH_SCHEMA_VERSION,
@@ -254,6 +255,11 @@ def _run_research_with_retry(
     force_search = False
     correction: str | None = None
     max_tokens = int(_settings_value(settings, "research_max_output_tokens", 3200))
+    last_brief: LexResearchBrief | None = None
+    last_response_id: str | None = None
+    last_search_urls: frozenset[str] | None = None
+    last_search_calls: int | None = None
+    conversation_text = cleaned.conversation_text  # type: ignore[attr-defined]
     for _attempt in range(2):
         envelope = build_research_envelope(
             cleaned=cleaned,  # type: ignore[arg-type]
@@ -274,11 +280,15 @@ def _run_research_with_retry(
                 max_output_tokens=max_tokens,
             )
             brief = LexResearchBrief.model_validate(result.data)
+            last_brief = brief
+            last_response_id = result.openai_response_id
+            last_search_urls = result.web_search_source_urls
+            last_search_calls = result.web_search_calls
             validate_research_brief(
                 brief,
                 web_search_source_urls=result.web_search_source_urls,
                 web_search_calls=result.web_search_calls,
-                conversation_text=cleaned.conversation_text,  # type: ignore[attr-defined]
+                conversation_text=conversation_text,
             )
             return brief, result.openai_response_id
         except ResearchValidationError as exc:
@@ -295,6 +305,18 @@ def _run_research_with_retry(
                 "The previous research brief failed. Correct it using only the "
                 "cleaned conversation and verified web-search sources."
             )
+
+    if last_brief is not None:
+        degraded = degrade_failed_research_brief(
+            last_brief,
+            conversation_text=conversation_text,
+            last_error=last_error,
+            web_search_source_urls=last_search_urls,
+            web_search_calls=last_search_calls,
+        )
+        if degraded is not None:
+            return degraded, last_response_id
+
     raise TwoPassPipelineFailure(str(last_error), attempt_count=2)
 
 

--- a/services/lex/tests/unit/test_research_degrade.py
+++ b/services/lex/tests/unit/test_research_degrade.py
@@ -1,0 +1,90 @@
+"""Unit tests for research degrade (dialogue ladder)."""
+
+from __future__ import annotations
+
+from app.llm.research_degrade import degrade_failed_research_brief
+from app.llm.research_schema import ResearchImmediateAction, ResearchSource
+from tests.unit.test_two_pass import _brief
+
+
+def test_degrade_empty_answer_becomes_clarify() -> None:
+    brief = _brief(sources=[], immediate_actions=[], contacts=[])
+    degraded = degrade_failed_research_brief(
+        brief,
+        conversation_text=(
+            "My mother is in hospice in Luxembourg with only a few days remaining."
+        ),
+        last_error="answer_without_source",
+    )
+    assert degraded is not None
+    assert degraded.action == "clarify"
+    assert degraded.missing_fields
+    assert not degraded.sources
+    assert not degraded.immediate_actions
+
+
+def test_degrade_restores_answer_after_dropping_material_ungrounded_fact() -> None:
+    conversation = (
+        "My mother is in Haus Omega hospice in Luxembourg with only a few days "
+        "remaining. What should we prepare after she dies?"
+    )
+    brief = _brief(
+        user_facts=[
+            "Mother lives in Haus Omega hospice in Luxembourg",
+            "The family owns a vineyard in Chile",
+        ]
+    )
+    degraded = degrade_failed_research_brief(
+        brief,
+        conversation_text=conversation,
+        last_error="user_fact_not_grounded",
+        web_search_source_urls=frozenset(
+            {"https://guichet.public.lu", "https://fpf.lu"}
+        ),
+        web_search_calls=1,
+    )
+    assert degraded is not None
+    assert degraded.action == "answer"
+    assert "Chile" not in "\n".join(degraded.user_facts)
+    assert any("Luxembourg" in fact for fact in degraded.user_facts)
+
+
+def test_degrade_sets_explicit_clarify_action() -> None:
+    brief = _brief(
+        sources=[
+            ResearchSource(
+                id=1,
+                title="Guide",
+                publisher="X",
+                url="https://invented.example/nope",
+            )
+        ],
+        immediate_actions=[
+            ResearchImmediateAction(
+                id="A1",
+                action="Do something",
+                explanation="Ungrounded source only.",
+                timing="now",
+                handled_by=["family"],
+                documents=[],
+                source_ids=[1],
+                contact_ids=[],
+                required=True,
+            )
+        ],
+        contacts=[],
+    )
+    degraded = degrade_failed_research_brief(
+        brief,
+        conversation_text=(
+            "Father died yesterday after a car accident in Germany. What now?"
+        ),
+        last_error="unsupported_source_url",
+        web_search_source_urls=frozenset({"https://guichet.public.lu"}),
+        web_search_calls=1,
+    )
+    assert degraded is not None
+    assert degraded.action == "clarify"
+    assert "subdivision" in degraded.missing_fields or "death_country" in (
+        degraded.missing_fields
+    )

--- a/services/lex/tests/unit/test_two_pass_coverage.py
+++ b/services/lex/tests/unit/test_two_pass_coverage.py
@@ -24,7 +24,6 @@ from app.llm.research_validation import ResearchValidationError, validate_resear
 from app.llm.writer_schema import LexWrittenResponse
 from app.llm.writer_validation import WriterValidationError, validate_written_response
 from app.pipeline.two_pass import (
-    TwoPassPipelineFailure,
     prepared_to_lex_response,
     run_two_pass_pipeline,
 )
@@ -268,7 +267,7 @@ def test_two_pass_writer_fallback_after_validation_failures() -> None:
     assert "Lex." in prepared.body_markdown
 
 
-def test_two_pass_research_failure_raises_after_retry() -> None:
+def test_two_pass_research_failure_degrades_to_clarify() -> None:
     bad = _brief(sources=[], immediate_actions=[])
     llm = FakeLlmAdapter(
         structured_responses=[
@@ -276,14 +275,16 @@ def test_two_pass_research_failure_raises_after_retry() -> None:
             _structured(bad.model_dump(mode="json"), response_id="r2"),
         ]
     )
-    with pytest.raises(TwoPassPipelineFailure):
-        run_two_pass_pipeline(
-            llm,
-            settings=_settings(),
-            parsed=_parsed(),
-            thread_messages=[_parsed()],
-            current_date_utc=datetime(2026, 7, 25, tzinfo=UTC),
-        )
+    prepared = run_two_pass_pipeline(
+        llm,
+        settings=_settings(),
+        parsed=_parsed(),
+        thread_messages=[_parsed()],
+        current_date_utc=datetime(2026, 7, 25, tzinfo=UTC),
+    )
+    assert prepared.action == "clarify"
+    assert prepared.body_markdown.rstrip().endswith("Lex.")
+    assert "sorry" in prepared.body_markdown.casefold()
 
 
 def test_valid_long_writer_body_passes() -> None:


### PR DESCRIPTION
## Summary
- After two research validation failures, degrade the last parseable brief instead of raising immediately.
- Drop remaining ungegrounded facts (including material) as a last-resort repair; if an `answer` still validates, send it.
- Otherwise **explicitly set `action=clarify`** with inferred `missing_fields` (writer does not invent the action).
- Stacked on #237 (PR1 fact repair + conversation-aware exceptional gating).

## Test plan
- [x] `pytest tests/unit` in `services/lex`
- [ ] Confirm empty/broken research briefs become clarify emails, not `TECHNICAL_FAILURE_BODY`
- [ ] Merge #237 first (or merge this stack in order)

## Follow-ups
- PR3: soft URL strip, continue-dialogue copy, sparse→second-turn eval