### PR TITLE
lex: never strand messages after worker crash or lease_held

### DIFF
--- a/services/lex/app/config.py
+++ b/services/lex/app/config.py
@@ -124,6 +124,7 @@ class Settings(BaseSettings):
     adapter_backend: AdapterBackend = "memory"
     poll_max_results: int = 50
     lease_duration_seconds: int = 600
+    max_process_attempts: int = 8
     cloud_tasks_queue: str = "lex-process"
     cloud_tasks_location: str = REQUIRED_REGION
     cloud_tasks_target_url: str = ""
@@ -184,6 +185,7 @@ class Settings(BaseSettings):
         "max_thread_chars",
         "poll_max_results",
         "lease_duration_seconds",
+        "max_process_attempts",
         "max_output_tokens",
         "research_max_output_tokens",
         "writer_max_output_tokens",

--- a/services/lex/app/domain/ports.py
+++ b/services/lex/app/domain/ports.py
@@ -151,6 +151,16 @@ class MessageStatePort(Protocol):
         """Delete metadata records whose ``expires_at`` is in the past."""
         ...
 
+    def list_expired_processing_leases(
+        self, *, now: datetime, limit: int = 50
+    ) -> list[ProcessingRecord]:
+        """Return non-terminal processing records whose lease has expired.
+
+        Used to re-enqueue work that crashed after acquiring a lease when Cloud
+        Tasks stopped retrying (for example after a mistaken 2xx on lease_held).
+        """
+        ...
+
 
 @dataclass(frozen=True, slots=True)
 class LlmGenerationResult:

--- a/services/lex/app/infrastructure/firestore.py
+++ b/services/lex/app/infrastructure/firestore.py
@@ -315,6 +315,26 @@ class FirestoreMessageState:
             deleted += 1
         return deleted
 
