### PR TITLE
Ad Grants site: identity, Contact page, donations, /en default

### DIFF
--- a/apps/web/__tests__/sitemap.test.ts
+++ b/apps/web/__tests__/sitemap.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import sitemap from "@/app/sitemap";
+import { hreflangLanguages } from "@/lib/i18n";
+
+describe("sitemap", () => {
+  it("includes an indexable contact page for every language", () => {
+    const urls = sitemap().map((entry) => entry.url);
+    expect(urls).toContain("https://clarvia.org/en/contact");
+    expect(urls).toContain("https://clarvia.org/fr/contact");
+    expect(urls).toContain("https://clarvia.org/de/contact");
+    expect(urls).toContain("https://clarvia.org/lu/contact");
+  });
+
+  it("sets hreflang x-default to the English URL", () => {
+    const home = sitemap().find((entry) => entry.url === "https://clarvia.org/en");
+    expect(home?.alternates?.languages?.["x-default"]).toBe("https://clarvia.org/en");
+
+    const contact = sitemap().find((entry) => entry.url === "https://clarvia.org/en/contact");
+    expect(contact?.alternates?.languages?.["x-default"]).toBe("https://clarvia.org/en/contact");
+  });
+});
+
+describe("hreflangLanguages", () => {
+  it("maps Luxembourgish to lb and defaults to English", () => {
+    expect(hreflangLanguages()).toMatchObject({
+      en: "https://clarvia.org/en",
+      fr: "https://clarvia.org/fr",
+      de: "https://clarvia.org/de",
+      lb: "https://clarvia.org/lu",
+      "x-default": "https://clarvia.org/en",
+    });
+  });
+});

