### PR TITLE
web: plain-language pass on EN checklist intro and empty states

### DIFF
--- a/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
+++ b/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
@@ -503,10 +503,10 @@ export default function ChecklistPage() {
           {/* Checklist preview card */}
           <div className="glass-panel p-4 sm:p-5 rounded-xl">
             <div className="text-sm font-semibold mb-2" style={{ color: "#2b3a67" }}>
-              {l(lang, "What the checklist is being built to look like", "Ce que la liste de démarches est conçue pour devenir", "Wie die Checkliste aussehen soll", "Wéi d'Checklëscht soll ausgesinn")}
+              {l(lang, "A preview of what we're building", "Ce que la liste de démarches est conçue pour devenir", "Wie die Checkliste aussehen soll", "Wéi d'Checklëscht soll ausgesinn")}
             </div>
             <p className="text-[11px] text-calm-blue-500 leading-relaxed mb-3">
-              {l(lang, "The image illustrates the type of step-by-step guidance Clarvia is working to deliver. It is not a finished product — the content, design, and features are still being developed and validated.", "L'image illustre le type d'accompagnement étape par étape que Clarvia travaille à offrir. Il ne s'agit pas d'un produit finalisé — le contenu, le design et les fonctionnalités sont encore en cours de développement et de validation.", "Das Bild zeigt, welche Art von schrittweiser Orientierung Clarvia entwickeln möchte. Es handelt sich nicht um ein fertiges Produkt — Inhalte, Design und Funktionen werden noch entwickelt und geprüft.", "D'Bild weist déi Zort Schrëtt-fir-Schrëtt-Orientéierung, un där Clarvia schafft. Et ass nach kee fäerdege Produit — Inhalt, Design a Funktioune ginn nach entwéckelt a validéiert.")}
+              {l(lang, "This image shows the kind of step-by-step guidance Clarvia is working towards. It is not a finished product — the content, design, and features are still being developed and validated.", "L'image illustre le type d'accompagnement étape par étape que Clarvia travaille à offrir. Il ne s'agit pas d'un produit finalisé — le contenu, le design et les fonctionnalités sont encore en cours de développement et de validation.", "Das Bild zeigt, welche Art von schrittweiser Orientierung Clarvia entwickeln möchte. Es handelt sich nicht um ein fertiges Produkt — Inhalte, Design und Funktionen werden noch entwickelt und geprüft.", "D'Bild weist déi Zort Schrëtt-fir-Schrëtt-Orientéierung, un där Clarvia schafft. Et ass nach kee fäerdege Produit — Inhalt, Design a Funktioune ginn nach entwéckelt a validéiert.")}
             </p>
             <button
               onClick={() => setLightboxOpen(true)}
@@ -571,7 +571,7 @@ export default function ChecklistPage() {
             {l(lang, "Bereavement Checklist", "Liste de démarches en cas de décès", "Checkliste im Trauerfall", "Checklëscht am Trauerfall")}
           </h1>
           <p className="text-calm-blue-500 text-sm mb-8">
-            {l(lang, "Answer a few questions to get a personalised list of administrative steps.", "Répondez à quelques questions pour obtenir une liste personnalisée de démarches administratives.", "Beantworten Sie einige Fragen, um eine personalisierte Liste der Verwaltungsschritte zu erhalten.", "Beäntwert e puer Froen, fir eng personaliséiert Lëscht vun administrativen Démarchen ze kréien.")}
+            {l(lang, "Answer a few questions and we'll show you the steps that apply to your situation.", "Répondez à quelques questions pour obtenir une liste personnalisée de démarches administratives.", "Beantworten Sie einige Fragen, um eine personalisierte Liste der Verwaltungsschritte zu erhalten.", "Beäntwert e puer Froen, fir eng personaliséiert Lëscht vun administrativen Démarchen ze kréien.")}
           </p>
 
         {step === "intake" && intake && (
@@ -769,7 +769,7 @@ function ChecklistResults({
         </div>
         <p className="text-sm text-calm-blue-500">
           {appliesCount > 0 &&
-            l(lang, `${appliesCount} item${appliesCount > 1 ? "s" : ""} applicable`, `${appliesCount} élément${appliesCount > 1 ? "s" : ""} applicable${appliesCount > 1 ? "s" : ""}`, `${appliesCount} zutreffende${appliesCount > 1 ? "r" : ""} Punkt${appliesCount > 1 ? "e" : ""}`, `${appliesCount} Element${appliesCount > 1 ? "er" : ""} uwendbar`)}
+            l(lang, `${appliesCount} step${appliesCount > 1 ? "s" : ""} for your situation`, `${appliesCount} élément${appliesCount > 1 ? "s" : ""} applicable${appliesCount > 1 ? "s" : ""}`, `${appliesCount} zutreffende${appliesCount > 1 ? "r" : ""} Punkt${appliesCount > 1 ? "e" : ""}`, `${appliesCount} Element${appliesCount > 1 ? "er" : ""} uwendbar`)}
         </p>
       </div>
 
@@ -778,7 +778,7 @@ function ChecklistResults({
         <div className="space-y-3">
           <h3 className="text-sm font-bold text-amber-700 uppercase tracking-wide flex items-center gap-2">
             <span className="w-8 h-px bg-amber-300" />
-            {l(lang, "More information needed", "Informations supplémentaires nécessaires", "Weitere Informationen erforderlich", "Méi Informatiounen néideg")}
+            {l(lang, "What we still need to know", "Informations supplémentaires nécessaires", "Weitere Informationen erforderlich", "Méi Informatiounen néideg")}
           </h3>
           {unknownQuestions.map((q) => (
             <div
@@ -792,7 +792,7 @@ function ChecklistResults({
                     {lang === "fr" ? q.label_fr : lang === "de" ? q.label_de : q.label_en}
                   </p>
                   <p className="text-xs text-amber-700 mt-1">
-                    {l(lang, "Your checklist may be incomplete because this answer is unknown. Once you have this information, come back and generate a new checklist.", "Votre liste pourrait être incomplète car cette réponse est inconnue. Une fois cette information obtenue, revenez générer une nouvelle liste.", "Ihre Checkliste ist möglicherweise unvollständig, da diese Antwort unbekannt ist. Sobald Sie diese Information haben, erstellen Sie eine neue Checkliste.", "Är Checklëscht ka onvollstänneg sinn, well dës Äntwert onbekannt ass. Wann Dir dës Informatioun hutt, kommt zréck a generéiert eng nei Checklëscht.")}
+                    {l(lang, "Without this answer, your checklist may be missing some steps. When you have it, come back and generate the checklist again.", "Votre liste pourrait être incomplète car cette réponse est inconnue. Une fois cette information obtenue, revenez générer une nouvelle liste.", "Ihre Checkliste ist möglicherweise unvollständig, da diese Antwort unbekannt ist. Sobald Sie diese Information haben, erstellen Sie eine neue Checkliste.", "Är Checklëscht ka onvollstänneg sinn, well dës Äntwert onbekannt ass. Wann Dir dës Informatioun hutt, kommt zréck a generéiert eng nei Checklëscht.")}
                   </p>
                 </div>
               </div>
@@ -823,7 +823,7 @@ function ChecklistResults({
       {items.length === 0 && unknownQuestions.length === 0 && (
         <div className="glass-panel p-8 rounded-xl text-center">
           <p className="text-calm-blue-500 text-sm">
-            {l(lang, "No items match your situation based on the answers provided. This may be because the alpha prototype has very limited coverage.", "Aucun élément ne correspond à votre situation sur la base des réponses fournies. Cela peut être dû à la couverture très limitée du prototype alpha.", "Keine Einträge passen zu Ihrer Situation basierend auf den gegebenen Antworten. Dies kann daran liegen, dass der Alpha-Prototyp eine sehr begrenzte Abdeckung hat.", "Keng Elementer passen op Basis vun den uginnene Äntwerten zu Ärer Situatioun. Dat kann dorunner leien, datt den Alpha-Prototyp nach eng ganz limitéiert Ofdeckung huet.")}
+            {l(lang, "Nothing in the checklist matches your answers. This is an early prototype and its coverage is still very limited, so there may be steps it does not know about yet.", "Aucun élément ne correspond à votre situation sur la base des réponses fournies. Cela peut être dû à la couverture très limitée du prototype alpha.", "Keine Einträge passen zu Ihrer Situation basierend auf den gegebenen Antworten. Dies kann daran liegen, dass der Alpha-Prototyp eine sehr begrenzte Abdeckung hat.", "Keng Elementer passen op Basis vun den uginnene Äntwerten zu Ärer Situatioun. Dat kann dorunner leien, datt den Alpha-Prototyp nach eng ganz limitéiert Ofdeckung huet.")}
           </p>
         </div>
       )}
@@ -990,7 +990,7 @@ function ChecklistItemCard({
               )}
               {item.status === "needs_fact" && item.missing_facts && (
                 <p className="text-amber-600">
-                  {l(lang, "We need more information to determine if this applies to your situation.", "Nous avons besoin de plus d'informations pour déterminer si cela s'applique à votre situation.", "Wir benötigen weitere Informationen, um festzustellen, ob dies auf Ihre Situation zutrifft.", "Mir brauchen nach méi Informatiounen, fir ze bestëmmen, ob dat op Är Situatioun zoutrëfft.")}
+                  {l(lang, "We need a bit more information before we can tell you whether this applies to you.", "Nous avons besoin de plus d'informations pour déterminer si cela s'applique à votre situation.", "Wir benötigen weitere Informationen, um festzustellen, ob dies auf Ihre Situation zutrifft.", "Mir brauchen nach méi Informatiounen, fir ze bestëmmen, ob dat op Är Situatioun zoutrëfft.")}
                 </p>
               )}
             </div>


### PR DESCRIPTION
## What does this PR do?

Plain-language pass over the English strings families see on `/en/checklist` — the intro,
the empty state, and the "we need more info" guidance. English only; FR/DE/LU are untouched,
per the issue scope.

The goal was to move from a system-reporting register ("No items match your situation based
on the answers provided") to a person explaining what happened and what to do next.

## Changes

All changes are the EN argument of existing `l()` calls in
`apps/web/src/app/[lang]/checklist/ChecklistPage.tsx`. No logic, structure, or dependency changes.

**Intro**
- "Answer a few questions to get a personalised list of administrative steps."
  → "Answer a few questions and we'll show you the steps that apply to your situation."
- Preview card heading: "What the checklist is being built to look like" → "A preview of what we're building"
- Preview card body, first sentence only: "The image illustrates the type of step-by-step guidance
  Clarvia is working to deliver." → "This image shows the kind of step-by-step guidance Clarvia is
  working towards." (the "not a finished product" hedge is left exactly as-is)

**Empty state**
- "No items match your situation based on the answers provided. This may be because the alpha
  prototype has very limited coverage."
  → "Nothing in the checklist matches your answers. This is an early prototype and its coverage is
  still very limited, so there may be steps it does not know about yet."

**Guidance / soft error**
- Section heading: "More information needed" → "What we still need to know"
- "Your checklist may be incomplete because this answer is unknown. Once you have this information,
  come back and generate a new checklist."
  → "Without this answer, your checklist may be missing some steps. When you have it, come back and
  generate the checklist again."
- "We need more information to determine if this applies to your situation."
  → "We need a bit more information before we can tell you whether this applies to you."

**Results summary**
- "3 items applicable" → "3 steps for your situation" ("applicable" reads like a form field; the
  neutral phrasing also avoids implying every item is an obligation, since the list mixes obligations
  with rights/benefits)

## Legal-sounding claims — flagged, not changed

Per the issue's "flag, do not invent" instruction, I deliberately left these alone:

- The amber alpha banner ("Alpha Prototype - Not Legal Advice", "For informational purposes only.
  Not legal, tax, or professional advice…"). This is a disclaimer with legal weight — it should be
  reworded by someone who owns that risk, not in a copy pass. Happy to propose plainer wording in a
  follow-up if you want it.
- The "Standards & Licenses" line ("compatible with: CPSV-AP, CCCEV, ELI (planned), PROV-O (planned)")
  is a compliance claim that a reader could rely on. Worth confirming it is source-backed.
- Deadline text (e.g. "within 24 hours") is rendered from graph data via `formatDuration`, not from
  UI copy, so it is out of scope here and stays source-backed.

## Testing

- `pnpm web:test` — 18/18 passing, unchanged from the pre-change baseline (4 files, 18 tests)
- `pnpm web:build` — succeeds; all `/en /fr /de /lu` routes prerender
- `pnpm web:lint` — fails on `main` before this change and fails identically after, on an unrelated
  file: `eslint-plugin-react@7.37.5` crashes loading `react/display-name` under ESLint 10
  (`contextOrFilename.getFilename is not a function`). Not introduced here.

Closes #244
