### PR TITLE
lex: soft URL strip + continue-dialogue failure copy

### DIFF
--- a/services/lex/app/email/templates.py
+++ b/services/lex/app/email/templates.py
@@ -108,9 +108,10 @@ ATTACHMENT_ONLY_BODY = (
 )
 
 TECHNICAL_FAILURE_BODY = (
-    "I\u2019m sorry, but Lex could not prepare a reliable response to this "
-    "request. Please try again later. Your question has not been answered."
-    "\n\nLex."
+    "I\u2019m sorry \u2014 this is a lot to hold at once, and I couldn\u2019t finish "
+    "a full verified answer in one pass. Reply with the country (or countries) "
+    "involved, the city or commune if you know it, and the main thing you need "
+    "help with first. I\u2019ll continue from there.\n\nLex."
 )
 
 TEMPORARY_UNAVAILABILITY_BODY = (

--- a/services/lex/app/llm/clarify_decline.py
+++ b/services/lex/app/llm/clarify_decline.py
@@ -8,24 +8,29 @@ _CLARIFY_TEMPLATES: dict[str, str] = {
     "death_country+residence_country": (
         "I'm very sorry. Which country did the person die in, and in which country "
         "did they normally live?\n\n"
-        "Those details determine the authorities, documents and deadlines."
+        "Those details determine the authorities, documents and deadlines. "
+        "Reply with what you know and we can take the next steps from there."
     ),
     "death_country": (
         "I'm very sorry. Which country did the death occur in?\n\n"
-        "That determines which authorities handle the declaration and certificates."
+        "That determines which authorities handle the declaration and certificates. "
+        "Reply when you can and I'll continue."
     ),
     "residence_country": (
         "I'm very sorry. In which country did the person normally live?\n\n"
-        "That helps identify the right authorities and next steps."
+        "That helps identify the right authorities and next steps. "
+        "Reply with that detail and I'll continue."
     ),
     "death_or_planning_status": (
         "I'm very sorry. Has the person already died, or are you preparing for an "
         "expected death?\n\n"
-        "The first steps differ in those situations."
+        "The first steps differ in those situations. Reply with which applies and "
+        "I'll continue."
     ),
     "default": (
         "I'm very sorry. I need one or two details before I can give accurate next "
-        "steps: {fields}."
+        "steps: {fields}.\n\n"
+        "Reply in this thread when you can — we can take this step by step."
     ),
 }
 

--- a/services/lex/app/llm/research_validation.py
+++ b/services/lex/app/llm/research_validation.py
@@ -284,38 +284,99 @@ def _canonicalise_brief_urls(
     *,
     web_search_source_urls: Collection[str] | None,
 ) -> None:
-    """Rewrite source/contact URLs to matched search URLs when evidence exists."""
+    """Rewrite matched URLs; drop ungegrounded sources/contacts (soft strip).
+
+    Keeps the dialogue alive when some cites are grounded. Raises only when no
+    grounded source remains.
+    """
     if web_search_source_urls is None:
         return
     search_list = list(web_search_source_urls)
-    new_sources = []
+    kept_sources = []
+    dropped_source_urls: list[str] = []
+    old_to_new: dict[int, int] = {}
     for source in brief.sources:
         matched = match_search_url(source.url, search_list)
         if matched is None:
-            raise ResearchValidationError(
-                "unsupported_source_url",
-                "Source URL was not returned by web search.",
-            )
-        new_sources.append(source.model_copy(update={"url": matched}))
-    brief.sources = new_sources
+            dropped_source_urls.append(source.url)
+            continue
+        new_id = len(kept_sources) + 1
+        old_to_new[source.id] = new_id
+        kept_sources.append(source.model_copy(update={"id": new_id, "url": matched}))
+    if dropped_source_urls:
+        _LOG.info(
+            "Soft-stripped %s ungegrounded source URLs: %s",
+            len(dropped_source_urls),
+            dropped_source_urls,
+        )
+    if not kept_sources:
+        raise ResearchValidationError(
+            "unsupported_source_url",
+            "Source URL was not returned by web search.",
+        )
+    brief.sources = kept_sources
 
-    sources_by_id = {source.id: source for source in brief.sources}
-    new_contacts = []
+    kept_contacts = []
+    dropped_contacts = 0
+    old_contact_to_new: dict[int, int] = {}
     for contact in brief.contacts:
-        source = sources_by_id.get(contact.source_id)
-        source_url = source.url if source is not None else None
+        new_source_id = old_to_new.get(contact.source_id)
+        if new_source_id is None:
+            dropped_contacts += 1
+            continue
+        source = next(s for s in brief.sources if s.id == new_source_id)
         resolved = _resolve_contact_website(
             contact.website,
-            source_url=source_url,
+            source_url=source.url,
             search_urls=search_list,
         )
         if resolved is None:
-            raise ResearchValidationError(
-                "unsupported_contact_website",
-                "Contact website is not related to its cited source.",
+            dropped_contacts += 1
+            continue
+        new_id = len(kept_contacts) + 1
+        old_contact_to_new[contact.id] = new_id
+        kept_contacts.append(
+            contact.model_copy(
+                update={
+                    "id": new_id,
+                    "source_id": new_source_id,
+                    "website": resolved,
+                }
             )
-        new_contacts.append(contact.model_copy(update={"website": resolved}))
-    brief.contacts = new_contacts
+        )
+    if dropped_contacts:
+        _LOG.info("Soft-stripped %s ungegrounded contacts", dropped_contacts)
+    brief.contacts = kept_contacts
+
+    kept_actions = []
+    for action in brief.immediate_actions:
+        new_source_ids = [
+            old_to_new[source_id]
+            for source_id in action.source_ids
+            if source_id in old_to_new
+        ]
+        if not new_source_ids:
+            continue
+        new_contact_ids = [
+            old_contact_to_new[contact_id]
+            for contact_id in action.contact_ids
+            if contact_id in old_contact_to_new
+        ]
+        kept_actions.append(
+            action.model_copy(
+                update={
+                    "id": f"A{len(kept_actions) + 1}",
+                    "source_ids": new_source_ids,
+                    "contact_ids": new_contact_ids,
+                }
+            )
+        )
+    if len(kept_actions) < len(brief.immediate_actions):
+        _LOG.info(
+            "Soft-stripped %s actions that lost all grounded sources",
+            len(brief.immediate_actions) - len(kept_actions),
+        )
+    brief.immediate_actions = kept_actions
 
 
 def _renumber_brief_ids(brief: LexResearchBrief) -> None:
@@ -523,18 +584,22 @@ def validate_research_brief(
             "answer_research_not_adequate",
             "Answer requires adequate research.",
         )
-        _require(bool(brief.sources), "answer_without_source", "Answer needs sources.")
-        _require(
-            bool(brief.immediate_actions),
-            "answer_without_action",
-            "Answer needs immediate actions.",
-        )
         if web_search_calls is not None:
             _require(
                 web_search_calls >= 1,
                 "answer_without_search",
                 "Answer requires web search.",
             )
+        # Soft-strip ungegrounded URLs before emptiness / count checks.
+        _canonicalise_brief_urls(
+            brief, web_search_source_urls=web_search_source_urls
+        )
+        _require(bool(brief.sources), "answer_without_source", "Answer needs sources.")
+        _require(
+            bool(brief.immediate_actions),
+            "answer_without_action",
+            "Answer needs immediate actions.",
+        )
         if brief.situation_stage in {"imminent_death", "recent_death"}:
             count = len(brief.immediate_actions)
             _require(
@@ -566,10 +631,6 @@ def validate_research_brief(
                     "focused_follow_up_irrelevant",
                     "Focused follow-up actions must address current_question.",
                 )
-
-        _canonicalise_brief_urls(
-            brief, web_search_source_urls=web_search_source_urls
-        )
 
     elif brief.action == "clarify":
         _require(

--- a/services/lex/tests/unit/test_research_degrade.py
+++ b/services/lex/tests/unit/test_research_degrade.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.llm.research_degrade import degrade_failed_research_brief
 from app.llm.research_schema import ResearchImmediateAction, ResearchSource
+from app.llm.research_validation import validate_research_brief
 from tests.unit.test_two_pass import _brief
 
 
@@ -88,3 +89,48 @@ def test_degrade_sets_explicit_clarify_action() -> None:
     assert "subdivision" in degraded.missing_fields or "death_country" in (
         degraded.missing_fields
     )
+
+
+def test_sparse_first_turn_degrades_to_clarify_with_asks() -> None:
+    """Weak input still yields a dialogue move, not silence."""
+    brief = _brief(
+        sources=[],
+        contacts=[],
+        immediate_actions=[],
+        user_facts=[],
+        jurisdictions=[],
+    )
+    degraded = degrade_failed_research_brief(
+        brief,
+        conversation_text="My father died. What do I do?",
+        last_error="answer_without_source",
+    )
+    assert degraded is not None
+    assert degraded.action == "clarify"
+    assert degraded.missing_fields
+    assert "death_country" in degraded.missing_fields
+
+
+def test_second_turn_facts_allow_answer_path() -> None:
+    """After clarify asks are answered, a grounded brief can answer."""
+    conversation = (
+        "My father died in Luxembourg yesterday. He lived in Luxembourg City. "
+        "What should we do first?"
+    )
+    brief = _brief(
+        situation_stage="recent_death",
+        user_facts=[
+            "Father died in Luxembourg yesterday",
+            "He lived in Luxembourg City",
+        ],
+    )
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset(
+            {"https://guichet.public.lu", "https://fpf.lu"}
+        ),
+        web_search_calls=1,
+        conversation_text=conversation,
+    )
+    assert brief.action == "answer"
+    assert len(brief.immediate_actions) >= 3

--- a/services/lex/tests/unit/test_research_validation_followups.py
+++ b/services/lex/tests/unit/test_research_validation_followups.py
@@ -176,7 +176,7 @@ def test_http_and_non_lu_host_grounded_in_search() -> None:
     assert brief.contacts[0].website == search_http
 
 
-def test_ungrounded_host_rejected() -> None:
+def test_ungrounded_host_rejected_when_no_source_remains() -> None:
     brief = _brief(
         sources=[
             ResearchSource(
@@ -187,9 +187,9 @@ def test_ungrounded_host_rejected() -> None:
             ),
             ResearchSource(
                 id=2,
-                title="Funeral federation members",
-                publisher="FPF",
-                url="https://fpf.lu",
+                title="Other blog",
+                publisher="Example",
+                url="https://medium.com/other-post",
             ),
         ]
     )
@@ -208,7 +208,46 @@ def test_ungrounded_host_rejected() -> None:
     assert exc.value.code == "unsupported_source_url"
 
 
-def test_invented_contact_website_rejected() -> None:
+def test_soft_strips_partial_ungrounded_sources() -> None:
+    brief = _brief(
+        sources=[
+            ResearchSource(
+                id=1,
+                title="Declaring a death",
+                publisher="Guichet.lu",
+                url="https://guichet.public.lu",
+            ),
+            ResearchSource(
+                id=2,
+                title="Blog post",
+                publisher="Medium",
+                url="https://medium.com/some-bereavement-post",
+            ),
+        ]
+    )
+    # Remap funeral contacts onto the grounded source so soft-strip can keep them.
+    brief.contacts = [
+        contact.model_copy(update={"source_id": 1}) for contact in brief.contacts
+    ]
+    brief.immediate_actions = [
+        action.model_copy(update={"source_ids": [1], "contact_ids": []})
+        for action in brief.immediate_actions
+    ]
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset({"https://guichet.public.lu"}),
+        web_search_calls=1,
+        conversation_text=(
+            "My mother is in Haus Omega hospice in Luxembourg with only a few days "
+            "remaining. What should we prepare after she dies?"
+        ),
+    )
+    assert len(brief.sources) == 1
+    assert brief.sources[0].url == "https://guichet.public.lu"
+    assert len(brief.immediate_actions) == 3
+
+
+def test_soft_strips_invented_contact_website() -> None:
     brief = _brief(
         contacts=[
             ResearchContact(
@@ -249,19 +288,21 @@ def test_invented_contact_website_rejected() -> None:
             ),
         ]
     )
-    with pytest.raises(ResearchValidationError) as exc:
-        validate_research_brief(
-            brief,
-            web_search_source_urls=frozenset(
-                {"https://guichet.public.lu", "https://fpf.lu"}
-            ),
-            web_search_calls=1,
-            conversation_text=(
-                "My mother is in Haus Omega hospice in Luxembourg with only a few days "
-                "remaining. What should we prepare after she dies?"
-            ),
-        )
-    assert exc.value.code == "unsupported_contact_website"
+    validate_research_brief(
+        brief,
+        web_search_source_urls=frozenset(
+            {"https://guichet.public.lu", "https://fpf.lu"}
+        ),
+        web_search_calls=1,
+        conversation_text=(
+            "My mother is in Haus Omega hospice in Luxembourg with only a few days "
+            "remaining. What should we prepare after she dies?"
+        ),
+    )
+    assert all(
+        "totally-invented" not in contact.website for contact in brief.contacts
+    )
+    assert len(brief.contacts) == 2
 
 
 def test_non_english_rejects_material_english_hallucination() -> None:
@@ -347,6 +388,41 @@ def test_non_contiguous_ids_are_renumbered() -> None:
                 commercial=True,
                 note="Orientation only",
                 source_id=7,
+            ),
+        ],
+        immediate_actions=[
+            ResearchImmediateAction(
+                id="A1",
+                action="Ask hospice staff what they arrange at the time of death",
+                explanation="Hospice teams usually involve the treating doctor.",
+                timing="now",
+                handled_by=["Haus Omega staff", "treating doctor"],
+                documents=[],
+                source_ids=[4],
+                contact_ids=[9],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A2",
+                action="Prepare identity documents for the death declaration",
+                explanation="The commune will need ID documents soon after death.",
+                timing="before_death",
+                handled_by=["family"],
+                documents=["ID cards"],
+                source_ids=[4],
+                contact_ids=[],
+                required=True,
+            ),
+            ResearchImmediateAction(
+                id="A3",
+                action="Compare funeral directors or use a recognised directory",
+                explanation="A funeral director can handle many formalities.",
+                timing="next_few_days",
+                handled_by=["family", "funeral director"],
+                documents=[],
+                source_ids=[7],
+                contact_ids=[2, 3],
+                required=True,
             ),
         ],
     )

