### PR TITLE
Worldwide English homepage; cookie bar no longer covers Send

### DIFF
--- a/apps/web/src/app/[lang]/about/page.tsx
+++ b/apps/web/src/app/[lang]/about/page.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/Header";
 import { headlineStyle } from "../data";
 import FooterSection from "../sections/FooterSection";
 import FoundingSection from "../sections/FoundingSection";
+import ProblemSection from "../sections/ProblemSection";
 
 const BASE_URL = "https://clarvia.org";
 
@@ -109,6 +110,8 @@ export default async function AboutPage({
             </p>
           </div>
         </section>
+
+        <ProblemSection lang={lang} />
 
         {/* ═══ Active Programs & Services ═══ */}
         <section className="mb-16" aria-labelledby="programs-heading">

--- a/apps/web/src/app/[lang]/layout.tsx
+++ b/apps/web/src/app/[lang]/layout.tsx
@@ -9,7 +9,7 @@ const META: Record<Lang, { title: string; description: string }> = {
   en: {
     title: "Clarvia — Guiding families through what comes next",
     description:
-      "Open workflow infrastructure for bereavement administration in Luxembourg and across Europe. Free, multilingual, source-backed guidance to help families navigate every administrative step after a loss.",
+      "Free, source-linked guidance from a terminal diagnosis through the practical questions that can arise years after a death.",
   },
   fr: {
     title: "Clarvia — Accompagner les familles dans ce qui suit",
@@ -104,7 +104,7 @@ export default async function LangLayout({
                 },
                 "foundingDate": "2026-05",
 
-                "description": "Clarvia is a Luxembourgish non-profit building open, source-backed workflow infrastructure for bereavement administration across Europe, starting with a free multilingual bereavement checklist for families in Luxembourg.",
+                "description": "Clarvia is an independent non-profit providing free, source-linked bereavement and end-of-life guidance for families worldwide.",
                 "knowsAbout": [
                   "bereavement administration",
                   "life-event consequence modeling",
@@ -117,12 +117,7 @@ export default async function LangLayout({
                   "CPSV-AP",
                   "CCCEV",
                   "ELI",
-                  "PROV-O",
-                  "Luxembourg",
-                  "France",
-                  "Germany",
-                  "Belgium",
-                  "Portugal"
+                  "PROV-O"
                 ]
               },
               {
@@ -134,7 +129,7 @@ export default async function LangLayout({
                   "@id": "https://clarvia.org/#organization"
                 },
                 "inLanguage": ["en", "fr", "de", "lu"],
-                "description": "Free multilingual bereavement guidance for families in Luxembourg, backed by open workflow infrastructure."
+                "description": "Free multilingual bereavement guidance for families worldwide, backed by open workflow infrastructure."
               },
               {
                 "@type": "SoftwareSourceCode",
@@ -159,12 +154,11 @@ export default async function LangLayout({
                 "creator": {
                   "@id": "https://clarvia.org/#organization"
                 },
-                "description": "Clarvia combines an infrastructure layer and an application layer. The infrastructure layer is open, standards-compatible consequence graph infrastructure for EU life events. The application layer is a free bereavement checklist for real people in Luxembourg and cross-border family situations.",
+                "description": "Clarvia combines an infrastructure layer and an application layer. The infrastructure layer is open, standards-compatible consequence graph infrastructure for life events. The application layer is free bereavement guidance for families worldwide.",
                 "about": [
                   "open workflow infrastructure",
                   "bereavement checklist",
                   "life-event consequence graph",
-                  "European administrative interoperability",
                   "source-backed guidance"
                 ]
               }

--- a/apps/web/src/app/[lang]/page.tsx
+++ b/apps/web/src/app/[lang]/page.tsx
@@ -1,8 +1,7 @@
 import { type Metadata } from "next";
-import { type Lang, l, LANGUAGES } from "@/lib/i18n";
+import { type Lang, LANGUAGES } from "@/lib/i18n";
 import Header from "@/components/Header";
 import HeroSection from "./sections/HeroSection";
-import ProblemSection from "./sections/ProblemSection";
 import TestimonialsSection from "./sections/TestimonialsSection";
 import FormsSection from "./sections/FormsSection";
 import FooterSection from "./sections/FooterSection";
@@ -13,7 +12,7 @@ const HOME_META: Record<Lang, { title: string; description: string }> = {
   en: {
     title: "Not sure what to do when a loved one is terminally ill or has died? — Clarvia",
     description:
-      "Free guidance from a terminal diagnosis through the practical questions that can still arise years after a death.",
+      "Free, source-linked guidance from a terminal diagnosis through the practical questions that can arise years after a death.",
   },
   fr: {
     title: "Clarvia — Accompagner les familles dans ce qui suit",
@@ -76,19 +75,7 @@ export default async function LandingPage({
 
       <main id="main-content" className="flex-grow w-full max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
         <HeroSection lang={lang} />
-        <ProblemSection lang={lang} />
         <TestimonialsSection lang={lang} />
-        <p className="text-center text-base text-calm-blue-600 mb-20">
-          <a href={`/${lang}/checklist`} className="underline hover:text-calm-blue-800">
-            {l(
-              lang,
-              "Looking for step-by-step Luxembourg guidance? See the free bereavement checklist.",
-              "Looking for step-by-step Luxembourg guidance? See the free bereavement checklist.",
-              "Looking for step-by-step Luxembourg guidance? See the free bereavement checklist.",
-              "Looking for step-by-step Luxembourg guidance? See the free bereavement checklist."
-            )}
-          </a>
-        </p>
         <FormsSection lang={lang} showFeedback={false} showContact />
       </main>
 

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -10,7 +10,7 @@ export default function FooterSection({ lang }: { lang: Lang }) {
           <div>
             <Image src="/clarvia-logo.webp" alt="Clarvia logo" width={96} height={48} className="h-12 w-auto mb-4" />
             <p className="text-sm text-calm-blue-600 leading-relaxed">
-              {l(lang, "Free bereavement guidance for families in Luxembourg.", "Un accompagnement gratuit pour les familles au Luxembourg après un décès.", "Kostenlose Orientierung im Trauerfall für Familien in Luxemburg.", "Gratis Orientéierung am Trauerfall fir Familljen zu Lëtzebuerg.")}
+              {l(lang, "Free bereavement guidance for families.", "Un accompagnement gratuit pour les familles au Luxembourg après un décès.", "Kostenlose Orientierung im Trauerfall für Familien in Luxemburg.", "Gratis Orientéierung am Trauerfall fir Familljen zu Lëtzebuerg.")}
             </p>
           </div>
           <div>

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -13,10 +13,10 @@ const ASK_OK_KEY = "clarvia-ask-submitted";
 
 const EXAMPLES = [
   "My father died last week in Paris. I live in France. What do I need to do first?",
-  "My partner has a terminal diagnosis and we live in Luxembourg. What should we organise while we still can?",
-  "My mother died in Germany two years ago. I still have questions about pension and paperwork in Luxembourg.",
-  "Someone I love died abroad. They lived in Luxembourg. How do we handle the death certificate and funeral?",
-  "I need to tell banks and the commune after a death in Luxembourg. Where do I start?",
+  "My partner has a terminal diagnosis. What should we organise while we still can?",
+  "My mother died two years ago. I still have questions about pension and paperwork.",
+  "Someone I love died in another country. How do we handle the death certificate and funeral?",
+  "I need to tell banks and local authorities after a death. Where do I start?",
   "We are not sure who should handle the funeral and the first official steps.",
 ] as const;
 
@@ -96,15 +96,20 @@ export default function HeroSection({ lang }: { lang: Lang }) {
         <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-4">
           {t(
             lang,
-            "Free guidance from a terminal diagnosis through the practical questions that can still arise years after a death."
+            "Free, source-linked guidance from a terminal diagnosis through the practical questions that can arise years after a death."
+          )}
+        </p>
+        <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-4">
+          {t(
+            lang,
+            "Type what happened in your own language, from anywhere. Include where your loved one lived, where the death occurred, or where things stand today. The more context you share, the better we can help."
           )}
         </p>
         <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-10">
-          {t(lang, "Type what happened. Include")}{" "}
-          <strong>{t(lang, "where your loved one lived")}</strong>
-          {t(lang, ", and")}{" "}
-          <strong>{t(lang, "where they are now or where the death occurred")}</strong>
-          {t(lang, ". You’ll get a thoughtful email, usually within a few minutes.")}
+          {t(
+            lang,
+            "Clarvia will send a carefully researched reply to your email, usually within a few minutes."
+          )}
         </p>
 
         <form onSubmit={onSubmit} className="glass-panel p-6 sm:p-8 max-w-2xl mx-auto text-left">
@@ -168,7 +173,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
               disabled={!canSubmit}
               className="btn-primary px-8 py-3 text-base whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed sm:self-end"
             >
-              {status === "sending" ? t(lang, "Sending...") : t(lang, "Ask us")}
+              {status === "sending" ? t(lang, "Sending...") : t(lang, "Send")}
             </button>
           </div>
 
@@ -189,6 +194,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             )}
           </p>
         </form>
+        <div id="cookie-consent-slot" className="max-w-2xl mx-auto mt-4" />
       </section>
 
       <section className="mb-16">
@@ -226,7 +232,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
         </h2>
         <ul className="max-w-3xl mx-auto space-y-4 text-base text-calm-blue-700 leading-relaxed">
           <li>
-            <strong>{t(lang, "Researched, not guessed.")}</strong>{" "}
+            <strong>{t(lang, "Researched with cited sources.")}</strong>{" "}
             {t(
               lang,
               "We use reliable online sources and, where available, Clarvia’s maintained official information and current laws. You get links so you can check."
@@ -250,13 +256,10 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             <strong>{t(lang, "Made by Clarvia.")}</strong>{" "}
             {t(
               lang,
-              "A free service from a registered Luxembourg nonprofit (Clarvia ASBL, RCS F15680), for people who need a next step in a difficult time."
+              "A free service from a registered nonprofit (Clarvia ASBL, RCS F15680), for people who need a next step in a difficult time."
             )}
           </li>
         </ul>
-        <p className="text-sm text-calm-blue-500 text-center mt-8">
-          {t(lang, "This is information, not medical or legal advice.")}
-        </p>
       </section>
     </>
   );

--- a/apps/web/src/app/[lang]/sections/ProblemSection.tsx
+++ b/apps/web/src/app/[lang]/sections/ProblemSection.tsx
@@ -1,44 +1,14 @@
 import { type Lang, l } from "@/lib/i18n";
-import { headlineStyle, LU_STATS } from "../data";
 
 export default function ProblemSection({ lang }: { lang: Lang }) {
   return (
-    <section className="mb-20">
-      <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-10" style={headlineStyle}>
-        {l(lang, "After a loss, practical help is not equally accessible", "Après un décès, l'aide pratique n'est pas accessible à tous de la même manière.", "Nach einem Todesfall ist praktische Hilfe nicht für alle gleichermaßen zugänglich.", "No engem Verloscht ass praktesch Hëllef net fir jiddereen d'selwecht zougänglech")}
-      </h2>
-
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 mb-10">
-        {LU_STATS.map((s, i) => (
-          <div key={i} className="glass-panel p-6 sm:p-8 flex flex-col">
-            <div className="text-3xl sm:text-4xl font-bold mb-2 text-center" style={{ color: "#7162ae" }}>{s.num}</div>
-            <p className="text-base text-calm-blue-700 font-medium text-center mb-3">
-              {l(lang, s.en_label, s.fr_label, s.de_label, s.lu_label)}
-            </p>
-            <p className="text-sm text-calm-blue-600 leading-relaxed mb-4 flex-grow">
-              {l(lang, s.en_detail, s.fr_detail, s.de_detail, s.lu_detail)}
-            </p>
-            <p className="text-xs text-calm-blue-500 pt-3 border-t border-calm-blue-100/50">
-              {l(lang, "Source", "Source", "Quelle", "Quell")}:{" "}
-              {s.sources.map((src, j) => (
-                <span key={j}>
-                  {j > 0 && ", "}
-                  <a href={src.url} target="_blank" rel="noopener noreferrer" className="underline hover:text-calm-blue-700 transition-colors">
-                    {src.label}
-                  </a>
-                </span>
-              ))}
-            </p>
-          </div>
-        ))}
-      </div>
-
+    <section className="mb-16">
       <div className="glass-panel p-8 sm:p-10 max-w-3xl mx-auto">
         <p className="text-base text-calm-blue-600 leading-relaxed mb-4">
           {l(lang, "When someone passes away, families are suddenly expected to handle administration, documents, institutions, urgent steps, funeral matters, succession-related questions, and personal memories - often while in shock.", "Lorsqu'une personne décède, les familles doivent soudainement gérer des démarches administratives, des documents, des institutions, des urgences, des questions liées aux obsèques, à la succession et aux souvenirs personnels - souvent alors qu'elles sont encore sous le choc.", "Wenn ein Mensch stirbt, müssen Angehörige plötzlich Verwaltung, Dokumente, Behörden, dringende Schritte, Bestattungsfragen, Nachlassthemen und persönliche Erinnerungen ordnen - oft mitten im Schock.", "Wann e Mënsch stierft, musse Familljen op eemol Administratioun, Dokumenter, Institutiounen, dréngend Schrëtt, Begriefnesfroen, Successiounsthemen a perséinlech Erënnerungen ugoen – dacks nach am Schock.")}
         </p>
         <p className="text-base text-calm-blue-600 leading-relaxed mb-4">
-          {l(lang, "For many people, this is harder because of language barriers, cross-border family situations, limited financial means, unfamiliarity with Luxembourg's systems, or simply not knowing who to ask.", "Pour beaucoup, cette période est rendue encore plus difficile par la barrière de la langue, des situations familiales transfrontalières, des moyens financiers limités, une méconnaissance du système luxembourgeois ou simplement le fait de ne pas savoir à qui s'adresser.", "Für viele Menschen wird dies zusätzlich erschwert: durch Sprachbarrieren, grenzüberschreitende Familiensituationen, begrenzte finanzielle Mittel, fehlende Vertrautheit mit den luxemburgischen Systemen oder schlicht durch die Frage, an wen man sich überhaupt wenden kann.", "Fir vill Leit ass dat nach méi schwéier wéinst Sproochebarrièren, grenziwwerschreidende Familljesituatiounen, begrenzte finanzielle Mëttelen, Onvertrautheet mam lëtzebuergesche System oder einfach well se net wëssen, wien se froe sollen.")}
+          {l(lang, "For many people, this is harder because of language barriers, cross-border family situations, limited financial means, unfamiliarity with local systems, or simply not knowing who to ask.", "Pour beaucoup, cette période est rendue encore plus difficile par la barrière de la langue, des situations familiales transfrontalières, des moyens financiers limités, une méconnaissance du système luxembourgeois ou simplement le fait de ne pas savoir à qui s'adresser.", "Für viele Menschen wird dies zusätzlich erschwert: durch Sprachbarrieren, grenzüberschreitende Familiensituationen, begrenzte finanzielle Mittel, fehlende Vertrautheit mit den luxemburgischen Systemen oder schlicht durch die Frage, an wen man sich überhaupt wenden kann.", "Fir vill Leit ass dat nach méi schwéier wéinst Sproochebarrièren, grenziwwerschreidende Familljesituatiounen, begrenzte finanzielle Mëttelen, Onvertrautheet mam lëtzebuergesche System oder einfach well se net wëssen, wien se froe sollen.")}
         </p>
         <p className="text-base text-calm-blue-600 leading-relaxed mb-6 italic">
           {l(lang, "The information may exist, but it is often scattered, technical, and difficult to navigate at the very moment families have the least capacity to search.", "L'information existe parfois, mais elle est souvent dispersée, technique et difficile à comprendre au moment même où les familles ont le moins d'énergie pour chercher.", "Informationen gibt es zwar, doch sie sind oft verstreut, technisch formuliert und schwer zu überblicken - gerade in dem Moment, in dem Familien am wenigsten Kraft zum Suchen haben.", "D'Informatioune kënnen existéieren, mee si sinn dacks verspreet, technesch formuléiert a schwéier ze iwwersi – grad an deem Moment, wou Familljen am mannste Kraaft hunn ze sichen.")}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -48,6 +48,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   min-height: 100vh;
+  padding-bottom: var(--cookie-banner-height, 0px);
 }
 
 @media (min-width: 768px) {

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { type Lang, l } from "@/lib/i18n";
 import { saveConsentPreference, updateGoogleConsent, CONSENT_STORAGE_KEY, CONSENT_VERSION } from "@/lib/consent";
 
 export default function CookieConsent({ lang }: { lang: Lang }) {
   const [isVisible, setIsVisible] = useState(false);
   const [isRendered, setIsRendered] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const [openedFromSettings, setOpenedFromSettings] = useState(false);
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  const barRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     let showBanner = true;
@@ -24,6 +26,8 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
       console.error("Error reading consent from localStorage", e);
     }
 
+    setSlot(document.getElementById("cookie-consent-slot"));
+
     if (showBanner) {
       const t1 = setTimeout(() => setIsRendered(true), 50);
       const t2 = setTimeout(() => setIsVisible(true), 150);
@@ -36,6 +40,7 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
 
   useEffect(() => {
     const handleOpen = () => {
+      setOpenedFromSettings(true);
       setIsRendered(true);
       setTimeout(() => setIsVisible(true), 10);
     };
@@ -44,47 +49,29 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
     return () => window.removeEventListener("clarvia-open-cookie-settings", handleOpen);
   }, []);
 
+  const useInline = Boolean(slot) && !openedFromSettings;
+
   useEffect(() => {
-    if (!isVisible) return;
-
-    const dialog = dialogRef.current;
-    if (!dialog) return;
-
-    previousFocusRef.current =
-      document.activeElement instanceof HTMLElement ? document.activeElement : null;
-
-    const focusable = dialog.querySelectorAll<HTMLElement>(
-      'button, a[href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    const focusFrame = requestAnimationFrame(() => first?.focus());
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Tab" || focusable.length === 0) return;
-
-      if (!dialog.contains(document.activeElement)) {
-        event.preventDefault();
-        (event.shiftKey ? last : first)?.focus();
-        return;
-      }
-
-      if (event.shiftKey && document.activeElement === first) {
-        event.preventDefault();
-        last?.focus();
-      } else if (!event.shiftKey && document.activeElement === last) {
-        event.preventDefault();
-        first?.focus();
-      }
+    if (!isRendered || useInline) {
+      document.documentElement.style.removeProperty("--cookie-banner-height");
+      return;
+    }
+    const el = barRef.current;
+    if (!el) return;
+    const apply = () => {
+      document.documentElement.style.setProperty(
+        "--cookie-banner-height",
+        `${el.offsetHeight}px`
+      );
     };
-
-    document.addEventListener("keydown", handleKeyDown);
+    apply();
+    const observer = new ResizeObserver(apply);
+    observer.observe(el);
     return () => {
-      cancelAnimationFrame(focusFrame);
-      document.removeEventListener("keydown", handleKeyDown);
-      previousFocusRef.current?.focus();
+      observer.disconnect();
+      document.documentElement.style.removeProperty("--cookie-banner-height");
     };
-  }, [isVisible]);
+  }, [isRendered, isVisible, lang, useInline]);
 
   const handleChoice = (status: "granted" | "denied") => {
     saveConsentPreference(status);
@@ -92,46 +79,58 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
     window.dispatchEvent(new Event("clarvia-consent-updated"));
 
     setIsVisible(false);
-    setTimeout(() => setIsRendered(false), 500); // Wait for transition animation to finish
+    setOpenedFromSettings(false);
+    setTimeout(() => setIsRendered(false), 500);
   };
 
   if (!isRendered) return null;
 
-  return (
+  const bar = (
     <div
-      ref={dialogRef}
-      role="dialog"
-      aria-modal="true"
-      aria-hidden={!isVisible}
-      inert={!isVisible}
+      ref={barRef}
+      role="region"
       aria-labelledby="consent-title"
       aria-describedby="consent-description"
-      className={`fixed bottom-4 left-4 right-4 md:left-auto md:right-8 md:max-w-md z-50 transition-all duration-500 ease-in-out ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8 pointer-events-none"
-      }`}
+      className={
+        useInline
+          ? `rounded-2xl border border-calm-blue-200/70 bg-white/95 backdrop-blur-md shadow-[0_8px_30px_rgba(43,58,103,0.08)] transition-all duration-500 ease-in-out ${
+              isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4 pointer-events-none"
+            }`
+          : `fixed inset-x-0 bottom-0 z-50 border-t border-calm-blue-200/70 bg-white/95 backdrop-blur-md shadow-[0_-8px_30px_rgba(43,58,103,0.08)] transition-all duration-500 ease-in-out ${
+              isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-8 pointer-events-none"
+            }`
+      }
     >
-      <div className="glass-panel shadow-2xl border border-calm-blue-200/50 rounded-2xl p-5 md:p-6 text-sm flex flex-col gap-4">
-        <div>
-          <h2 id="consent-title" className="font-semibold text-base text-[#2b3a67] mb-1">
+      <div
+        className={`max-w-5xl mx-auto px-4 sm:px-6 py-3 flex flex-col sm:flex-row sm:items-center gap-3 ${
+          useInline ? "max-w-none" : ""
+        }`}
+        style={
+          useInline
+            ? undefined
+            : { paddingBottom: "max(0.75rem, env(safe-area-inset-bottom, 0px))" }
+        }
+      >
+        <div className="flex-1 min-w-0">
+          <h2 id="consent-title" className="font-semibold text-sm text-[#2b3a67]">
             {l(lang, "Privacy preferences", "Préférences de confidentialité", "Datenschutzeinstellungen", "Dateschutz-Astellungen")}
           </h2>
-          <p id="consent-description" className="text-xs text-calm-blue-600 leading-relaxed">
+          <p id="consent-description" className="text-xs text-calm-blue-600 leading-snug mt-0.5 line-clamp-2 sm:line-clamp-none">
             {l(lang, "We are a non-profit building a free bereavement service. To help us understand site performance and improve our checklists, we use Google Analytics. Accepting optional measurement directly helps our mission — or you can continue with essential-only settings.", "Nous sommes une association sans but lucratif qui développe un service d'accompagnement gratuit. Pour nous aider à comprendre les performances du site et à améliorer nos listes de démarches, nous utilisons Google Analytics. Accepter ces mesures facultatives soutient directement notre mission — ou vous pouvez continuer avec les paramètres essentiels uniquement.", "Wir sind ein gemeinnütziger Verein, der eine kostenlose Orientierungshilfe im Trauerfall entwickelt. Um die Leistung unserer Website besser zu verstehen und unsere Checklisten zu verbessern, nutzen wir Google Analytics. Wenn Sie diesen optionalen Messungen zustimmen, unterstützen Sie unsere Arbeit direkt — oder Sie können nur mit den erforderlichen Einstellungen fortfahren.", "Mir sinn eng ASBL, déi e gratis Service fir Begleedung am Trauerfall opbaut. Fir besser ze verstoen, wéi eis Websäit funktionéiert, an eis Checklëschten ze verbesseren, benotze mir Google Analytics. Wann Dir déi fakultativ Miessungen akzeptéiert, ënnerstëtzt Dir direkt eis Missioun — oder Dir kënnt mat nëmmen den néidegen Astellunge weiderfueren.")}
           </p>
         </div>
-
-        <div className="flex flex-row gap-2">
+        <div className="flex flex-row gap-2 sm:shrink-0">
           <button
             type="button"
             onClick={() => handleChoice("denied")}
-            className="flex-1 py-2 px-3 border border-calm-blue-200 hover:border-calm-blue-300 text-calm-blue-800 font-medium text-xs rounded-xl bg-white hover:bg-calm-blue-50 transition-all cursor-pointer text-center"
+            className="flex-1 sm:flex-none py-2 px-4 border border-calm-blue-200 hover:border-calm-blue-300 text-calm-blue-800 font-medium text-xs rounded-xl bg-white hover:bg-calm-blue-50 transition-all cursor-pointer text-center"
           >
             {l(lang, "Decline / Essential only", "Refuser / Essentiel uniquement", "Ablehnen / Nur erforderlich", "Refuséieren / nëmmen dat Noutwendegt")}
           </button>
           <button
             type="button"
             onClick={() => handleChoice("granted")}
-            className="flex-1 py-2 px-3 bg-calm-blue-100 hover:bg-calm-blue-200 hover:border-calm-blue-300 border border-transparent text-calm-blue-900 font-semibold text-xs rounded-xl transition-all cursor-pointer text-center"
+            className="flex-1 sm:flex-none py-2 px-4 border border-calm-blue-200 hover:border-calm-blue-300 text-calm-blue-800 font-medium text-xs rounded-xl bg-white hover:bg-calm-blue-50 transition-all cursor-pointer text-center"
           >
             {l(lang, "Accept all", "Tout accepter", "Alle akzeptieren", "Alles akzeptéieren")}
           </button>
@@ -139,4 +138,10 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
       </div>
     </div>
   );
+
+  if (useInline && slot) {
+    return createPortal(bar, slot);
+  }
+
+  return bar;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to merged #285. English homepage now matches worldwide availability, and the first-visit privacy banner no longer covers the consent checkbox or Send.

**Cookie banner**
- On the homepage, it sits **under the form** (not over Send). Decline and Accept are the same size and equally visible.
- No modal / focus trap.
- On other pages, it stays a compact bottom bar with space so footer links are not covered.
- Approved FR/DE/LU cookie wording is unchanged; the bar is shorter on small screens.

**English homepage copy**
- New hero text, button **Send**, “Researched with cited sources.”
- Removed the extra medical/legal line (already in the footer).
- Removed the three Luxembourg stat boxes and the checklist sentence (already in the header).
- Worldwide examples (no Luxembourg-only prompts).
- English footer tagline: “Free bereavement guidance for families.” Address / RCS Luxembourg unchanged.
- English metadata and structured data describe a worldwide service. Organisation address stays Luxembourg.

**About**
- The “When someone passes away…” box now sits under Our Mission. About is otherwise unchanged.

FR/DE/LU homepage strings stay English until Tommi approves and translations are supplied.

## What to click / test

**Pass if**
- Phone `/en`, first visit: privacy banner is **under the form**, not on top of the checkbox or **Send**. Decline and Accept are both visible and the same size. You can send without dismissing cookies first.
- Hero matches the new English copy. Button says **Send**, not Ask us. Why ask us? starts with **Researched with cited sources.** No “This is information, not medical or legal advice.”
- No 40k / 47% / 24h boxes. No “Looking for step-by-step Luxembourg guidance?” on the home page.
- About: the “When someone passes away…” box is under Our Mission.
- English footer: worldwide tagline, local emergency services, no US sentence. Luxembourg still appears in RCS + address only.
- View source /en: JSON-LD describes worldwide guidance, not a Luxembourg-first European service.

**Fail if** the privacy banner covers Send on first visit, or `/en` still positions Clarvia as Luxembourg/Europe-only (except legal address).

## Checklist

- [ ] CI passes (`pnpm validate`, `pnpm test`, `pnpm typecheck`)
- [ ] New graph records start as `draft` / `restricted_source`
- [ ] Source assertions include `text_quote` anchors
- [ ] Scenario tests cover new consequences
- [ ] Documentation updated (if applicable)

## Related issues

Follow-up to #268 (Ask us homepage) and #285 (footer disclaimer).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