+    def list_expired_processing_leases(
+        self, *, now: datetime, limit: int = 50
+    ) -> list[ProcessingRecord]:
+        collection = self.client.collection(
+            f"{ENVIRONMENTS_COLLECTION}/{self._settings.environment}"
+            f"/{MESSAGES_COLLECTION}"
+        )
+        # Filter in Python to avoid requiring a composite index for
+        # status + lease_until. Volume of in-flight processing is small.
+        recovered: list[ProcessingRecord] = []
+        query = collection.where("status", "==", ProcessingStatus.PROCESSING.value)
+        for snapshot in query.stream():
+            record = document_to_record(snapshot.id, snapshot.to_dict() or {})
+            if record.lease_until is None or record.lease_until > now:
+                continue
+            recovered.append(record)
+            if len(recovered) >= limit:
+                break
+        return recovered
+
 
 __all__ = [
     "document_path",

--- a/services/lex/app/infrastructure/gmail.py
+++ b/services/lex/app/infrastructure/gmail.py
@@ -38,6 +38,27 @@ _IAM_SIGN_SCOPES: tuple[str, ...] = (
 #: Gmail addresses the delegated mailbox as "me" once impersonation is set up.
 USER_ID = "me"
 
+_TRANSIENT_GMAIL_ERRORS = (
+    BrokenPipeError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
+
+def _execute_with_transient_retry(operation: Any, *, attempts: int = 3) -> Any:
+    """Retry Gmail/auth transport blips (BrokenPipe during token refresh)."""
+    last_exc: BaseException | None = None
+    for attempt in range(attempts):
+        try:
+            return operation()
+        except _TRANSIENT_GMAIL_ERRORS as exc:
+            last_exc = exc
+            if attempt + 1 >= attempts:
+                raise
+    assert last_exc is not None
+    raise last_exc
+
 
 def build_gmail_service(settings: Settings) -> Any:  # pragma: no cover - needs GCP
     """Build a domain-delegated Gmail client for the configured mailbox.
@@ -202,8 +223,8 @@ class GoogleGmailAdapter:
         if thread_id:
             body["threadId"] = thread_id
         try:
-            response = (
-                self._messages()
+            response = _execute_with_transient_retry(
+                lambda: self._messages()
                 .send(
                     userId=USER_ID,
                     body=body,
@@ -226,8 +247,8 @@ class GoogleGmailAdapter:
         outbound_message_id: str,
         request_id: str,
     ) -> str | None:
-        thread = (
-            self.service.users()
+        thread = _execute_with_transient_retry(
+            lambda: self.service.users()
             .threads()
             .get(
                 userId=USER_ID,

--- a/services/lex/app/infrastructure/memory.py
+++ b/services/lex/app/infrastructure/memory.py
@@ -397,6 +397,21 @@ class InMemoryMessageState:
                 del self._records[key]
             return len(expired)
 
+    def list_expired_processing_leases(
+        self, *, now: datetime, limit: int = 50
+    ) -> list[ProcessingRecord]:
+        with self._lock:
+            recovered: list[ProcessingRecord] = []
+            for record in self._records.values():
+                if record.status is not ProcessingStatus.PROCESSING:
+                    continue
+                if record.lease_until is None or record.lease_until > now:
+                    continue
+                recovered.append(record)
+                if len(recovered) >= limit:
+                    break
+            return recovered
+
 
 __all__ = [
     "SentOutboundMessage",

--- a/services/lex/app/main.py
+++ b/services/lex/app/main.py
@@ -128,11 +128,25 @@ def create_app(
         return poller.run().as_dict()
 
     @app.post("/internal/process", dependencies=[Depends(require_internal_token)])
-    async def internal_process(payload: ProcessRequest) -> dict[str, int | str]:
+    async def internal_process(payload: ProcessRequest) -> JSONResponse:
+        """Process one message.
+
+        ``lease_held`` must not return HTTP 200: Cloud Tasks treats 2xx as
+        success and stops retrying, which permanently strands a message when the
+        first worker crashes after acquiring the lease.
+        """
+        from app.services.processor import PROCESS_STATUS_LEASE_HELD
+
         result = processor.run(
             gmail_message_id=payload.gmail_message_id, thread_id=payload.thread_id
         )
-        return result.as_dict()
+        body = result.as_dict()
+        if result.status == PROCESS_STATUS_LEASE_HELD:
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                content=body,
+            )
+        return JSONResponse(status_code=status.HTTP_200_OK, content=body)
 
     @app.post("/internal/retention", dependencies=[Depends(require_internal_token)])
     async def internal_retention() -> dict[str, int]:

--- a/services/lex/app/services/poller.py
+++ b/services/lex/app/services/poller.py
@@ -42,6 +42,7 @@ class PollResult:
     enqueued: int = 0
     already_pending: int = 0
     failed: int = 0
+    recovered: int = 0
 
     def as_dict(self) -> dict[str, int | str]:
         return {
@@ -50,6 +51,7 @@ class PollResult:
             "enqueued": self.enqueued,
             "already_pending": self.already_pending,
             "failed": self.failed,
+            "recovered": self.recovered,
         }
 
 
@@ -113,15 +115,55 @@ class Poller:
             else:
                 already_pending += 1
 
+        recovered = self._recover_expired_leases()
+
         result = PollResult(
             status=POLL_STATUS_COMPLETED,
             discovered=len(refs),
             enqueued=enqueued,
             already_pending=already_pending,
             failed=failed,
+            recovered=recovered,
         )
         log_event(_logger, "poll_completed", status=POLL_STATUS_COMPLETED)
         return result
+
+    def _recover_expired_leases(self) -> int:
+        """Re-enqueue messages stuck in processing after an expired lease.
+
+        Covers the failure mode where a worker crashes after lease acquire and
+        Cloud Tasks stops retrying (e.g. earlier lease_held returned HTTP 200).
+        """
+        recovered = 0
+        now = self._clock.now()
+        for record in self._state.list_expired_processing_leases(now=now):
+            ref = GmailMessageRef(
+                message_id=record.message_key, thread_id=record.thread_id
+            )
+            try:
+                outcome = self._tasks.enqueue_process(ref)
+            except Exception:
+                log_event(
+                    _logger,
+                    "poll_recovery_failed",
+                    gmail_message_id=record.message_key,
+                    gmail_thread_id=record.thread_id,
+                    error_code="poll_recovery_failed",
+                )
+                continue
+            recovered += 1
+            log_event(
+                _logger,
+                "message_recovered",
+                gmail_message_id=record.message_key,
+                gmail_thread_id=record.thread_id,
+                status=(
+                    "enqueued"
+                    if outcome is EnqueueOutcome.CREATED
+                    else "already_pending"
+                ),
+            )
+        return recovered
 
     def _discover(self, ref: GmailMessageRef) -> EnqueueOutcome:
         key = message_key(ref.message_id)

--- a/services/lex/app/services/processor.py
+++ b/services/lex/app/services/processor.py
@@ -68,6 +68,7 @@ PROCESS_STATUS_LEASE_HELD = "lease_held"
 PROCESS_STATUS_ALREADY_DONE = "already_done"
 PROCESS_STATUS_SENT = "sent"
 PROCESS_STATUS_FAILED = "failed"
+PROCESS_STATUS_QUEUED = "queued"
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,10 +159,63 @@ class Processor:
             )
 
         attempt_count = decision.record.attempt_count if decision.record else 0
+        try:
+            return self._run_after_lease(
+                key,
+                thread_id=thread_id,
+                attempt_count=attempt_count,
+            )
+        except Exception as exc:
+            # Clear the lease so Cloud Tasks retries can acquire immediately
+            # instead of waiting out lease_duration_seconds.
+            code = getattr(exc, "code", None) or type(exc).__name__
+            self._state.mark_status(
+                key,
+                ProcessingStatus.QUEUED,
+                error_code=f"crash:{code}"[:120],
+            )
+            log_event(
+                _logger,
+                "process_crash_requeued",
+                gmail_message_id=key,
+                status=PROCESS_STATUS_QUEUED,
+                error_code=str(code)[:80],
+            )
+            raise
+
+    def _run_after_lease(
+        self,
+        key: str,
+        *,
+        thread_id: str | None,
+        attempt_count: int,
+    ) -> ProcessResult:
         record = self._state.get_record(key)
         resolved_thread = thread_id or (record.thread_id if record else "")
         ref = GmailMessageRef(message_id=key, thread_id=resolved_thread)
         parsed = self._gmail.fetch_parsed_message(ref)
+
+        if attempt_count > self._settings.max_process_attempts:
+            lex_addresses = frozenset(
+                {
+                    self._settings.lex_mailbox.lower(),
+                    *self._settings.resolved_lex_aliases,
+                }
+            )
+            recipients = build_reply_recipients(
+                from_address=parsed.from_address,
+                reply_to=parsed.reply_to,
+                to_addresses=parsed.to_addresses,
+                cc_addresses=parsed.cc_addresses,
+                lex_addresses=lex_addresses,
+            )
+            return self._send_technical_failure(
+                key,
+                parsed=parsed,
+                recipients=recipients,
+                attempt_count=attempt_count,
+                error_code="max_process_attempts",
+            )
 
         auto = check_auto_ignore(parsed, self._settings)
         if auto.should_ignore:

--- a/services/lex/tests/unit/test_process_reliability.py
+++ b/services/lex/tests/unit/test_process_reliability.py
@@ -1,0 +1,126 @@
+"""Reliability: lease_held must be retryable; crashes must requeue."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import timedelta
+
+from app.domain.ids import task_name_for_message
+from app.domain.models import ProcessingStatus, new_queued_record
+from app.infrastructure.clock import FakeClock
+from app.infrastructure.daily_usage import InMemoryDailyUsage
+from app.infrastructure.memory import (
+    InMemoryGmail,
+    InMemoryMessageState,
+    InMemoryTaskQueue,
+)
+from app.infrastructure.rate_limit import InMemoryRateLimit
+from app.services.poller import Poller
+from app.services.processor import (
+    PROCESS_STATUS_LEASE_HELD,
+    Processor,
+)
+
+from .conftest import build_settings
+from .test_main import _build_client
+
+
+def test_lease_held_returns_http_503() -> None:
+    client, gmail, _tasks, state = _build_client()
+    gmail.add_inbox_message(message_id="m1", thread_id="t1")
+    # Hold an active lease far in the future relative to FakeClock epoch.
+    now = state._clock.now()
+    state.create_record(
+        new_queued_record(message_key="m1", thread_id="t1", now=now)
+    )
+    record = state.get_record("m1")
+    assert record is not None
+    state._records["m1"] = replace(
+        record,
+        status=ProcessingStatus.PROCESSING,
+        lease_until=now + timedelta(minutes=10),
+        lease_owner="other-worker",
+        attempt_count=1,
+        updated_at=now,
+    )
+    response = client.post(
+        "/internal/process", json={"gmail_message_id": "m1", "thread_id": "t1"}
+    )
+    assert response.status_code == 503
+    assert response.json()["status"] == PROCESS_STATUS_LEASE_HELD
+
+
+def test_worker_crash_requeues_for_retry() -> None:
+    class BoomGmail(InMemoryGmail):
+        def fetch_parsed_message(self, ref):  # type: ignore[no-untyped-def]
+            raise BrokenPipeError("simulated gmail blip")
+
+    clock = FakeClock()
+    settings = build_settings(
+        processing_enabled=True,
+        processing_mode="public",
+        adapter_backend="memory",
+        hmac_secret="test-secret",
+        max_process_attempts=8,
+    )
+    gmail = BoomGmail()
+    state = InMemoryMessageState(clock=clock)
+    state.create_record(
+        new_queued_record(message_key="m1", thread_id="t1", now=clock.now())
+    )
+    processor = Processor(
+        settings=settings,
+        state=state,
+        gmail=gmail,
+        rate_limit=InMemoryRateLimit(),
+        daily_usage=InMemoryDailyUsage(),
+        llm=None,  # type: ignore[arg-type]
+        clock=clock,
+    )
+    try:
+        processor.run(gmail_message_id="m1", thread_id="t1")
+        raise AssertionError("expected BrokenPipeError")
+    except BrokenPipeError:
+        pass
+    record = state.get_record("m1")
+    assert record is not None
+    assert record.status is ProcessingStatus.QUEUED
+    assert record.lease_until is None
+    assert record.last_error_code and record.last_error_code.startswith("crash:")
+
+
+def test_poller_recovers_expired_processing_lease() -> None:
+    clock = FakeClock()
+    settings = build_settings(
+        processing_enabled=True,
+        processing_mode="public",
+        adapter_backend="memory",
+        hmac_secret="test-secret",
+    )
+    gmail = InMemoryGmail()
+    tasks = InMemoryTaskQueue()
+    state = InMemoryMessageState(clock=clock)
+    now = clock.now()
+    state.create_record(
+        new_queued_record(message_key="stuck", thread_id="t-stuck", now=now)
+    )
+    record = state.get_record("stuck")
+    assert record is not None
+    state._records["stuck"] = replace(
+        record,
+        status=ProcessingStatus.PROCESSING,
+        lease_until=now - timedelta(minutes=1),
+        lease_owner="dead-worker",
+        attempt_count=1,
+        updated_at=now,
+    )
+    poller = Poller(
+        settings=settings,
+        gmail=gmail,
+        tasks=tasks,
+        state=state,
+        clock=clock,
+    )
+    result = poller.run()
+    assert result.recovered == 1
+    assert task_name_for_message("stuck") in tasks.task_names


### PR DESCRIPTION
## Summary
- Return HTTP 503 for `lease_held` so Cloud Tasks keeps retrying (was HTTP 200 → permanent silence after crash).
- On unexpected worker crash after lease acquire: clear lease / requeue (`queued`) and re-raise.
- Poller recovers expired `processing` leases by re-enqueueing.
- Retry transient Gmail auth/transport blips (BrokenPipe).
- Cap attempts via `max_process_attempts` (default 8) then technical-failure template.

## Context
Production incident: reply with CC got LLM success then crashed on Gmail token refresh; `lease_held` 200 stopped Cloud Tasks; message stuck in `LEX_PENDING` for hours. Manually retriggered for evaluation.

## Test plan
- [x] `pytest tests/unit` in `services/lex`
- [x] Redeploy Cloud Run image `20260812-173623` (env preserved)
- [ ] Send a follow-up in an existing Lex thread and confirm reply