--- a/services/lex/tests/unit/test_templates.py
+++ b/services/lex/tests/unit/test_templates.py
@@ -23,10 +23,12 @@ _DETERMINISTIC_BODIES = (
 )
 
 
-def test_rate_limit_exact_wording() -> None:
-    assert "up to five emails per day" in RATE_LIMIT_BODY
-    assert "full daily quota of five" in RATE_LIMIT_BODY
-    assert "immediate danger" not in RATE_LIMIT_BODY.casefold()
+def test_technical_failure_invites_continue_dialogue() -> None:
+    lowered = TECHNICAL_FAILURE_BODY.casefold()
+    assert "not been answered" not in lowered
+    assert "try again later" not in lowered
+    assert "reply" in lowered
+    assert "continue" in lowered
 
 
 def test_rate_limit_avoids_punitive_language() -> None:


### PR DESCRIPTION
## Summary
- Soft-strip ungegrounded sources/contacts/actions when at least one search-grounded source remains (instead of hard-failing the whole brief).
- Replace brick-wall `TECHNICAL_FAILURE_BODY` with continue-dialogue copy that asks for country/commune/next need.
- Clarify templates invite a reply; unit coverage for sparse→clarify and second-turn answer.
- Stacked on #238 (research degrade ladder) → #237 (fact repair).

## Test plan
- [x] `pytest tests/unit` in `services/lex`
- [ ] Partial search set keeps grounded cites and continues
- [ ] Last-resort failure email invites reply (no “not been answered”)
- [ ] Merge order: #237 → #238 → this PR