### PR TITLE
Home contact cleanup, checklist headers, Ask Clarvia on About

### DIFF
--- a/apps/web/src/app/[lang]/about/page.tsx
+++ b/apps/web/src/app/[lang]/about/page.tsx
@@ -121,14 +121,37 @@ export default async function AboutPage({
             {l(lang, "Active Programs & Services", "Programmes et services actifs", "Aktive Programme und Angebote", "Aktiv Programmer a Servicer")}
           </h2>
           <p className="text-base text-calm-blue-600 mb-6">
-            {l(lang, "Clarvia operates three free, public-interest programs:", "Clarvia gère trois programmes gratuits d'intérêt public :", "Clarvia betreibt drei kostenlose Programme im öffentlichen Interesse:", "Clarvia bedreift dräi gratis Programmer am ëffentlechen Interessi:")}
+            {l(lang, "Clarvia operates four free, public-interest programs:", "Clarvia gère quatre programmes gratuits d'intérêt public :", "Clarvia betreibt vier kostenlose Programme im öffentlichen Interesse:", "Clarvia bedreift véier gratis Programmer am ëffentlechen Interessi:")}
           </p>
 
           <div className="space-y-6">
             {/* Program 1 */}
             <div className="glass-panel p-6">
               <h3 className="text-lg font-semibold text-calm-blue-800 mb-2">
-                {l(lang, "1. Bereavement Guidance Service", "1. Service d'accompagnement après un décès", "1. Orientierungshilfe nach einem Todesfall", "1. Begleedung nom Doudesfall")}
+                {l(lang, "1. Ask Clarvia", "1. Ask Clarvia", "1. Ask Clarvia", "1. Ask Clarvia")}
+              </h3>
+              <div className="space-y-3 text-base text-calm-blue-600 leading-relaxed">
+                <p>
+                  {l(
+                    lang,
+                    "Ask Clarvia is our live email service for families worldwide. Describe what happened in your own language. Lex at Clarvia replies by email, usually within a few minutes, with cited sources. The service is free.",
+                    "Ask Clarvia is our live email service for families worldwide. Describe what happened in your own language. Lex at Clarvia replies by email, usually within a few minutes, with cited sources. The service is free.",
+                    "Ask Clarvia is our live email service for families worldwide. Describe what happened in your own language. Lex at Clarvia replies by email, usually within a few minutes, with cited sources. The service is free.",
+                    "Ask Clarvia is our live email service for families worldwide. Describe what happened in your own language. Lex at Clarvia replies by email, usually within a few minutes, with cited sources. The service is free."
+                  )}
+                </p>
+                <p>
+                  <Link href={`/${lang}#ask-us`} className="text-calm-blue-700 font-medium hover:text-calm-blue-900 underline underline-offset-2 transition-colors">
+                    {l(lang, "Ask us →", "Posez-nous votre question →", "Fragen Sie uns →", "Frot eis →")}
+                  </Link>
+                </p>
+              </div>
+            </div>
+
+            {/* Program 2 */}
+            <div className="glass-panel p-6">
+              <h3 className="text-lg font-semibold text-calm-blue-800 mb-2">
+                {l(lang, "2. Bereavement Guidance Service", "2. Service d'accompagnement après un décès", "2. Orientierungshilfe nach einem Todesfall", "2. Begleedung nom Doudesfall")}
               </h3>
               <div className="space-y-3 text-base text-calm-blue-600 leading-relaxed">
                 <p>
@@ -145,20 +168,20 @@ export default async function AboutPage({
               </div>
             </div>
 
-            {/* Program 2 */}
+            {/* Program 3 */}
             <div className="glass-panel p-6">
               <h3 className="text-lg font-semibold text-calm-blue-800 mb-2">
-                {l(lang, "2. Government Source Registry", "2. Registre des sources officielles", "2. Register offizieller Quellen", "2. Register vun offiziellen Quellen")}
+                {l(lang, "3. Government Source Registry", "3. Registre des sources officielles", "3. Register offizieller Quellen", "3. Register vun offiziellen Quellen")}
               </h3>
               <p className="text-base text-calm-blue-600 leading-relaxed">
                 {l(lang, "Every administrative step in our checklists is mapped back to its official government source. We maintain a structured, openly licensed registry of these sources so that families and professionals can verify the accuracy of every recommendation.", "Chaque démarche administrative figurant dans nos checklists est reliée à sa source gouvernementale officielle. Nous maintenons un registre structuré, publié sous licence ouverte, afin que les familles et les professionnels puissent vérifier l'exactitude de chaque recommandation.", "Jeder administrative Schritt in unseren Checklisten ist mit der jeweiligen offiziellen staatlichen Quelle verknüpft. Wir pflegen ein strukturiertes Register dieser Quellen unter einer offenen Lizenz, damit Familien und Fachpersonen die Genauigkeit jeder Empfehlung überprüfen können.", "All administrativen Schrëtt an eise Checklëschte gëtt op seng offiziell staatlech Quell zeréckgefouert. Mir féieren e strukturéierten, oppen lizenzéierte Register vun dëse Quellen, fir datt Familljen a Fachleit d'Genauegkeet vun all Recommandatioun iwwerpréiwe kënnen.")}
               </p>
             </div>
 
-            {/* Program 3 */}
+            {/* Program 4 */}
             <div className="glass-panel p-6">
               <h3 className="text-lg font-semibold text-calm-blue-800 mb-2">
-                {l(lang, "3. Cross-Border Support", "3. Accompagnement transfrontalier", "3. Grenzüberschreitende Unterstützung", "3. Grenziwwerschreidend Ënnerstëtzung")}
+                {l(lang, "4. Cross-Border Support", "4. Accompagnement transfrontalier", "4. Grenzüberschreitende Unterstützung", "4. Grenziwwerschreidend Ënnerstëtzung")}
               </h3>
               <p className="text-base text-calm-blue-600 leading-relaxed">
                 {l(lang, "Our initial focus is Luxembourg, but we extend into critical cross-border corridors, including France, Germany, Belgium, and Portugal, to support migrant workers and cross-border families who face obligations in more than one country.", "Notre premier champ d'action est le Luxembourg, mais nous couvrons également les principaux contextes transfrontaliers, notamment avec la France, l'Allemagne, la Belgique et le Portugal, afin d'aider les travailleurs migrants et les familles concernées par des obligations dans plusieurs pays.", "Unser erster Schwerpunkt liegt auf Luxemburg. Gleichzeitig berücksichtigen wir wichtige grenzüberschreitende Situationen, insbesondere mit Frankreich, Deutschland, Belgien und Portugal, um Grenzgängerinnen und Grenzgänger, Migrantinnen und Migranten sowie Familien zu unterstützen, die Pflichten in mehr als einem Land erfüllen müssen.", "Eise Startpunkt ass Lëtzebuerg. Gläichzäiteg berécksiichtege mir wichteg grenziwwerschreidend Situatiounen, ënner anerem mat Frankräich, Däitschland, der Belsch a Portugal, fir Migrantenaarbechter a grenziwwerschreidend Familljen z'ënnerstëtzen, déi Obligatiounen a méi wéi engem Land hunn.")}

--- a/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
+++ b/apps/web/src/app/[lang]/checklist/ChecklistPage.tsx
@@ -695,18 +695,19 @@ function IntakeWizard({
         return (
           <fieldset
             key={q.id}
+            aria-labelledby={questionLabelId}
             className="glass-panel p-6 rounded-xl transition-all"
             style={{ animationDelay: `${idx * 100}ms` }}
           >
-            <legend
+            <div
               id={questionLabelId}
-              className="block text-sm font-semibold text-calm-blue-800 mb-3"
+              className="text-sm font-semibold text-calm-blue-800 mb-3"
             >
               <span className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-calm-blue-100 text-calm-blue-600 text-xs font-bold mr-2">
                 {idx + 1}
               </span>
               {questionLabel}
-            </legend>
+            </div>
 
             {options ? (
               /* Button-grid for jurisdiction_code, boolean, and enum with options */

--- a/apps/web/src/app/[lang]/page.tsx
+++ b/apps/web/src/app/[lang]/page.tsx
@@ -3,7 +3,6 @@ import { type Lang, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import HeroSection from "./sections/HeroSection";
 import TestimonialsSection from "./sections/TestimonialsSection";
-import FormsSection from "./sections/FormsSection";
 import FooterSection from "./sections/FooterSection";
 
 const BASE_URL = "https://clarvia.org";
@@ -74,7 +73,6 @@ export default async function LandingPage({
       <main id="main-content" className="flex-grow w-full max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
         <HeroSection lang={lang} />
         <TestimonialsSection lang={lang} />
-        <FormsSection lang={lang} showFeedback={false} showContact />
       </main>
 
       <FooterSection lang={lang} />

--- a/apps/web/src/app/[lang]/privacy/privacy-data.ts
+++ b/apps/web/src/app/[lang]/privacy/privacy-data.ts
@@ -70,7 +70,7 @@ export const privacyCookiePolicy: Record<Exclude<Lang, "lu">, PolicyData> = {
           "Lex is the name used to sign Clarvia’s automated end-of-life and bereavement information emails. We use artificial intelligence tools, including large language models, to translate messages, research relevant information, and prepare conversational replies with sources and suggested next steps.",
           "Lex replies may be sent automatically without prior review by a Clarvia volunteer. Authorised Clarvia volunteers may review conversations afterward for safety, quality, or support purposes.",
           "Our AI and infrastructure providers process information on Clarvia’s behalf and under Clarvia’s instructions. We use providers with appropriate data-processing agreements. Under our arrangements with them, they are not permitted to use message content to train their general-purpose models.",
-          "Lawful basis for the Ask us form: your consent under Article 6(1)(a) of the GDPR. If you choose to include health information in your question, we process that special-category data under Article 9(2)(a) (explicit consent). You can withdraw consent at any time by contacting us using the contact form on the homepage. Withdrawal does not affect the lawfulness of processing carried out before you withdrew consent. We will then stop using that information to send further automated guidance, and you may also request deletion as described in section 6.",
+          "Lawful basis for the Ask us form: your consent under Article 6(1)(a) of the GDPR. If you choose to include health information in your question, we process that special-category data under Article 9(2)(a) (explicit consent). You can withdraw consent at any time by contacting us using the contact form. Withdrawal does not affect the lawfulness of processing carried out before you withdrew consent. We will then stop using that information to send further automated guidance, and you may also request deletion as described in section 6.",
           "Lawful basis for other correspondence (including when you email Clarvia or use a contact or support form): Clarvia’s legitimate interests under Article 6(1)(f) of the GDPR, specifically providing the free information or support requested and doing so accurately and efficiently.",
           "Retention: We keep correspondence for as long as reasonably necessary to provide the guidance or support you requested and to maintain continuity, including where a matter remains unresolved or may require follow-up over an extended period. We periodically review requests to determine whether the correspondence is still needed. Once a matter is concluded and related follow-up is no longer reasonably expected, we delete or anonymise the correspondence unless continued retention is required by law or necessary to establish, exercise, or defend legal claims.",
           "Access: Human access is limited to authorised Clarvia volunteers handling your request. Our contracted service providers may process the data only as needed to provide their services to Clarvia and in accordance with our instructions."
@@ -102,7 +102,7 @@ export const privacyCookiePolicy: Record<Exclude<Lang, "lu">, PolicyData> = {
         heading: "8. Contact details",
         body: [
           "Clarvia ASBL, registered with the Luxembourg RCS under number F15680, is the controller of your data for Clarvia.org.",
-          "For privacy questions or to exercise your data-protection rights, please contact us using the “Contact Us” form available on our homepage at clarvia.org."
+          "For privacy questions or to exercise your data-protection rights, please contact us using the contact form on our Contact page.",
         ]
       },
       {
@@ -200,7 +200,7 @@ export const privacyCookiePolicy: Record<Exclude<Lang, "lu">, PolicyData> = {
         heading: "8. Coordonnées",
         body: [
           "Clarvia ASBL, inscrite au RCS Luxembourg sous le numéro F15680, est le responsable du traitement de vos données pour Clarvia.org.",
-          "Pour toute question relative à la confidentialité ou pour exercer vos droits en matière de protection des données, veuillez nous contacter au moyen du formulaire « Contact Us » disponible sur notre page d’accueil à clarvia.org."
+          "Pour toute question relative à la confidentialité ou pour exercer vos droits en matière de protection des données, veuillez nous contacter au moyen du formulaire de contact disponible sur notre page Contact.",
         ]
       },
       {
@@ -298,7 +298,7 @@ export const privacyCookiePolicy: Record<Exclude<Lang, "lu">, PolicyData> = {
         heading: "8. Kontaktdaten",
         body: [
           "Clarvia ASBL, eingetragen im RCS Luxemburg unter der Nummer F15680, ist für Clarvia.org der Verantwortliche für die Verarbeitung Ihrer Daten.",
-          "Bei Fragen zum Datenschutz oder zur Ausübung Ihrer Datenschutzrechte kontaktieren Sie uns bitte über das Formular „Contact Us“ auf unserer Homepage unter clarvia.org."
+          "Bei Fragen zum Datenschutz oder zur Ausübung Ihrer Datenschutzrechte kontaktieren Sie uns bitte über das Kontaktformular auf unserer Contact-Seite.",
         ]
       },
       {

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -20,6 +20,7 @@ export default function FooterSection({ lang }: { lang: Lang }) {
             <nav className="flex flex-col gap-2" aria-label={l(lang, "Footer navigation", "Navigation du pied de page", "Fußzeilennavigation", "Navigatioun am Foussberäich")} >
               {[
                 { label: l(lang, "Home", "Accueil", "Startseite", "Startsäit"), href: `/${lang}` },
+                { label: l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis"), href: `/${lang}#ask-us` },
                 { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
                 { label: l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen"), href: `/${lang}/support` },
                 { label: l(lang, "Luxembourg checklist", "Checklist Luxembourg", "Luxemburg-Checkliste", "Lëtzebuerg-Checklëscht"), href: `/${lang}/checklist` },

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -20,7 +20,6 @@ export default function FooterSection({ lang }: { lang: Lang }) {
             <nav className="flex flex-col gap-2" aria-label={l(lang, "Footer navigation", "Navigation du pied de page", "Fußzeilennavigation", "Navigatioun am Foussberäich")} >
               {[
                 { label: l(lang, "Home", "Accueil", "Startseite", "Startsäit"), href: `/${lang}` },
-                { label: l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis"), href: `/${lang}#ask-us` },
                 { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
                 { label: l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen"), href: `/${lang}/support` },
                 { label: l(lang, "Luxembourg checklist", "Checklist Luxembourg", "Luxemburg-Checkliste", "Lëtzebuerg-Checklëscht"), href: `/${lang}/checklist` },

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import { type Lang, l } from "@/lib/i18n";
 import { isPlausibleEmail } from "@/lib/email";
 import Turnstile from "@/components/Turnstile";
@@ -219,7 +218,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             "Beschreift an Ärer eegener Sprooch, wat geschitt ass, egal wou Dir sidd. Gitt wa méiglech un, wou déi Persoun gelieft huet, wou den Doudesfall geschitt ass oder wou Dir haut mat den Demarchë stitt. Wat Dir eis méi Kontext gitt, wat mir Iech méi geziilt hëllefe kënnen."
           )}
         </p>
-        <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-8">
+        <p className="text-base sm:text-lg text-calm-blue-600 max-w-3xl mx-auto leading-relaxed mb-10">
           {l(
             lang,
             "Clarvia will send a carefully researched reply to your email, usually within a few minutes.",
@@ -228,50 +227,6 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             "Clarvia schéckt Iech eng virsiichteg recherchéiert Äntwert per E-Mail, normalerweis bannent e puer Minutten."
           )}
         </p>
-
-        <div className="glass-panel max-w-2xl mx-auto mb-8 p-5 sm:p-6 text-left">
-          <p className="text-sm font-semibold text-calm-blue-800">
-            {l(
-              lang,
-              "Clarvia ASBL · RCS Luxembourg F15680",
-              "Clarvia ASBL · RCS Luxembourg F15680",
-              "Clarvia ASBL · RCS Luxembourg F15680",
-              "Clarvia ASBL · RCS Luxembourg F15680"
-            )}
-          </p>
-          <p className="text-sm text-calm-blue-600 mt-2 leading-relaxed">
-            {l(
-              lang,
-              "Free worldwide guidance from a Luxembourg nonprofit. We do not show ads.",
-              "Un accompagnement gratuit dans le monde entier, proposé par une association luxembourgeoise à but non lucratif. Nous n’affichons aucune publicité.",
-              "Kostenlose Orientierung weltweit von einem gemeinnützigen Verein aus Luxemburg. Wir zeigen keine Werbung.",
-              "Gratis Orientéierung weltwäit vun engem net gewënnorientéierte Veräin aus Lëtzebuerg. Mir weise keng Reklammen."
-            )}
-          </p>
-          <p className="text-sm text-calm-blue-600 mt-2 leading-relaxed">
-            {l(
-              lang,
-              "Two programs: Ask us by email (worldwide), and a Luxembourg checklist in public alpha.",
-              "Deux services : Posez-nous votre question par e-mail, partout dans le monde, et une checklist pour le Luxembourg en version alpha publique.",
-              "Zwei Angebote: Fragen Sie uns per E-Mail, weltweit verfügbar, und eine Luxemburg-Checkliste in der öffentlichen Alpha-Version.",
-              "Zwee Servicer: Frot eis per E-Mail, weltwäit disponibel, an eng Lëtzebuerg-Checklëscht an der ëffentlecher Alpha-Versioun."
-            )}
-          </p>
-          <div className="flex flex-wrap gap-3 mt-4">
-            <Link
-              href={`/${lang}/support`}
-              className="btn-secondary inline-flex items-center justify-center px-5 py-2.5 text-sm"
-            >
-              {l(lang, "Donate", "Faire un don", "Spenden", "Spenden")}
-            </Link>
-            <Link
-              href={`/${lang}/contact`}
-              className="btn-secondary inline-flex items-center justify-center px-5 py-2.5 text-sm"
-            >
-              {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
-            </Link>
-          </div>
-        </div>
 
         <form onSubmit={onSubmit} className="glass-panel p-6 sm:p-8 max-w-2xl mx-auto text-left">
           <label htmlFor="ask-question" className="block text-sm font-semibold text-calm-blue-800 mb-1.5">

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -187,7 +187,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
 
   return (
     <>
-      <section id="ask-us" className="text-center py-12 sm:py-20 scroll-mt-24">
+      <section className="text-center py-12 sm:py-20">
         <h1
           className="text-3xl sm:text-5xl lg:text-6xl font-semibold tracking-tight mb-6 drop-shadow-sm max-w-4xl mx-auto"
           style={headlineStyle}
@@ -228,7 +228,11 @@ export default function HeroSection({ lang }: { lang: Lang }) {
           )}
         </p>
 
-        <form onSubmit={onSubmit} className="glass-panel p-6 sm:p-8 max-w-2xl mx-auto text-left">
+        <form
+          id="ask-us"
+          onSubmit={onSubmit}
+          className="glass-panel p-6 sm:p-8 max-w-2xl mx-auto text-left scroll-mt-24"
+        >
           <label htmlFor="ask-question" className="block text-sm font-semibold text-calm-blue-800 mb-1.5">
             {l(lang, "Your situation", "Votre situation", "Ihre Situation", "Är Situatioun")}
           </label>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -81,12 +81,6 @@ export default function Header({ lang }: { lang: Lang }) {
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-semibold">
             <Link
-              href={`/${lang}#ask-us`}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
-            </Link>
-            <Link
               href={`/${lang}/checklist`}
               aria-label={l(
                 lang,
@@ -207,13 +201,6 @@ export default function Header({ lang }: { lang: Lang }) {
         }`}
       >
         <nav className="flex flex-col gap-5 text-lg font-semibold flex-grow">
-          <Link
-            href={`/${lang}#ask-us`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
-          </Link>
           <Link
             href={`/${lang}/checklist`}
             onClick={toggleMenu}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -81,6 +81,12 @@ export default function Header({ lang }: { lang: Lang }) {
           {/* Desktop Navigation */}
           <div className="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-semibold">
             <Link
+              href={`/${lang}#ask-us`}
+              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
+            >
+              {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
+            </Link>
+            <Link
               href={`/${lang}/checklist`}
               aria-label={l(
                 lang,
@@ -201,6 +207,13 @@ export default function Header({ lang }: { lang: Lang }) {
         }`}
       >
         <nav className="flex flex-col gap-5 text-lg font-semibold flex-grow">
+          <Link
+            href={`/${lang}#ask-us`}
+            onClick={toggleMenu}
+            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
+          >
+            {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
+          </Link>
           <Link
             href={`/${lang}/checklist`}
             onClick={toggleMenu}

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -90,17 +90,17 @@ export default function Header({ lang }: { lang: Lang }) {
               href={`/${lang}/checklist`}
               aria-label={l(
                 lang,
-                "Luxembourg checklist (public alpha)",
-                "Checklist Luxembourg (version alpha publique)",
-                "Luxemburg-Checkliste (öffentliche Alpha-Version)",
-                "Lëtzebuerg-Checklëscht (ëffentlech Alpha-Versioun)"
+                "Checklist (public alpha)",
+                "Checklist (version alpha publique)",
+                "Checkliste (öffentliche Alpha-Version)",
+                "Checklëscht (ëffentlech Alpha-Versioun)"
               )}
               className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
             >
               <span className="inline-flex items-baseline gap-1">
                 {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
                 <span className="text-[11px] font-medium text-calm-blue-400">
-                  {l(lang, "LU alpha", "LU alpha", "LU Alpha", "LU Alpha")}
+                  {l(lang, "alpha", "alpha", "Alpha", "Alpha")}
                 </span>
               </span>
             </Link>
@@ -221,10 +221,10 @@ export default function Header({ lang }: { lang: Lang }) {
           >
             {l(
               lang,
-              "Luxembourg checklist (alpha)",
-              "Checklist Luxembourg (alpha)",
-              "Luxemburg-Checkliste (Alpha-Version)",
-              "Lëtzebuerg-Checklëscht (Alpha-Versioun)"
+              "Checklist (alpha)",
+              "Checklist (alpha)",
+              "Checkliste (Alpha-Version)",
+              "Checklëscht (Alpha-Versioun)"
             )}
           </Link>
           <Link


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Follow-up to #288 from live-site review.

- Home: removed the identity box (Donate / Contact / RCS already in header and footer)
- Home: removed the duplicate contact form (Contact page only)
- Privacy: contact form now points at the Contact page
- Header: checklist badge is **alpha**, not LU alpha
- Checklist intake: question titles sit inside the card
- About: **Ask Clarvia** is program 1; the alpha checklist is program 2

## What to click

1. `/en` — no identity box, no Work with us form, Send still there
2. Header **Ask us** — same homepage, jumps to the form (Ask us is the home page, not a copy)
3. `/en/contact` — only place with the org contact form
4. Header checklist — reads Checklist **alpha**
5. `/en/checklist` — numbered titles inside the white cards
6. `/en/about` — Ask Clarvia first

## Checklist

- [ ] CI passes
- [ ] N/A graph records
- [ ] N/A source assertions
- [ ] N/A scenario tests
- [ ] Privacy contact location updated

## Related issues

Follow-up to #288.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9db0b285-7b75-479d-8434-b8ee4a5b6ccf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

