### PR TITLE
fix(web): improve checklist accessibility

### DIFF
--- a/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
+++ b/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { type Lang, l } from "@/lib/i18n";
@@ -293,10 +293,57 @@ export default function ChecklistPage() {
   const [unknownQuestions, setUnknownQuestions] = useState<IntakeQuestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [lightboxOpen, setLightboxOpen] = useState(false);
+  const lightboxDialogRef = useRef<HTMLDivElement>(null);
+  const lightboxTriggerRef = useRef<HTMLButtonElement>(null);
 
   const imgLang = lang === "lu" ? "fr" : lang;
   const previewThumb = `/checklist-preview-${imgLang}-thumb-v2.jpg`;
   const previewFull = `/checklist-preview-${imgLang}-v2.jpg`;
+
+  useEffect(() => {
+    if (!lightboxOpen) return;
+
+    const dialog = lightboxDialogRef.current;
+    if (!dialog) return;
+
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const focusFrame = requestAnimationFrame(() => first?.focus());
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setLightboxOpen(false);
+        return;
+      }
+
+      if (event.key !== "Tab" || focusable.length === 0) return;
+
+      if (!dialog.contains(document.activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first)?.focus();
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      lightboxTriggerRef.current?.focus();
+    };
+  }, [lightboxOpen]);
 
   // Load data
   useEffect(() => {
@@ -509,6 +556,8 @@ export default function ChecklistPage() {
               {l(lang, "The image illustrates the type of step-by-step guidance Clarvia is working to deliver. It is not a finished product — the content, design, and features are still being developed and validated.", "L'image illustre le type d'accompagnement étape par étape que Clarvia travaille à offrir. Il ne s'agit pas d'un produit finalisé — le contenu, le design et les fonctionnalités sont encore en cours de développement et de validation.", "Das Bild zeigt, welche Art von schrittweiser Orientierung Clarvia entwickeln möchte. Es handelt sich nicht um ein fertiges Produkt — Inhalte, Design und Funktionen werden noch entwickelt und geprüft.", "D'Bild weist déi Zort Schrëtt-fir-Schrëtt-Orientéierung, un där Clarvia schafft. Et ass nach kee fäerdege Produit — Inhalt, Design a Funktioune ginn nach entwéckelt a validéiert.")}
             </p>
             <button
+              ref={lightboxTriggerRef}
+              type="button"
               onClick={() => setLightboxOpen(true)}
               className="group relative w-full rounded-lg overflow-hidden shadow-md hover:shadow-lg transition-shadow duration-300 cursor-zoom-in border border-calm-blue-200/60"
               aria-label={l(lang, "View full checklist preview", "Voir l'aperçu complet de la liste de démarches", "Vollständige Vorschau der Checkliste anzeigen", "Déi komplett Virschau vun der Checklëscht kucken")}
@@ -535,6 +584,7 @@ export default function ChecklistPage() {
         {/* ── Lightbox ── */}
         {lightboxOpen && (
           <div
+            ref={lightboxDialogRef}
             className="fixed inset-0 z-[9999] bg-black/70 backdrop-blur-sm flex items-start justify-center overflow-y-auto"
             onClick={() => setLightboxOpen(false)}
             role="dialog"
@@ -542,6 +592,7 @@ export default function ChecklistPage() {
             aria-label={l(lang, "Checklist preview", "Aperçu de la liste de démarches", "Vorschau der Checkliste", "Virschau vun der Checklëscht")}
           >
             <button
+              type="button"
               onClick={() => setLightboxOpen(false)}
               className="fixed top-4 right-4 z-[10000] bg-white/90 backdrop-blur-sm text-calm-blue-700 w-10 h-10 rounded-full flex items-center justify-center shadow-lg hover:bg-white transition-colors text-xl font-bold"
               aria-label={l(lang, "Close", "Fermer", "Schließen", "Zoumaachen")}
@@ -626,6 +677,10 @@ function IntakeWizard({
   return (
     <div className="space-y-6">
       {questions.map((q, idx) => {
+        const questionLabelId = `question-${q.id}-label`;
+        const questionLabel =
+          lang === "fr" ? q.label_fr : lang === "de" ? q.label_de : q.label_en;
+
         // Build options based on question type
         const options = q.options && q.options.length > 0
           ? q.options
@@ -638,17 +693,20 @@ function IntakeWizard({
             : null;
 
         return (
-          <div
+          <fieldset
             key={q.id}
             className="glass-panel p-6 rounded-xl transition-all"
             style={{ animationDelay: `${idx * 100}ms` }}
           >
-            <label className="block text-sm font-semibold text-calm-blue-800 mb-3">
+            <legend
+              id={questionLabelId}
+              className="block text-sm font-semibold text-calm-blue-800 mb-3"
+            >
               <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-calm-blue-100 text-calm-blue-600 text-xs font-bold mr-2">
                 {idx + 1}
               </span>
-              {lang === "fr" ? q.label_fr : lang === "de" ? q.label_de : q.label_en}
-            </label>
+              {questionLabel}
+            </legend>
 
             {options ? (
               /* Button-grid for jurisdiction_code, boolean, and enum with options */
@@ -658,7 +716,9 @@ function IntakeWizard({
                   return (
                     <button
                       key={opt.value}
+                      type="button"
                       onClick={() => onAnswer(q.id, opt.value)}
+                      aria-pressed={selected}
                       className={`px-4 py-2.5 rounded-lg text-sm font-medium transition-all border ${
                         selected
                           ? "bg-calm-blue-800 text-white border-calm-blue-800 shadow-md"
@@ -680,13 +740,16 @@ function IntakeWizard({
                 <input
                   type="number"
                   min="0"
+                  aria-labelledby={questionLabelId}
                   value={answers[q.id] && answers[q.id] !== "UNKNOWN" ? answers[q.id] : ""}
                   onChange={(e) => onAnswer(q.id, e.target.value || "UNKNOWN")}
                   placeholder="0"
                   className="w-32 px-4 py-2.5 rounded-lg text-sm border border-calm-blue-200 bg-white/60 text-calm-blue-800 focus:outline-none focus:border-calm-blue-400 focus:ring-1 focus:ring-calm-blue-400"
                 />
                 <button
+                  type="button"
                   onClick={() => onAnswer(q.id, "UNKNOWN")}
+                  aria-pressed={answers[q.id] === "UNKNOWN"}
                   className={`px-4 py-2.5 rounded-lg text-sm font-medium transition-all border ${
                     answers[q.id] === "UNKNOWN"
                       ? "bg-calm-blue-800 text-white border-calm-blue-800 shadow-md"
@@ -701,13 +764,16 @@ function IntakeWizard({
               <div className="flex gap-2 items-center">
                 <input
                   type="text"
+                  aria-labelledby={questionLabelId}
                   value={answers[q.id] && answers[q.id] !== "UNKNOWN" ? answers[q.id] : ""}
                   onChange={(e) => onAnswer(q.id, e.target.value || "UNKNOWN")}
                   placeholder={l(lang, "Enter value…", "Saisir une valeur…", "Wert eingeben…", "Wäert aginn…")}
                   className="flex-grow px-4 py-2.5 rounded-lg text-sm border border-calm-blue-200 bg-white/60 text-calm-blue-800 focus:outline-none focus:border-calm-blue-400 focus:ring-1 focus:ring-calm-blue-400"
                 />
                 <button
+                  type="button"
                   onClick={() => onAnswer(q.id, "UNKNOWN")}
+                  aria-pressed={answers[q.id] === "UNKNOWN"}
                   className={`px-4 py-2.5 rounded-lg text-sm font-medium transition-all border ${
                     answers[q.id] === "UNKNOWN"
                       ? "bg-calm-blue-800 text-white border-calm-blue-800 shadow-md"
@@ -718,11 +784,12 @@ function IntakeWizard({
                 </button>
               </div>
             )}
-          </div>
+          </fieldset>
         );
       })}
 
       <button
+        type="button"
         onClick={onGenerate}
         disabled={!allAnswered}
         className={`w-full py-3.5 rounded-xl text-base font-semibold transition-all ${
@@ -856,6 +923,7 @@ function ChecklistItemCard({
   lang: Lang;
 }) {
   const [expanded, setExpanded] = useState(false);
+  const detailsId = `checklist-item-${item.id}-details`;
 
   const statusConfig = {
     applies: {
@@ -887,13 +955,20 @@ function ChecklistItemCard({
   };
 
   return (
-    <div
-      className={`rounded-xl border p-4 transition-all cursor-pointer hover:shadow-sm ${s.bg}`}
-      onClick={() => setExpanded(!expanded)}
-    >
-      <div className="flex items-start gap-3">
-        <span className={`text-lg mt-0.5 ${s.color} font-bold`}>{s.icon}</span>
-        <div className="flex-grow min-w-0">
+    <div className={`rounded-xl border p-4 transition-all hover:shadow-sm ${s.bg}`}>
+      <button
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={detailsId}
+        onClick={() => setExpanded((isExpanded) => !isExpanded)}
+        className="w-full text-left rounded-lg focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-calm-blue-500"
+      >
+        <div className="flex items-start gap-3">
+          <span className="sr-only">{s.label}. </span>
+          <span aria-hidden="true" className={`text-lg mt-0.5 ${s.color} font-bold`}>
+            {s.icon}
+          </span>
+          <div className="flex-grow min-w-0">
           <div className="flex items-start justify-between gap-2">
             <h4 className="text-sm font-semibold text-calm-blue-800 leading-snug">
               {item.title}
@@ -942,10 +1017,16 @@ function ChecklistItemCard({
               </span>
             )}
           </div>
+          </div>
+        </div>
+      </button>
 
-          {/* Expanded details */}
-          {expanded && (
-            <div className="mt-3 pt-3 border-t border-calm-blue-200/50 space-y-2 text-xs text-calm-blue-600">
+      {/* Expanded details */}
+      <div
+        id={detailsId}
+        hidden={!expanded}
+        className="mt-3 pt-3 border-t border-calm-blue-200/50 space-y-2 text-xs text-calm-blue-600"
+      >
               {item.evidence && item.evidence.length > 0 && (
                 <div>
                   <span className="font-semibold">
@@ -973,7 +1054,6 @@ function ChecklistItemCard({
                             target="_blank"
                             rel="noopener noreferrer"
                             className="underline text-calm-blue-600 hover:text-calm-blue-800"
-                            onClick={(e) => e.stopPropagation()}
                           >
                             {s.title}
                           </a>
@@ -993,9 +1073,6 @@ function ChecklistItemCard({
                   {l(lang, "We need more information to determine if this applies to your situation.", "Nous avons besoin de plus d'informations pour déterminer si cela s'applique à votre situation.", "Wir benötigen weitere Informationen, um festzustellen, ob dies auf Ihre Situation zutrifft.", "Mir brauchen nach méi Informatiounen, fir ze bestëmmen, ob dat op Är Situatioun zoutrëfft.")}
                 </p>
               )}
-            </div>
-          )}
-        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { type Lang, l } from "@/lib/i18n";
 import { saveConsentPreference, updateGoogleConsent, CONSENT_STORAGE_KEY, CONSENT_VERSION } from "@/lib/consent";
 
 export default function CookieConsent({ lang }: { lang: Lang }) {
   const [isVisible, setIsVisible] = useState(false);
   const [isRendered, setIsRendered] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     let showBanner = true;
@@ -42,6 +44,48 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
     return () => window.removeEventListener("clarvia-open-cookie-settings", handleOpen);
   }, []);
 
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    const focusable = dialog.querySelectorAll<HTMLElement>(
+      'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const focusFrame = requestAnimationFrame(() => first?.focus());
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab" || focusable.length === 0) return;
+
+      if (!dialog.contains(document.activeElement)) {
+        event.preventDefault();
+        (event.shiftKey ? last : first)?.focus();
+        return;
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      cancelAnimationFrame(focusFrame);
+      document.removeEventListener("keydown", handleKeyDown);
+      previousFocusRef.current?.focus();
+    };
+  }, [isVisible]);
+
   const handleChoice = (status: "granted" | "denied") => {
     saveConsentPreference(status);
     updateGoogleConsent(status);
@@ -55,7 +99,11 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
+      aria-modal="true"
+      aria-hidden={!isVisible}
+      inert={!isVisible}
       aria-labelledby="consent-title"
       aria-describedby="consent-description"
       className={`fixed bottom-4 left-4 right-4 md:left-auto md:right-8 md:max-w-md z-50 transition-all duration-500 ease-in-out ${
@@ -64,9 +112,9 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
     >
       <div className="glass-panel shadow-2xl border border-calm-blue-200/50 rounded-2xl p-5 md:p-6 text-sm flex flex-col gap-4">
         <div>
-          <h4 id="consent-title" className="font-semibold text-base text-[#2b3a67] mb-1">
+          <h2 id="consent-title" className="font-semibold text-base text-[#2b3a67] mb-1">
             {l(lang, "Privacy preferences", "Préférences de confidentialité", "Datenschutzeinstellungen", "Dateschutz-Astellungen")}
-          </h4>
+          </h2>
           <p id="consent-description" className="text-xs text-calm-blue-600 leading-relaxed">
             {l(lang, "We are a non-profit building a free bereavement service. To help us understand site performance and improve our checklists, we use Google Analytics. Accepting optional measurement directly helps our mission — or you can continue with essential-only settings.", "Nous sommes une association sans but lucratif qui développe un service d'accompagnement gratuit. Pour nous aider à comprendre les performances du site et à améliorer nos listes de démarches, nous utilisons Google Analytics. Accepter ces mesures facultatives soutient directement notre mission — ou vous pouvez continuer avec les paramètres essentiels uniquement.", "Wir sind ein gemeinnütziger Verein, der eine kostenlose Orientierungshilfe im Trauerfall entwickelt. Um die Leistung unserer Website besser zu verstehen und unsere Checklisten zu verbessern, nutzen wir Google Analytics. Wenn Sie diesen optionalen Messungen zustimmen, unterstützen Sie unsere Arbeit direkt — oder Sie können nur mit den erforderlichen Einstellungen fortfahren.", "Mir sinn eng ASBL, déi e gratis Service fir Begleedung am Trauerfall opbaut. Fir besser ze verstoen, wéi eis Websäit funktionéiert, an eis Checklëschten ze verbesseren, benotze mir Google Analytics. Wann Dir déi fakultativ Miessungen akzeptéiert, ënnerstëtzt Dir direkt eis Missioun — oder Dir kënnt mat nëmmen den néidegen Astellunge weiderfueren.")}
           </p>
@@ -74,12 +122,14 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
 
         <div className="flex flex-row gap-2">
           <button
+            type="button"
             onClick={() => handleChoice("denied")}
             className="flex-1 py-2 px-3 border border-calm-blue-200 hover:border-calm-blue-300 text-calm-blue-800 font-medium text-xs rounded-xl bg-white hover:bg-calm-blue-50 transition-all cursor-pointer text-center"
           >
             {l(lang, "Decline / Essential only", "Refuser / Essentiel uniquement", "Ablehnen / Nur erforderlich", "Refuséieren / nëmmen dat Noutwendegt")}
           </button>
           <button
+            type="button"
             onClick={() => handleChoice("granted")}
             className="flex-1 py-2 px-3 bg-calm-blue-100 hover:bg-calm-blue-200 hover:border-calm-blue-300 border border-transparent text-calm-blue-900 font-semibold text-xs rounded-xl transition-all cursor-pointer text-center"
           >

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -8,8 +8,9 @@ import { type Lang, l, LANGUAGES } from "@/lib/i18n";
 export default function Header({ lang }: { lang: Lang }) {
   const [isOpen, setIsOpen] = useState(false);
   const drawerRef = useRef<HTMLDivElement>(null);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
 
-  const toggleMenu = () => setIsOpen(!isOpen);
+  const toggleMenu = () => setIsOpen((open) => !open);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -22,8 +23,18 @@ export default function Header({ lang }: { lang: Lang }) {
     const last = focusable[focusable.length - 1];
     first?.focus();
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") { setIsOpen(false); return; }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setIsOpen(false);
+        menuButtonRef.current?.focus();
+        return;
+      }
       if (e.key !== "Tab") return;
+      if (!drawer.contains(document.activeElement)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first)?.focus();
+        return;
+      }
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last?.focus();
@@ -121,9 +132,12 @@ export default function Header({ lang }: { lang: Lang }) {
 
           {/* Mobile Hamburger Menu Button */}
           <button
+            ref={menuButtonRef}
+            type="button"
             onClick={toggleMenu}
             className="md:hidden p-2 rounded-xl text-calm-blue-600 hover:bg-white/40 transition-colors focus:outline-none focus:ring-2 focus:ring-calm-lilac-400 z-50 relative"
             aria-expanded={isOpen}
+            aria-controls="mobile-navigation-menu"
             aria-label={l(lang, "Toggle menu", "Menu", "Menü ein-/ausblenden", "Menü op- an zouklappen")}
           >
             <svg
@@ -146,16 +160,23 @@ export default function Header({ lang }: { lang: Lang }) {
       {/* Mobile Drawer Backdrop */}
       {isOpen && (
         <div
-          onClick={toggleMenu}
+          aria-hidden="true"
+          onClick={() => {
+            setIsOpen(false);
+            menuButtonRef.current?.focus();
+          }}
           className="fixed inset-0 bg-slate-900/20 backdrop-blur-sm z-40 md:hidden transition-opacity"
         />
       )}
 
       {/* Mobile Drawer (Calm/Glass aesthetic) */}
       <div
+        id="mobile-navigation-menu"
         ref={drawerRef}
         role="dialog"
         aria-modal="true"
+        aria-hidden={!isOpen}
+        inert={!isOpen}
         aria-label={l(lang, "Navigation menu", "Menu de navigation", "Navigationsmenü")}
         className={`fixed top-0 right-0 h-full w-72 max-w-[80vw] bg-white/80 backdrop-blur-xl border-l border-white/50 shadow-2xl z-40 transform transition-transform duration-300 ease-out md:hidden flex flex-col p-6 pt-24 ${
           isOpen ? "translate-x-0" : "translate-x-full"


### PR DESCRIPTION
## Summary

- keep the closed mobile navigation out of the keyboard and accessibility trees, trap focus while open, and restore focus on Escape
- give the cookie and checklist-preview dialogs correct initial focus, focus containment, Escape behavior, and focus restoration
- associate checklist questions with their controls and expose selected answers with `aria-pressed`
- make generated checklist cards keyboard-operable expansion buttons with accessible status and expanded/collapsed state

## Before / after

Before, closed drawer links remained tabbable, modal focus could escape into the page, checklist selections and the numeric input lacked useful programmatic context, and generated result cards were mouse-only.

After, hidden controls are removed from navigation, modal focus stays contained and returns to the opener, NVDA announces question labels and selected states, and result cards can be expanded or collapsed with the keyboard.

## Validation

- `corepack pnpm --filter @clarvia/workflow-web exec tsc --noEmit`
- `corepack pnpm --filter @clarvia/workflow-web test` — 18 tests passed
- `corepack pnpm --filter @clarvia/workflow-web build` — production build passed, 48 static pages generated
- keyboard-only testing with Tab, Shift+Tab, Enter, and Escape on desktop and a 375×812 mobile viewport
- axe-core 4.10.3 spot-check — zero violations on `/en/checklist` and `/en/contribute`
- NVDA 2026.1.1 with Chrome on Windows — verified dialog names and focus behavior, question associations, pressed states, numeric-input naming, result-card collapsed/expanded announcements, mobile-navigation focus restoration, landmarks, headings, and contribute-page links

## Tooling note

Targeted ESLint could not start because the repository currently resolves ESLint 10.8.1 with `eslint-plugin-react` 7.37.5 (`contextOrFilename.getFilename is not a function`). TypeScript, tests, build, keyboard, axe, and NVDA checks passed.

Closes #241