--- a/apps/web/src/app/[lang]/about/page.tsx
+++ b/apps/web/src/app/[lang]/about/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
-import { type Lang, l, LANGUAGES } from "@/lib/i18n";
+import { type Lang, l, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import { headlineStyle } from "../data";
 import FooterSection from "../sections/FooterSection";
@@ -46,9 +46,7 @@ export async function generateMetadata({
     description: meta.description,
     alternates: {
       canonical: `${BASE_URL}/${lang}/about`,
-      languages: Object.fromEntries(
-        LANGUAGES.map((code) => [code, `${BASE_URL}/${code}/about`])
-      ),
+      languages: hreflangLanguages("about"),
     },
     openGraph: {
       title: meta.title,
@@ -183,7 +181,24 @@ export default async function AboutPage({
               {l(lang, "Clarvia is a non-profit association. We do not charge fees, display advertisements, or monetise personal data. There are no premium tiers or paid features. All services are free for every family.", "Clarvia est une association sans but lucratif. Nous ne facturons aucun frais, n'affichons pas de publicité et ne monétisons pas les données personnelles. Il n'existe ni offre premium ni fonctionnalité payante : tous les services sont gratuits pour toutes les familles.", "Clarvia ist ein gemeinnütziger Verein. Wir erheben keine Gebühren, schalten keine Werbung und monetarisieren keine personenbezogenen Daten. Es gibt keine Premium-Stufen und keine kostenpflichtigen Funktionen. Alle Angebote sind für jede Familie kostenlos.", "Clarvia ass eng Associatioun ouni Gewënnzweck. Mir froe keng Fraisen, weisen keng Reklammen a verdéngen net un perséinlechen Donnéeën. Et gëtt keng Premium-Offeren a keng bezuelte Funktiounen. All Servicer si fir all Famill gratis.")}
             </p>
             <p>
-              {l(lang, "Our operations are supported by corporate sponsors, grant funding, and volunteer contributions. Our tools, data, and source code are all freely available to the public.", "Nos activités sont soutenues par des sponsors d'entreprise, des financements sous forme de subventions et des contributions bénévoles. Nos outils, nos données et notre code source sont librement accessibles au public.", "Unsere Arbeit wird durch Unternehmenssponsoren, Fördermittel und ehrenamtliche Beiträge ermöglicht. Unsere Werkzeuge, Daten und unser Quellcode sind der Öffentlichkeit frei zugänglich.", "Eis Aarbecht gëtt duerch Entreprisesponsoren, Subventiounen a fräiwëlleg Bäiträg ënnerstëtzt. Eis Tools, Donnéeën an eise Quellcode si fir de Public fräi zougänglech.")}
+              {l(lang, "Our operations are supported by donations, corporate sponsors, grant funding, and volunteer contributions. Our tools, data, and source code are all freely available to the public.", "Nos activités sont soutenues par des sponsors d'entreprise, des financements sous forme de subventions et des contributions bénévoles. Nos outils, nos données et notre code source sont librement accessibles au public.", "Unsere Arbeit wird durch Unternehmenssponsoren, Fördermittel und ehrenamtliche Beiträge ermöglicht. Unsere Werkzeuge, Daten und unser Quellcode sind der Öffentlichkeit frei zugänglich.", "Eis Aarbecht gëtt duerch Entreprisesponsoren, Subventiounen a fräiwëlleg Bäiträg ënnerstëtzt. Eis Tools, Donnéeën an eise Quellcode si fir de Public fräi zougänglech.")}
+            </p>
+            <p>
+              {l(
+                lang,
+                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
+                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
+                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
+                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective."
+              )}{" "}
+              <a
+                href="https://opencollective.com/clarvia-org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-calm-blue-700 font-medium hover:text-calm-blue-900 underline underline-offset-2"
+              >
+                opencollective.com/clarvia-org
+              </a>
             </p>
           </div>
         </section>

--- a/apps/web/src/app/[lang]/about/page.tsx
+++ b/apps/web/src/app/[lang]/about/page.tsx
@@ -187,9 +187,9 @@ export default async function AboutPage({
               {l(
                 lang,
                 "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
-                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
-                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective.",
-                "Donations keep our free services running. We do not show ads. Payments are processed through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates. Our 2026 accounts have not yet been filed — live income and eligible expenses are on Open Collective."
+                "Les dons permettent de maintenir nos services gratuits. Nous n’affichons aucune publicité. Les paiements sont traités par Stripe, Open Collective et GitHub Sponsors. Nous ne délivrons actuellement aucun certificat fiscal. Nos comptes pour 2026 n’ont pas encore été déposés. Nos recettes et les dépenses admissibles peuvent être consultées en temps réel sur Open Collective.",
+                "Spenden sichern den Betrieb unserer kostenlosen Angebote. Wir zeigen keine Werbung. Zahlungen werden über Stripe, Open Collective und GitHub Sponsors abgewickelt. Derzeit stellen wir keine Spendenbescheinigungen aus. Unser Jahresabschluss für 2026 wurde noch nicht eingereicht. Laufende Einnahmen und anerkannte Ausgaben können auf Open Collective eingesehen werden.",
+                "Spenden halen eis gratis Servicer um Lafen. Mir weise keng Reklammen. D’Bezuelunge ginn iwwer Stripe, Open Collective a GitHub Sponsors ofgewéckelt. De Moment stelle mir keng Steierbescheinegungen aus. Eis Konte fir 2026 sinn nach net agereecht ginn. Déi aktuell Recetten an eligible Ausgabe kënnen op Open Collective nogekuckt ginn."
               )}{" "}
               <a
                 href="https://opencollective.com/clarvia-org"

--- a/apps/web/src/app/[lang]/contact/page.tsx
+++ b/apps/web/src/app/[lang]/contact/page.tsx
@@ -1,14 +1,165 @@
-import { redirect } from "next/navigation";
+import { type Metadata } from "next";
+import Link from "next/link";
+import { type Lang, l, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
+import Header from "@/components/Header";
+import { headlineStyle } from "../data";
+import FooterSection from "../sections/FooterSection";
+import FormsSection from "../sections/FormsSection";
 
-export const metadata = {
-  robots: { index: false, follow: true },
+const BASE_URL = "https://clarvia.org";
+
+const META: Record<Lang, { title: string; description: string }> = {
+  en: {
+    title: "Contact Clarvia ASBL",
+    description:
+      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+  },
+  fr: {
+    title: "Contact Clarvia ASBL",
+    description:
+      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+  },
+  de: {
+    title: "Contact Clarvia ASBL",
+    description:
+      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+  },
+  lu: {
+    title: "Contact Clarvia ASBL",
+    description:
+      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+  },
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang: rawLang } = await params;
+  const lang = (LANGUAGES.includes(rawLang as Lang) ? rawLang : "en") as Lang;
+  const meta = META[lang];
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: {
+      canonical: `${BASE_URL}/${lang}/contact`,
+      languages: hreflangLanguages("contact"),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: `${BASE_URL}/${lang}/contact`,
+      siteName: "Clarvia",
+      locale: lang,
+      type: "website",
+      images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630 }],
+    },
+  };
+}
 
 export default async function ContactPage({
   params,
 }: {
   params: Promise<{ lang: string }>;
 }) {
-  const { lang } = await params;
-  redirect(`/${lang}#contact`);
+  const { lang: rawLang } = await params;
+  const lang = (LANGUAGES.includes(rawLang as Lang) ? rawLang : "en") as Lang;
+
+  return (
+    <>
+      <Header lang={lang} />
+
+      <main id="main-content" className="flex-grow w-full max-w-3xl mx-auto px-4 sm:px-6 py-16 relative z-10">
+        <h1
+          className="text-4xl sm:text-5xl font-semibold tracking-tight mb-6 text-center"
+          style={headlineStyle}
+        >
+          {l(lang, "Contact Clarvia", "Contact Clarvia", "Contact Clarvia", "Contact Clarvia")}
+        </h1>
+        <p className="text-lg text-calm-blue-700 leading-relaxed text-center max-w-2xl mx-auto mb-10">
+          {l(
+            lang,
+            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
+            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
+            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
+            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions."
+          )}
+        </p>
+        <div className="flex flex-wrap justify-center gap-3 mb-12">
+          <Link
+            href={`/${lang}#ask-us`}
+            className="btn-primary inline-flex items-center justify-center px-6 py-2.5 text-sm"
+          >
+            {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+          </Link>
+          <Link
+            href={`/${lang}/support`}
+            className="btn-secondary inline-flex items-center justify-center px-6 py-2.5 text-sm"
+          >
+            {l(lang, "Donate", "Donate", "Donate", "Donate")}
+          </Link>
+        </div>
+
+        <section className="mb-12" aria-labelledby="contact-org-heading">
+          <h2
+            id="contact-org-heading"
+            className="text-2xl font-semibold text-calm-blue-800 mb-4 text-center"
+            style={{ fontFamily: headlineStyle.fontFamily }}
+          >
+            {l(lang, "Organisation", "Organisation", "Organisation", "Organisation")}
+          </h2>
+          <div className="glass-panel p-6 space-y-2 text-sm text-calm-blue-600 max-w-xl mx-auto">
+            <p>
+              <span className="font-semibold text-calm-blue-800">
+                {l(lang, "Legal name", "Nom légal", "Rechtsname", "Juristeschen Numm")}:
+              </span>{" "}
+              CLARVIA ASBL
+            </p>
+            <p>
+              <span className="font-semibold text-calm-blue-800">
+                {l(lang, "Type", "Type", "Rechtsform", "Form")}:
+              </span>{" "}
+              {l(
+                lang,
+                "Non-profit association (ASBL) under Luxembourg law",
+                "Association sans but lucratif (ASBL) de droit luxembourgeois",
+                "Gemeinnütziger Verein (ASBL) nach luxemburgischem Recht",
+                "Associatioun ouni Gewënnzweck (ASBL) no lëtzebuergeschem Recht"
+              )}
+            </p>
+            <p>
+              <span className="font-semibold text-calm-blue-800">
+                {l(lang, "Registration", "Enregistrement", "Registrierung", "Aschreiwung")}:
+              </span>{" "}
+              RCS Luxembourg F15680
+            </p>
+            <p>
+              <span className="font-semibold text-calm-blue-800">
+                {l(lang, "Address", "Adresse", "Adresse", "Adress")}:
+              </span>{" "}
+              46, Rue de la Lavande · 1923 Luxembourg
+            </p>
+          </div>
+        </section>
+
+        <FormsSection
+          lang={lang}
+          showFeedback={false}
+          showContact
+          contactHeading={l(lang, "Write to us", "Write to us", "Write to us", "Write to us")}
+          contactIntro={l(
+            lang,
+            "We welcome contact from:",
+            "We welcome contact from:",
+            "We welcome contact from:",
+            "We welcome contact from:"
+          )}
+        />
+      </main>
+
+      <FooterSection lang={lang} />
+    </>
+  );
 }

--- a/apps/web/src/app/[lang]/contact/page.tsx
+++ b/apps/web/src/app/[lang]/contact/page.tsx
@@ -15,19 +15,19 @@ const META: Record<Lang, { title: string; description: string }> = {
       "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
   },
   fr: {
-    title: "Contact Clarvia ASBL",
+    title: "Contacter Clarvia ASBL",
     description:
-      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+      "Contactez Clarvia ASBL, une association luxembourgeoise à but non lucratif (RCS F15680). Utilisez ce formulaire pour les partenariats, les demandes de presse, le bénévolat et les questions générales.",
   },
   de: {
-    title: "Contact Clarvia ASBL",
+    title: "Clarvia ASBL kontaktieren",
     description:
-      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+      "Kontaktieren Sie Clarvia ASBL, einen gemeinnützigen Verein aus Luxemburg (RCS F15680). Nutzen Sie dieses Formular für Partnerschaften, Presseanfragen, ehrenamtliche Mitarbeit und allgemeine Fragen.",
   },
   lu: {
-    title: "Contact Clarvia ASBL",
+    title: "Clarvia ASBL kontaktéieren",
     description:
-      "Contact Clarvia ASBL, a Luxembourg nonprofit (RCS F15680). Use this form for partnerships, press, volunteering, and general questions.",
+      "Kontaktéiert Clarvia ASBL, en net gewënnorientéierte Veräin aus Lëtzebuerg (RCS F15680). Benotzt dëse Formulaire fir Partnerschaften, Presseufroen, Benevolat an allgemeng Froen.",
   },
 };
 
@@ -76,15 +76,15 @@ export default async function ContactPage({
           className="text-4xl sm:text-5xl font-semibold tracking-tight mb-6 text-center"
           style={headlineStyle}
         >
-          {l(lang, "Contact Clarvia", "Contact Clarvia", "Contact Clarvia", "Contact Clarvia")}
+          {l(lang, "Contact Clarvia", "Contacter Clarvia", "Clarvia kontaktieren", "Clarvia kontaktéieren")}
         </h1>
         <p className="text-lg text-calm-blue-700 leading-relaxed text-center max-w-2xl mx-auto mb-10">
           {l(
             lang,
             "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
-            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
-            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions.",
-            "If someone you love is terminally ill or has died, please use Ask us on the homepage. Lex replies by email. This page is for everything else: partnerships, press, volunteering, and general questions."
+            "Si l’un de vos proches est en phase terminale ou est décédé, veuillez utiliser « Posez-nous votre question » sur la page d’accueil. Lex vous répondra par e-mail. Cette page est destinée à toutes les autres demandes : partenariats, presse, bénévolat et questions générales.",
+            "Wenn ein geliebter Mensch unheilbar krank ist oder verstorben ist, nutzen Sie bitte „Fragen Sie uns“ auf der Startseite. Lex antwortet Ihnen per E-Mail. Diese Seite ist für alle anderen Anliegen gedacht: Partnerschaften, Presseanfragen, ehrenamtliche Mitarbeit und allgemeine Fragen.",
+            "Wann eng Persoun, déi Iech nosteet, onheelbar krank ass oder gestuerwen ass, benotzt wgl. „Frot eis“ op der Startsäit. De Lex äntwert Iech per E-Mail. Dës Säit ass fir all aner Uleies geduecht: Partnerschaften, Presseufroen, Benevolat an allgemeng Froen."
           )}
         </p>
         <div className="flex flex-wrap justify-center gap-3 mb-12">
@@ -92,13 +92,13 @@ export default async function ContactPage({
             href={`/${lang}#ask-us`}
             className="btn-primary inline-flex items-center justify-center px-6 py-2.5 text-sm"
           >
-            {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+            {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
           </Link>
           <Link
             href={`/${lang}/support`}
             className="btn-secondary inline-flex items-center justify-center px-6 py-2.5 text-sm"
           >
-            {l(lang, "Donate", "Donate", "Donate", "Donate")}
+            {l(lang, "Donate", "Faire un don", "Spenden", "Spenden")}
           </Link>
         </div>
 
@@ -108,7 +108,7 @@ export default async function ContactPage({
             className="text-2xl font-semibold text-calm-blue-800 mb-4 text-center"
             style={{ fontFamily: headlineStyle.fontFamily }}
           >
-            {l(lang, "Organisation", "Organisation", "Organisation", "Organisation")}
+            {l(lang, "Organisation", "L’association", "Organisation", "Organisatioun")}
           </h2>
           <div className="glass-panel p-6 space-y-2 text-sm text-calm-blue-600 max-w-xl mx-auto">
             <p>
@@ -148,13 +148,13 @@ export default async function ContactPage({
           lang={lang}
           showFeedback={false}
           showContact
-          contactHeading={l(lang, "Write to us", "Write to us", "Write to us", "Write to us")}
+          contactHeading={l(lang, "Write to us", "Écrivez-nous", "Schreiben Sie uns", "Schreift eis")}
           contactIntro={l(
             lang,
             "We welcome contact from:",
-            "We welcome contact from:",
-            "We welcome contact from:",
-            "We welcome contact from:"
+            "Nous sommes heureux d’échanger avec :",
+            "Wir freuen uns über Nachrichten von:",
+            "Mir freeën eis iwwer Noriichte vun:"
           )}
         />
       </main>

--- a/apps/web/src/app/[lang]/layout.tsx
+++ b/apps/web/src/app/[lang]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { LANGUAGES, type Lang } from "@/lib/i18n";
+import { LANGUAGES, type Lang, hreflangLanguages } from "@/lib/i18n";
 import CookieConsent from "@/components/CookieConsent";
 
 
@@ -46,9 +46,7 @@ export async function generateMetadata({
     description: meta.description,
     alternates: {
       canonical: `${BASE_URL}/${lang}`,
-      languages: Object.fromEntries(
-        LANGUAGES.map((l) => [l === "lu" ? "lb" : l, `${BASE_URL}/${l}`])
-      ),
+      languages: hreflangLanguages(),
     },
     openGraph: {
       title: meta.title,
@@ -101,6 +99,11 @@ export default async function LangLayout({
                   "postalCode": "1923",
                   "addressLocality": "Luxembourg",
                   "addressCountry": "LU"
+                },
+                "contactPoint": {
+                  "@type": "ContactPoint",
+                  "url": "https://clarvia.org/en/contact",
+                  "contactType": "customer support"
                 },
                 "foundingDate": "2026-05",
 

--- a/apps/web/src/app/[lang]/page.tsx
+++ b/apps/web/src/app/[lang]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next";
-import { type Lang, LANGUAGES } from "@/lib/i18n";
+import { type Lang, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import HeroSection from "./sections/HeroSection";
 import TestimonialsSection from "./sections/TestimonialsSection";
@@ -45,9 +45,7 @@ export async function generateMetadata({
     description: meta.description,
     alternates: {
       canonical: `${BASE_URL}/${lang}`,
-      languages: Object.fromEntries(
-        LANGUAGES.map((code) => [code === "lu" ? "lb" : code, `${BASE_URL}/${code}`])
-      ),
+      languages: hreflangLanguages(),
     },
     openGraph: {
       title: meta.title,

--- a/apps/web/src/app/[lang]/privacy/page.tsx
+++ b/apps/web/src/app/[lang]/privacy/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { LANGUAGES, type Lang } from "@/lib/i18n";
+import { LANGUAGES, type Lang, hreflangLanguages } from "@/lib/i18n";
 import PrivacyPage from "./PrivacyPage";
 
 const BASE_URL = "https://clarvia.org";
@@ -39,9 +39,7 @@ export async function generateMetadata({
     description: meta.description,
     alternates: {
       canonical: `${BASE_URL}/${lang}/privacy`,
-      languages: Object.fromEntries(
-        LANGUAGES.map((l) => [l, `${BASE_URL}/${l}/privacy`])
-      ),
+      languages: hreflangLanguages("privacy"),
     },
     openGraph: {
       title: meta.title,

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -20,10 +20,10 @@ export default function FooterSection({ lang }: { lang: Lang }) {
             <nav className="flex flex-col gap-2" aria-label={l(lang, "Footer navigation", "Navigation du pied de page", "Fußzeilennavigation", "Navigatioun am Foussberäich")} >
               {[
                 { label: l(lang, "Home", "Accueil", "Startseite", "Startsäit"), href: `/${lang}` },
-                { label: l(lang, "Ask us", "Ask us", "Ask us", "Ask us"), href: `/${lang}#ask-us` },
+                { label: l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis"), href: `/${lang}#ask-us` },
                 { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
                 { label: l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen"), href: `/${lang}/support` },
-                { label: l(lang, "Luxembourg checklist", "Luxembourg checklist", "Luxembourg checklist", "Luxembourg checklist"), href: `/${lang}/checklist` },
+                { label: l(lang, "Luxembourg checklist", "Checklist Luxembourg", "Luxemburg-Checkliste", "Lëtzebuerg-Checklëscht"), href: `/${lang}/checklist` },
                 { label: l(lang, "About", "À propos", "Über uns", "Iwwer eis"), href: `/${lang}/about` },
                 { label: l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten"), href: `/${lang}/updates` },
                 { label: l(lang, "Presentation Brochure", "Brochure de présentation", "Präsentationsbroschüre", "Presentatiounsbroschür"), href: `/${lang}/brochure` },

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -20,14 +20,15 @@ export default function FooterSection({ lang }: { lang: Lang }) {
             <nav className="flex flex-col gap-2" aria-label={l(lang, "Footer navigation", "Navigation du pied de page", "Fußzeilennavigation", "Navigatioun am Foussberäich")} >
               {[
                 { label: l(lang, "Home", "Accueil", "Startseite", "Startsäit"), href: `/${lang}` },
+                { label: l(lang, "Ask us", "Ask us", "Ask us", "Ask us"), href: `/${lang}#ask-us` },
+                { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
                 { label: l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen"), href: `/${lang}/support` },
-                { label: l(lang, "Checklist", "Liste de démarches", "Checkliste", "Checklëscht"), href: `/${lang}/checklist` },
+                { label: l(lang, "Luxembourg checklist", "Luxembourg checklist", "Luxembourg checklist", "Luxembourg checklist"), href: `/${lang}/checklist` },
                 { label: l(lang, "About", "À propos", "Über uns", "Iwwer eis"), href: `/${lang}/about` },
                 { label: l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten"), href: `/${lang}/updates` },
                 { label: l(lang, "Presentation Brochure", "Brochure de présentation", "Präsentationsbroschüre", "Presentatiounsbroschür"), href: `/${lang}/brochure` },
                 { label: l(lang, "Privacy Policy", "Politique de confidentialité", "Datenschutzerklärung", "Dateschutzerklärung"), href: `/${lang}/privacy` },
                 { label: l(lang, "Share your experience", "Partager votre expérience", "Erfahrung teilen", "Deelt Är Erfarung"), href: `/${lang}/contribute#experience` },
-                { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}#contact` },
               ].map((link) => (
                 <a key={link.label} href={link.href} className="text-sm text-calm-blue-600 hover:text-calm-blue-800 transition-colors">
                   {link.label}

--- a/apps/web/src/app/[lang]/sections/FormsSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FormsSection.tsx
@@ -10,10 +10,16 @@ export default function FormsSection({
   lang,
   showFeedback = true,
   showContact = true,
+  contactHeading,
+  contactIntro,
+  showContactAudience = true,
 }: {
   lang: Lang;
   showFeedback?: boolean;
   showContact?: boolean;
+  contactHeading?: string;
+  contactIntro?: string;
+  showContactAudience?: boolean;
 }) {
   const feedbackForm = useForm();
   const [fbHardest, setFbHardest] = useState("");
@@ -121,11 +127,19 @@ export default function FormsSection({
       {/* ═══ Contact ═══ */}
       <section id="contact" className="mb-10 scroll-mt-24">
         <h2 className="text-2xl sm:text-3xl font-semibold text-center mb-4" style={headlineStyle}>
-          {l(lang, "Work with us", "Travailler avec nous", "Mit uns zusammenarbeiten", "Mat eis zesummeschaffen")}
+          {contactHeading ?? l(lang, "Work with us", "Travailler avec nous", "Mit uns zusammenarbeiten", "Mat eis zesummeschaffen")}
         </h2>
         <p className="text-base text-calm-blue-600 text-center max-w-2xl mx-auto mb-3 leading-relaxed">
-          {l(lang, "We welcome contact from:", "Clarvia est actuellement en phase de construction et de validation. Nous sommes ouverts aux échanges avec :", "Clarvia befindet sich derzeit in der Aufbau- und Validierungsphase. Wir freuen uns über Kontakt von:", "Clarvia ass de Moment an der Opbau- a Validéierungsphas. Mir freeën eis iwwer Kontakt vun:")}
+          {contactIntro ??
+            l(
+              lang,
+              "We welcome contact from:",
+              "We welcome contact from:",
+              "We welcome contact from:",
+              "We welcome contact from:"
+            )}
         </p>
+        {showContactAudience && (
         <ul className="text-sm text-calm-blue-500 max-w-md mx-auto mb-8 leading-relaxed space-y-1.5">
           {[
             { en: "families willing to share practical experience", fr: "familles souhaitant partager leur expérience pratique", de: "Familien, die ihre praktische Erfahrung teilen möchten" },
@@ -142,6 +156,7 @@ export default function FormsSection({
             </li>
           ))}
         </ul>
+        )}
 
         <div className="glass-panel p-6 sm:p-8 max-w-xl mx-auto">
           {contactForm.status === "sent" ? (

--- a/apps/web/src/app/[lang]/sections/FormsSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FormsSection.tsx
@@ -134,9 +134,9 @@ export default function FormsSection({
             l(
               lang,
               "We welcome contact from:",
-              "We welcome contact from:",
-              "We welcome contact from:",
-              "We welcome contact from:"
+              "Nous sommes heureux d’échanger avec :",
+              "Wir freuen uns über Nachrichten von:",
+              "Mir freeën eis iwwer Noriichte vun:"
             )}
         </p>
         {showContactAudience && (

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { type Lang, l } from "@/lib/i18n";
 import { isPlausibleEmail } from "@/lib/email";
 import Turnstile from "@/components/Turnstile";
@@ -187,7 +188,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
 
   return (
     <>
-      <section className="text-center py-12 sm:py-20">
+      <section id="ask-us" className="text-center py-12 sm:py-20 scroll-mt-24">
         <h1
           className="text-3xl sm:text-5xl lg:text-6xl font-semibold tracking-tight mb-6 drop-shadow-sm max-w-4xl mx-auto"
           style={headlineStyle}
@@ -218,7 +219,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             "Beschreift an Ärer eegener Sprooch, wat geschitt ass, egal wou Dir sidd. Gitt wa méiglech un, wou déi Persoun gelieft huet, wou den Doudesfall geschitt ass oder wou Dir haut mat den Demarchë stitt. Wat Dir eis méi Kontext gitt, wat mir Iech méi geziilt hëllefe kënnen."
           )}
         </p>
-        <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-10">
+        <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-8">
           {l(
             lang,
             "Clarvia will send a carefully researched reply to your email, usually within a few minutes.",
@@ -227,6 +228,50 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             "Clarvia schéckt Iech eng virsiichteg recherchéiert Äntwert per E-Mail, normalerweis bannent e puer Minutten."
           )}
         </p>
+
+        <div className="glass-panel max-w-2xl mx-auto mb-8 p-5 sm:p-6 text-left">
+          <p className="text-sm font-semibold text-calm-blue-800">
+            {l(
+              lang,
+              "Clarvia ASBL · RCS Luxembourg F15680",
+              "Clarvia ASBL · RCS Luxembourg F15680",
+              "Clarvia ASBL · RCS Luxembourg F15680",
+              "Clarvia ASBL · RCS Luxembourg F15680"
+            )}
+          </p>
+          <p className="text-sm text-calm-blue-600 mt-2 leading-relaxed">
+            {l(
+              lang,
+              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
+              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
+              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
+              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads."
+            )}
+          </p>
+          <p className="text-sm text-calm-blue-600 mt-2 leading-relaxed">
+            {l(
+              lang,
+              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
+              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
+              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
+              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha."
+            )}
+          </p>
+          <div className="flex flex-wrap gap-3 mt-4">
+            <Link
+              href={`/${lang}/support`}
+              className="btn-secondary inline-flex items-center justify-center px-5 py-2.5 text-sm"
+            >
+              {l(lang, "Donate", "Donate", "Donate", "Donate")}
+            </Link>
+            <Link
+              href={`/${lang}/contact`}
+              className="btn-secondary inline-flex items-center justify-center px-5 py-2.5 text-sm"
+            >
+              {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
+            </Link>
+          </div>
+        </div>
 
         <form onSubmit={onSubmit} className="glass-panel p-6 sm:p-8 max-w-2xl mx-auto text-left">
           <label htmlFor="ask-question" className="block text-sm font-semibold text-calm-blue-800 mb-1.5">

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -243,18 +243,18 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             {l(
               lang,
               "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
-              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
-              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
-              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads."
+              "Un accompagnement gratuit dans le monde entier, proposé par une association luxembourgeoise à but non lucratif. Nous n’affichons aucune publicité.",
+              "Kostenlose Orientierung weltweit von einem gemeinnützigen Verein aus Luxemburg. Wir zeigen keine Werbung.",
+              "Gratis Orientéierung weltwäit vun engem net gewënnorientéierte Veräin aus Lëtzebuerg. Mir weise keng Reklammen."
             )}
           </p>
           <p className="text-sm text-calm-blue-600 mt-2 leading-relaxed">
             {l(
               lang,
               "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
-              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
-              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
-              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha."
+              "Deux services : Posez-nous votre question par e-mail, partout dans le monde, et une checklist pour le Luxembourg en version alpha publique.",
+              "Zwei Angebote: Fragen Sie uns per E-Mail, weltweit verfügbar, und eine Luxemburg-Checkliste in der öffentlichen Alpha-Version.",
+              "Zwee Servicer: Frot eis per E-Mail, weltwäit disponibel, an eng Lëtzebuerg-Checklëscht an der ëffentlecher Alpha-Versioun."
             )}
           </p>
           <div className="flex flex-wrap gap-3 mt-4">
@@ -262,7 +262,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
               href={`/${lang}/support`}
               className="btn-secondary inline-flex items-center justify-center px-5 py-2.5 text-sm"
             >
-              {l(lang, "Donate", "Donate", "Donate", "Donate")}
+              {l(lang, "Donate", "Faire un don", "Spenden", "Spenden")}
             </Link>
             <Link
               href={`/${lang}/contact`}

--- a/apps/web/src/app/[lang]/support/page.tsx
+++ b/apps/web/src/app/[lang]/support/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { LANGUAGES, type Lang } from "@/lib/i18n";
+import { LANGUAGES, type Lang, hreflangLanguages } from "@/lib/i18n";
 import SupportPage from "./SupportPage";
 
 const BASE_URL = "https://clarvia.org";
@@ -38,9 +38,7 @@ export async function generateMetadata({
     description: meta.description,
     alternates: {
       canonical: `${BASE_URL}/${lang}/support`,
-      languages: Object.fromEntries(
-        LANGUAGES.map((l) => [l, `${BASE_URL}/${l}/support`])
-      ),
+      languages: hreflangLanguages("support"),
     },
     openGraph: {
       title: meta.title,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -82,7 +82,7 @@ export default function RootLayout({
         {children}
         <Script
           id="gtag-js"
-          strategy="lazyOnload"
+          strategy="afterInteractive"
           src="https://www.googletagmanager.com/gtag/js?id=G-K67M5B4932"
         />
       </body>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,13 +1,5 @@
-import { redirect } from "next/navigation";
-import { headers } from "next/headers";
+import { permanentRedirect } from "next/navigation";
 
-export default async function RootPage() {
-  const headersList = await headers();
-  const acceptLang = headersList.get("accept-language") || "";
-
-  // Check for Luxembourgish, French or German preference, otherwise default to English
-  if (/(^|,\s*)lb\b/i.test(acceptLang)) redirect("/fr");
-  if (/(^|,\s*)fr\b/i.test(acceptLang)) redirect("/fr");
-  if (/(^|,\s*)de\b/i.test(acceptLang)) redirect("/de");
-  redirect("/en");
+export default function RootPage() {
+  permanentRedirect("/en");
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { MetadataRoute } from "next";
-import { LANGUAGES } from "@/lib/i18n";
+import { LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 
 const BASE_URL = "https://clarvia.org";
 
@@ -15,6 +15,7 @@ const localizedPages: SitemapPage[] = [
   { path: "updates", changeFrequency: "weekly", priority: 0.8 },
   { path: "contribute", changeFrequency: "monthly", priority: 0.7 },
   { path: "support", changeFrequency: "weekly", priority: 0.7 },
+  { path: "contact", changeFrequency: "monthly", priority: 0.6 },
   { path: "privacy", changeFrequency: "yearly", priority: 0.2 },
 ];
 
@@ -33,15 +34,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
         changeFrequency: page.changeFrequency,
         priority: page.priority,
         alternates: {
-          languages: Object.fromEntries(
-            LANGUAGES.map((alternateLang) => {
-              const alternatePath = page.path
-                ? `/${alternateLang}/${page.path}`
-                : `/${alternateLang}`;
-
-              return [alternateLang === "lu" ? "lb" : alternateLang, `${BASE_URL}${alternatePath}`];
-            })
-          ),
+          languages: hreflangLanguages(page.path),
         },
       });
     }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -79,12 +79,30 @@ export default function Header({ lang }: { lang: Lang }) {
           className="flex items-center gap-6"
         >
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-6 text-sm font-semibold">
+          <div className="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-semibold">
             <Link
-              href={`/${lang}/checklist`}
+              href={`/${lang}#ask-us`}
               className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
-              {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
+              {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+            </Link>
+            <Link
+              href={`/${lang}/checklist`}
+              aria-label={l(
+                lang,
+                "Luxembourg checklist (public alpha)",
+                "Luxembourg checklist (public alpha)",
+                "Luxembourg checklist (public alpha)",
+                "Luxembourg checklist (public alpha)"
+              )}
+              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
+            >
+              <span className="inline-flex items-baseline gap-1">
+                {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
+                <span className="text-[11px] font-medium text-calm-blue-400">
+                  {l(lang, "LU alpha", "LU alpha", "LU alpha", "LU alpha")}
+                </span>
+              </span>
             </Link>
             <Link
               href={`/${lang}/about`}
@@ -93,14 +111,20 @@ export default function Header({ lang }: { lang: Lang }) {
               {l(lang, "About", "À propos", "Über uns", "Iwwer eis")}
             </Link>
             <Link
-              href={`/${lang}/updates`}
+              href={`/${lang}/contact`}
               className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
+            >
+              {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
+            </Link>
+            <Link
+              href={`/${lang}/updates`}
+              className="hidden lg:inline text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
               {l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten")}
             </Link>
             <Link
               href={`/${lang}/contribute`}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
+              className="hidden lg:inline text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
               {l(lang, "Contribute", "Contribuer", "Mitwirken", "Matmaachen")}
             </Link>
@@ -184,11 +208,24 @@ export default function Header({ lang }: { lang: Lang }) {
       >
         <nav className="flex flex-col gap-5 text-lg font-semibold flex-grow">
           <Link
+            href={`/${lang}#ask-us`}
+            onClick={toggleMenu}
+            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
+          >
+            {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+          </Link>
+          <Link
             href={`/${lang}/checklist`}
             onClick={toggleMenu}
             className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
           >
-            {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
+            {l(
+              lang,
+              "Luxembourg checklist (alpha)",
+              "Luxembourg checklist (alpha)",
+              "Luxembourg checklist (alpha)",
+              "Luxembourg checklist (alpha)"
+            )}
           </Link>
           <Link
             href={`/${lang}/about`}
@@ -196,6 +233,13 @@ export default function Header({ lang }: { lang: Lang }) {
             className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
           >
             {l(lang, "About", "À propos", "Über uns", "Iwwer eis")}
+          </Link>
+          <Link
+            href={`/${lang}/contact`}
+            onClick={toggleMenu}
+            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
+          >
+            {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
           </Link>
           <Link
             href={`/${lang}/updates`}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -84,23 +84,23 @@ export default function Header({ lang }: { lang: Lang }) {
               href={`/${lang}#ask-us`}
               className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
-              {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+              {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
             </Link>
             <Link
               href={`/${lang}/checklist`}
               aria-label={l(
                 lang,
                 "Luxembourg checklist (public alpha)",
-                "Luxembourg checklist (public alpha)",
-                "Luxembourg checklist (public alpha)",
-                "Luxembourg checklist (public alpha)"
+                "Checklist Luxembourg (version alpha publique)",
+                "Luxemburg-Checkliste (öffentliche Alpha-Version)",
+                "Lëtzebuerg-Checklëscht (ëffentlech Alpha-Versioun)"
               )}
               className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
               <span className="inline-flex items-baseline gap-1">
                 {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
                 <span className="text-[11px] font-medium text-calm-blue-400">
-                  {l(lang, "LU alpha", "LU alpha", "LU alpha", "LU alpha")}
+                  {l(lang, "LU alpha", "LU alpha", "LU Alpha", "LU Alpha")}
                 </span>
               </span>
             </Link>
@@ -212,7 +212,7 @@ export default function Header({ lang }: { lang: Lang }) {
             onClick={toggleMenu}
             className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
           >
-            {l(lang, "Ask us", "Ask us", "Ask us", "Ask us")}
+            {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
           </Link>
           <Link
             href={`/${lang}/checklist`}
@@ -222,9 +222,9 @@ export default function Header({ lang }: { lang: Lang }) {
             {l(
               lang,
               "Luxembourg checklist (alpha)",
-              "Luxembourg checklist (alpha)",
-              "Luxembourg checklist (alpha)",
-              "Luxembourg checklist (alpha)"
+              "Checklist Luxembourg (alpha)",
+              "Luxemburg-Checkliste (Alpha-Version)",
+              "Lëtzebuerg-Checklëscht (Alpha-Versioun)"
             )}
           </Link>
           <Link

--- a/apps/web/src/features/donations/DonationLandingPage.tsx
+++ b/apps/web/src/features/donations/DonationLandingPage.tsx
@@ -299,36 +299,36 @@ export default function DonationLandingPage({ config }: DonationLandingPageProps
                 {l(
                   lang,
                   "How we use donations",
-                  "How we use donations",
-                  "How we use donations",
-                  "How we use donations"
+                  "Comment nous utilisons les dons",
+                  "Wie wir Spenden verwenden",
+                  "Wéi mir Spende benotzen"
                 )}
               </h2>
               <p>
                 {l(
                   lang,
                   "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
-                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
-                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
-                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads."
+                  "Votre don permet à Clarvia de maintenir ses services gratuits : des réponses par e-mail pour les familles du monde entier et la checklist Luxembourg, actuellement en version alpha publique. Nous n’affichons aucune publicité.",
+                  "Mit Ihrer Spende sichern Sie den Betrieb der kostenlosen Angebote von Clarvia: Antworten per E-Mail für Familien weltweit und die Luxemburg-Checkliste, die derzeit als öffentliche Alpha-Version verfügbar ist. Wir zeigen keine Werbung.",
+                  "Mat Ärem Don hëlleft Dir, dem Clarvia seng gratis Servicer um Lafen ze halen: Äntwerten per E-Mail fir Famillje weltwäit an d’Lëtzebuerg-Checklëscht, déi elo an der ëffentlecher Alpha-Versioun disponibel ass. Mir weise keng Reklammen."
                 )}
               </p>
               <p>
                 {l(
                   lang,
                   "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
-                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
-                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
-                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates."
+                  "Nous recevons des dons par l’intermédiaire de Stripe, Open Collective et GitHub Sponsors. Nous ne délivrons actuellement aucun certificat fiscal.",
+                  "Wir erhalten Spenden über Stripe, Open Collective und GitHub Sponsors. Derzeit stellen wir keine Spendenbescheinigungen aus.",
+                  "Mir kréien Spenden iwwer Stripe, Open Collective a GitHub Sponsors. De Moment stelle mir keng Steierbescheinegungen aus."
                 )}
               </p>
               <p>
                 {l(
                   lang,
                   "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
-                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
-                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
-                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective."
+                  "Nos comptes pour 2026 n’ont pas encore été déposés. Pour consulter nos données financières actualisées, rendez-vous sur Open Collective.",
+                  "Unser Jahresabschluss für 2026 wurde noch nicht eingereicht. Aktuelle Finanzdaten finden Sie auf Open Collective.",
+                  "Eis Konte fir 2026 sinn nach net agereecht ginn. Aktuell Finanzdate fannt Dir op Open Collective."
                 )}{" "}
                 <a
                   href="https://opencollective.com/clarvia-org"

--- a/apps/web/src/features/donations/DonationLandingPage.tsx
+++ b/apps/web/src/features/donations/DonationLandingPage.tsx
@@ -290,6 +290,56 @@ export default function DonationLandingPage({ config }: DonationLandingPageProps
                 </ul>
               )}
             </div>
+
+            <div className="glass-panel p-5 space-y-3 text-sm text-calm-blue-600 leading-relaxed">
+              <h2
+                className="text-xl font-semibold text-calm-blue-800"
+                style={{ fontFamily: headlineStyle.fontFamily }}
+              >
+                {l(
+                  lang,
+                  "How we use donations",
+                  "How we use donations",
+                  "How we use donations",
+                  "How we use donations"
+                )}
+              </h2>
+              <p>
+                {l(
+                  lang,
+                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
+                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
+                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
+                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads."
+                )}
+              </p>
+              <p>
+                {l(
+                  lang,
+                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
+                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
+                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates.",
+                  "We receive donations through Stripe, Open Collective, and GitHub Sponsors. We do not currently issue tax certificates."
+                )}
+              </p>
+              <p>
+                {l(
+                  lang,
+                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
+                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
+                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective.",
+                  "Our 2026 accounts have not yet been filed. For live transparency, see Open Collective."
+                )}{" "}
+                <a
+                  href="https://opencollective.com/clarvia-org"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-calm-lilac-500 hover:text-calm-lilac-600 underline underline-offset-2"
+                >
+                  opencollective.com/clarvia-org
+                </a>
+              </p>
+            </div>
           </div>
 
           {/* RIGHT COLUMN: Donation Selector Card */}

--- a/apps/web/src/features/donations/TrustStrip.tsx
+++ b/apps/web/src/features/donations/TrustStrip.tsx
@@ -7,6 +7,53 @@ export interface TrustStripProps {
 export default function TrustStrip({ lang }: TrustStripProps) {
   return (
     <div className="space-y-8">
+      <div className="glass-panel p-6 border border-white/60 space-y-3 text-sm text-calm-blue-600 leading-relaxed">
+        <h2 className="text-base font-semibold text-calm-blue-800">
+          {l(
+            lang,
+            "How we use donations",
+            "How we use donations",
+            "How we use donations",
+            "How we use donations"
+          )}
+        </h2>
+        <p>
+          {l(
+            lang,
+            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
+            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
+            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
+            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data."
+          )}
+        </p>
+        <p>
+          {l(
+            lang,
+            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
+            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
+            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
+            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates."
+          )}
+        </p>
+        <p>
+          {l(
+            lang,
+            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
+            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
+            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
+            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:"
+          )}{" "}
+          <a
+            href="https://opencollective.com/clarvia-org"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-calm-lilac-500 hover:text-calm-lilac-600 underline underline-offset-2"
+          >
+            opencollective.com/clarvia-org
+          </a>
+        </p>
+      </div>
+
       {/* Legal, Privacy and Transparency Grid */}
       <div
         className="border-t border-calm-blue-200/50 pt-8 space-y-6 text-xs text-calm-blue-500 leading-relaxed"

--- a/apps/web/src/features/donations/TrustStrip.tsx
+++ b/apps/web/src/features/donations/TrustStrip.tsx
@@ -12,36 +12,36 @@ export default function TrustStrip({ lang }: TrustStripProps) {
           {l(
             lang,
             "How we use donations",
-            "How we use donations",
-            "How we use donations",
-            "How we use donations"
+            "Comment nous utilisons les dons",
+            "Wie wir Spenden verwenden",
+            "Wéi mir Spende benotzen"
           )}
         </h2>
         <p>
           {l(
             lang,
             "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
-            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
-            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data.",
-            "Donations fund our free services: worldwide email guidance and the Luxembourg checklist. We do not show ads, and we do not sell data."
+            "Les dons financent nos services gratuits : notre accompagnement par e-mail dans le monde entier et la checklist Luxembourg. Nous n’affichons aucune publicité et ne vendons aucune donnée.",
+            "Spenden finanzieren unsere kostenlosen Angebote: weltweite Orientierung per E-Mail und die Luxemburg-Checkliste. Wir zeigen keine Werbung und verkaufen keine Daten.",
+            "Spende finanzéieren eis gratis Servicer: Orientéierung per E-Mail weltwäit an d’Lëtzebuerg-Checklëscht. Mir weise keng Reklammen a verkafe keng Daten."
           )}
         </p>
         <p>
           {l(
             lang,
             "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
-            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
-            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates.",
-            "Payments are processed through Stripe, Open Collective, and GitHub Sponsors. Clarvia ASBL does not currently issue tax certificates."
+            "Les paiements sont traités par Stripe, Open Collective et GitHub Sponsors. Clarvia ASBL ne délivre actuellement aucun certificat fiscal.",
+            "Zahlungen werden über Stripe, Open Collective und GitHub Sponsors abgewickelt. Clarvia ASBL stellt derzeit keine Spendenbescheinigungen aus.",
+            "D’Bezuelunge ginn iwwer Stripe, Open Collective a GitHub Sponsors ofgewéckelt. Clarvia ASBL stellt de Moment keng Steierbescheinegungen aus."
           )}
         </p>
         <p>
           {l(
             lang,
             "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
-            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
-            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:",
-            "Our 2026 accounts have not yet been filed. Open Collective shows live income and eligible expenses:"
+            "Nos comptes pour 2026 n’ont pas encore été déposés. Open Collective présente en temps réel nos recettes et les dépenses admissibles :",
+            "Unser Jahresabschluss für 2026 wurde noch nicht eingereicht. Auf Open Collective können Sie unsere laufenden Einnahmen und die anerkannten Ausgaben einsehen:",
+            "Eis Konte fir 2026 sinn nach net agereecht ginn. Op Open Collective kënnt Dir eis aktuell Recetten an déi eligible Ausgaben gesinn:"
           )}{" "}
           <a
             href="https://opencollective.com/clarvia-org"

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -16,3 +16,16 @@ export function l(lang: Lang, en: string, fr: string, de: string, lu?: string): 
   return lang === "fr" ? fr : lang === "de" ? de : en;
 }
 
+const SITE_URL = "https://clarvia.org";
+
+/** hreflang map for a path after the language prefix (`""` for home, `"contact"` for /{lang}/contact). */
+export function hreflangLanguages(pathAfterLang = ""): Record<string, string> {
+  const suffix = pathAfterLang ? `/${pathAfterLang}` : "";
+  const languages: Record<string, string> = {};
+  for (const code of LANGUAGES) {
+    languages[code === "lu" ? "lb" : code] = `${SITE_URL}/${code}${suffix}`;
+  }
+  languages["x-default"] = `${SITE_URL}/en${suffix}`;
+  return languages;
+}
+

--- a/services/lex/app/email/templates.py
+++ b/services/lex/app/email/templates.py
@@ -28,13 +28,13 @@ depend on your circumstances and may change. Please verify important requirement
 official authority or a qualified professional.</p>
 <p style="margin:0 0 6px;font-size:12px;color:#888">Lex may produce incomplete or incorrect
 information. To report an issue or contact Clarvia, please use the
-<a href="https://clarvia.org/en#contact" style="color:#888">contact form</a> on our website.</p>
+<a href="https://clarvia.org/en/contact" style="color:#888">contact form</a> on our website.</p>
 <p style="margin:0 0 6px;font-size:12px;color:#888">Tip: Lex can continue a conversation for up to
 five replies in the same email thread. For further help after that, send a new email to
 <a href="mailto:lex@clarvia.org" style="color:#888">lex@clarvia.org</a> with a short summary.</p>
 <p style="margin:0;font-size:12px;color:#888">
 <a href="https://clarvia.org/en/privacy" style="color:#888">Privacy Policy</a> &middot;
-<a href="https://clarvia.org/en#contact" style="color:#888">Contact Clarvia</a> &middot;
+<a href="https://clarvia.org/en/contact" style="color:#888">Contact Clarvia</a> &middot;
 <a href="https://clarvia.org/en" style="color:#888">clarvia.org</a></p>
 </div>
 """.strip()
@@ -51,12 +51,12 @@ Lex is Clarvia's AI-powered information service. It uses Clarvia's source-backed
 Clarvia does not provide emergency, legal, tax, medical, psychological, notarial, banking, financial or succession advice. Information may depend on your circumstances and may change. Please verify important requirements with the relevant official authority or a qualified professional.
 
 Lex may produce incomplete or incorrect information. To report an issue or contact Clarvia, please use the contact form on our website:
-https://clarvia.org/en#contact
+https://clarvia.org/en/contact
 
 Tip: Lex can continue a conversation for up to five replies in the same email thread. For further help after that, send a new email to lex@clarvia.org with a short summary.
 
 Privacy Policy: https://clarvia.org/en/privacy
-Contact Clarvia: https://clarvia.org/en#contact
+Contact Clarvia: https://clarvia.org/en/contact
 Website: https://clarvia.org/en
 """.strip()
 

--- a/services/lex/tests/unit/test_email_composition.py
+++ b/services/lex/tests/unit/test_email_composition.py
@@ -119,7 +119,7 @@ def test_all_approved_links_exist() -> None:
     for link in (
         "https://clarvia.org/en/support",
         "https://github.com/clarvia-org",
-        "https://clarvia.org/en#contact",
+        "https://clarvia.org/en/contact",
         "https://clarvia.org/en/privacy",
         "https://clarvia.org/en",
         "mailto:lex@clarvia.org",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Remaining **website** work before resubmitting Google Ad Grants. Landing URL stays `https://clarvia.org/en`. Search Console indexing is **not** a Grants gate.

This does **not** change Ask us / Send, privacy, or the footer legal disclaimer.

## Pass / fail

Open an incognito window after deploy.

| Check | Pass if |
|---|---|
| Homepage identity | Above the Send form: Clarvia ASBL, RCS F15680, free worldwide, no ads, two programs (Ask us + Luxembourg checklist alpha), **Donate** and **Contact** buttons |
| Send still works | Ask us form and Send are unchanged |
| Contact page | `https://clarvia.org/en/contact` is a real page (not a redirect), lists legal name / RCS / address, has the contact form, **no** public `lex@` or phone |
| Nav | First item is **Ask us**. Checklist is labelled Luxembourg alpha, not the first global item |
| Support | “How we use donations” — free services, no ads, Stripe / Open Collective / GitHub, no tax certificates, 2026 accounts not filed + Open Collective link |
| About | Same donations / transparency line |
| `/` | Still ends on `/en` (308 from the app, Cloudflare already 301s) |

## What to click

1. `/en` — identity box, Donate, Contact, then Send as before
2. Header **Ask us** → jumps to the form
3. Header / footer **Contact** → `/en/contact`
4. `/en/support` — How we use donations
5. `/en/about` — Funding section

## Risks

- New English copy is in all language slots until Tommi approves a translation handoff (FR/DE/LU Contact page and donations text will read in English).
- Desktop nav hides Updates / Contribute below the large-desktop breakpoint; they stay in the footer and the mobile menu.
- Lex email footers now point at `/en/contact` instead of `/en#contact` (home `#contact` still exists). **Coolify/Lex deploy** is needed for that email URL change to go live.

## Out of this PR

PageSpeed, waiting for Search Console, public email/phone, AdSense, pointing ads at `/checklist`.

## Checklist

- [x] Web tests (including sitemap) and Lex email tests pass locally
- [ ] CI passes
- [ ] N/A graph records
- [ ] N/A source assertions
- [ ] N/A scenario tests
- [ ] N/A docs

## Related issues

Ad Grants resubmission (site work only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

