### PR TITLE
Meet Ad Grants website quality: nav, speed, and homepage content

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,10 +3,6 @@ import { LANGUAGE_REDIRECTS } from "./src/lib/i18n";
 
 const securityHeaders = [
   {
-    key: "X-Frame-Options",
-    value: "DENY",
-  },
-  {
     key: "X-Content-Type-Options",
     value: "nosniff",
   },
@@ -24,7 +20,7 @@ const securityHeaders = [
   },
   {
     key: "Content-Security-Policy",
-    value: "frame-ancestors 'none'",
+    value: "frame-ancestors 'self' https://*.google.com https://*.googleusercontent.com",
   },
 ];
 

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -31,6 +31,12 @@ Allow: /
 User-agent: Google-Extended
 Allow: /
 
+User-agent: AdsBot-Google
+Allow: /
+
+User-agent: AdsBot-Google-Mobile
+Allow: /
+
 # Microsoft / Bing
 User-agent: Bingbot
 Allow: /
@@ -59,7 +65,6 @@ Disallow: /api/
 Disallow: /admin/
 Disallow: /private/
 Disallow: /internal/
-Disallow: /_next/
 Disallow: /cdn-cgi/
 Disallow: /forms/
 Disallow: /submit/

--- a/apps/web/src/app/[lang]/about/page.tsx
+++ b/apps/web/src/app/[lang]/about/page.tsx
@@ -155,15 +155,13 @@ export default async function AboutPage({
               </h3>
               <div className="space-y-3 text-base text-calm-blue-600 leading-relaxed">
                 <p>
-                  {l(lang, "We operate a free public service at clarvia.org that provides families with a personalised, step-by-step checklist of administrative steps following a death. An early alpha version is already available for public use.", "Nous proposons, sur clarvia.org, un service public gratuit qui fournit aux familles une liste personnalisée et étape par étape des démarches administratives à effectuer après un décès. Une première version alpha est déjà accessible au public.", "Auf clarvia.org bieten wir einen kostenlosen öffentlichen Dienst an, der Familien eine personalisierte Schritt-für-Schritt-Checkliste für die administrativen Aufgaben nach einem Todesfall bereitstellt. Eine erste Alpha-Version ist bereits öffentlich nutzbar.", "Op clarvia.org bidde mir e gratis ëffentleche Service un, deen de Familljen eng personaliséiert Schrëtt-fir-Schrëtt-Checklëscht mat administrativen Demarchen nom Doudesfall gëtt. Eng fréi Alpha-Versioun ass schonn ëffentlech verfügbar.")}
-                </p>
-                <p>
-                  <Link href={`/${lang}/checklist`} className="text-calm-blue-700 font-medium hover:text-calm-blue-900 underline underline-offset-2 transition-colors">
-                    {l(lang, "Try the checklist →", "Essayer la checklist →", "Checkliste ausprobieren →", "Checklëscht ausprobéieren →")}
-                  </Link>
-                </p>
-                <p className="text-sm text-calm-blue-500">
-                  {l(lang, "The service is designed to protect family privacy: it does not collect, store, or share personal data.", "Le service est conçu pour protéger la vie privée des familles : il ne collecte, ne conserve et ne partage aucune donnée personnelle.", "Der Dienst ist so gestaltet, dass die Privatsphäre der Familien geschützt bleibt: Es werden keine personenbezogenen Daten erhoben, gespeichert oder weitergegeben.", "De Service ass esou opgebaut, datt d'Privatsphär vun de Famillje geschützt bleift: et gi keng perséinlech Donnéeë gesammelt, gespäichert oder weiderginn.")}
+                  {l(
+                    lang,
+                    "Luxembourg checklist. We are building a free, source-linked checklist of administrative steps after a death in Luxembourg. It is not the public entry point yet. Families should use Ask us.",
+                    "Checklist Luxembourg. Nous développons une checklist gratuite, accompagnée de liens vers les sources, qui présente les démarches administratives à effectuer après un décès au Luxembourg. Elle n’est pas encore destinée à servir de point d’entrée au public. Les familles doivent utiliser « Posez-nous votre question ».",
+                    "Luxemburg-Checkliste. Wir entwickeln eine kostenlose Checkliste mit Links zu den Quellen, die durch die Verwaltungsschritte nach einem Todesfall in Luxemburg führt. Sie ist noch nicht als öffentlicher Einstiegspunkt vorgesehen. Familien sollten „Fragen Sie uns“ nutzen.",
+                    "Lëtzebuerg-Checklëscht. Mir entwéckelen eng gratis Checklëscht mat Linken op d’Quellen, déi duerch déi administrativ Schrëtt no engem Doudesfall zu Lëtzebuerg féiert. Si ass nach net als ëffentlechen Zougangspunkt geduecht. Famillje sollen „Frot eis“ benotzen."
+                  )}
                 </p>
               </div>
             </div>

--- a/apps/web/src/app/[lang]/page.tsx
+++ b/apps/web/src/app/[lang]/page.tsx
@@ -2,7 +2,10 @@ import { type Metadata } from "next";
 import { type Lang, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import HeroSection from "./sections/HeroSection";
+import HomeMissionSection from "./sections/HomeMissionSection";
+import HomeActionsSection from "./sections/HomeActionsSection";
 import TestimonialsSection from "./sections/TestimonialsSection";
+import LatestUpdatesSection from "./sections/LatestUpdatesSection";
 import FooterSection from "./sections/FooterSection";
 
 const BASE_URL = "https://clarvia.org";
@@ -72,7 +75,10 @@ export default async function LandingPage({
 
       <main id="main-content" className="flex-grow w-full max-w-5xl mx-auto px-4 sm:px-6 relative z-10">
         <HeroSection lang={lang} />
+        <HomeMissionSection lang={lang} />
+        <HomeActionsSection lang={lang} />
         <TestimonialsSection lang={lang} />
+        <LatestUpdatesSection lang={lang} omitAlphaHeadlines />
       </main>
 
       <FooterSection lang={lang} />

--- a/apps/web/src/app/[lang]/sections/FooterSection.tsx
+++ b/apps/web/src/app/[lang]/sections/FooterSection.tsx
@@ -21,14 +21,12 @@ export default function FooterSection({ lang }: { lang: Lang }) {
               {[
                 { label: l(lang, "Home", "Accueil", "Startseite", "Startsäit"), href: `/${lang}` },
                 { label: l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis"), href: `/${lang}#ask-us` },
-                { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
-                { label: l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen"), href: `/${lang}/support` },
-                { label: l(lang, "Luxembourg checklist", "Checklist Luxembourg", "Luxemburg-Checkliste", "Lëtzebuerg-Checklëscht"), href: `/${lang}/checklist` },
                 { label: l(lang, "About", "À propos", "Über uns", "Iwwer eis"), href: `/${lang}/about` },
+                { label: l(lang, "Contact", "Contact", "Kontakt", "Kontakt"), href: `/${lang}/contact` },
+                { label: l(lang, "Donate", "Faire un don", "Spenden", "Spenden"), href: `/${lang}/support` },
                 { label: l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten"), href: `/${lang}/updates` },
-                { label: l(lang, "Presentation Brochure", "Brochure de présentation", "Präsentationsbroschüre", "Presentatiounsbroschür"), href: `/${lang}/brochure` },
+                { label: l(lang, "Contribute", "Contribuer", "Mitwirken", "Matmaachen"), href: `/${lang}/contribute` },
                 { label: l(lang, "Privacy Policy", "Politique de confidentialité", "Datenschutzerklärung", "Dateschutzerklärung"), href: `/${lang}/privacy` },
-                { label: l(lang, "Share your experience", "Partager votre expérience", "Erfahrung teilen", "Deelt Är Erfarung"), href: `/${lang}/contribute#experience` },
               ].map((link) => (
                 <a key={link.label} href={link.href} className="text-sm text-calm-blue-600 hover:text-calm-blue-800 transition-colors">
                   {link.label}
@@ -37,221 +35,24 @@ export default function FooterSection({ lang }: { lang: Lang }) {
             </nav>
           </div>
           <div>
-            <div className="text-sm font-semibold text-calm-blue-700 mb-3 flex items-center gap-2">
-              <svg viewBox="0 0 24 24" className="w-4 h-4 fill-current" aria-hidden="true"><path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.6.113.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" /></svg>
+            <div className="text-sm font-semibold text-calm-blue-700 mb-3">
               {l(lang, "Built Openly", "Développé ouvertement", "Offen entwickelt", "Offen entwéckelt")}
             </div>
             <div className="text-sm text-calm-blue-600 leading-relaxed space-y-3">
               <p>
                 {l(lang, "Clarvia is built openly. Our public repositories contain the workflow model, validation logic, publishing layer, documentation, and governance standards behind the project.", "Clarvia est développé de manière ouverte. Nos dépôts publics regroupent le modèle de workflows, la logique de validation, la couche de publication, la documentation et les principes de gouvernance du projet.", "Clarvia wird offen entwickelt. Unsere öffentlichen Repositories enthalten das Workflow-Modell, die Validierungslogik, die Veröffentlichungsebene, die Dokumentation und die Governance-Grundsätze hinter dem Projekt.", "Clarvia gëtt offen entwéckelt. Eis ëffentlech Repositorien enthalen de Workflow-Modell, d'Validéierungslogik, d'Publikatiounsschicht, d'Dokumentatioun an d'Gouvernance-Standarden hannert dem Projet.")}
               </p>
-              <a href="https://github.com/clarvia-org" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-calm-blue-700 hover:text-calm-blue-900 font-medium transition-colors group">
-                github.com/clarvia-org
+              <a href="https://github.com/clarvia-org/clarvia-graph" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-calm-blue-700 hover:text-calm-blue-900 font-medium transition-colors group">
+                {l(
+                  lang,
+                  "Open source · EUPL / Apache-2.0 / CC-BY-4.0",
+                  "Open source · EUPL / Apache-2.0 / CC-BY-4.0",
+                  "Open source · EUPL / Apache-2.0 / CC-BY-4.0",
+                  "Open source · EUPL / Apache-2.0 / CC-BY-4.0"
+                )}
                 <span aria-hidden="true" className="group-hover:translate-x-0.5 transition-transform">&rarr;</span>
               </a>
-              <p className="text-xs text-calm-blue-400 mt-2">
-                {l(lang, "AI and agent context", "Contexte pour IA et agents", "KI- und Agentenkontext", "KI- an Agentekontext")}:{" "}
-                <a href="/llms.txt" className="hover:text-calm-blue-600 transition-colors">/llms.txt</a>
-                {" · "}
-                <a href="/llms-full.txt" className="hover:text-calm-blue-600 transition-colors">/llms-full.txt</a>
-                {" · "}
-                <a href="/ai-crawler-policy.txt" className="hover:text-calm-blue-600 transition-colors">/ai-crawler-policy.txt</a>
-              </p>
             </div>
-          </div>
-        </div>
-
-        {/* Standards & Licensing Banner */}
-        <div className="border-t border-calm-blue-200/30 pt-6 pb-2 mb-8 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
-          <div className="space-y-1">
-            <div className="text-xs font-semibold uppercase tracking-wider text-calm-blue-700">
-              {l(lang, "Standards & Licensing", "Normes & Licences", "Standards & Lizenzen", "Standarden & Lizenzen")}
-            </div>
-            <p className="text-xs text-calm-blue-500 max-w-md leading-relaxed">
-              {l(lang, "Clarvia complies with open science standards and open source licensing models.", "Clarvia respecte les normes de l'open science et les modèles de licences open source.", "Clarvia hält sich an Open-Science-Standards und Open-Source-Lizenzmodelle.", "Clarvia hält sech un Open-Science-Standarden an Open-Source-Lizenzmodeller.")}
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-3 md:justify-end">
-            <a 
-              href="https://github.com/clarvia-org/clarvia-graph/actions/workflows/ci.yml" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://github.com/clarvia-org/clarvia-graph/actions/workflows/ci.yml/badge.svg" 
-                alt="CI (graph)" 
-                className="h-6 w-auto"
-                width={90}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://github.com/clarvia-org/clarvia-graph/actions/workflows/validate-web.yml" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://github.com/clarvia-org/clarvia-graph/actions/workflows/validate-web.yml/badge.svg" 
-                alt="CI (web)" 
-                className="h-6 w-auto"
-                width={90}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://www.bestpractices.dev/en/projects/13112/passing" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://www.bestpractices.dev/projects/13112/badge" 
-                alt="OpenSSF Best Practices" 
-                className="h-6 w-auto"
-                width={146}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://scorecard.dev/#/projects/github.com/clarvia-org/clarvia-graph" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://api.scorecard.dev/projects/github.com/clarvia-org/clarvia-graph/badge" 
-                alt="OpenSSF Scorecard" 
-                className="h-6 w-auto"
-                width={120}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://api.reuse.software/info/github.com/clarvia-org/clarvia-graph" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://api.reuse.software/badge/github.com/clarvia-org/clarvia-graph" 
-                alt="REUSE compliant" 
-                className="h-6 w-auto"
-                width={100}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://codecov.io/gh/clarvia-org/clarvia-graph" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://codecov.io/gh/clarvia-org/clarvia-graph/graph/badge.svg" 
-                alt="Codecov" 
-                className="h-6 w-auto"
-                width={100}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://sonarcloud.io/summary/new_code?id=clarvia-org_clarvia-graph" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://sonarcloud.io/api/project_badges/measure?project=clarvia-org_clarvia-graph&metric=alert_status" 
-                alt="SonarCloud Quality Gate" 
-                className="h-6 w-auto"
-                width={120}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://doi.org/10.5281/zenodo.20572455" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.20572455-blue" 
-                alt="DOI: 10.5281/zenodo.20572455" 
-                className="h-6 w-auto"
-                width={190}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://fair-software.eu" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8F-green" 
-                alt="FAIR 4/5" 
-                className="h-6 w-auto"
-                width={130}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://github.com/clarvia-org/clarvia-graph/blob/main/LICENSE" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://img.shields.io/badge/Code_(graph)-EUPL--1.2-blue.svg" 
-                alt="License: EUPL-1.2" 
-                className="h-6 w-auto"
-                width={130}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://github.com/clarvia-org/clarvia-graph/blob/main/apps/web/LICENSE" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://img.shields.io/badge/Code_(web)-Apache--2.0-blue.svg" 
-                alt="License: Apache-2.0" 
-                className="h-6 w-auto"
-                width={125}
-                height={24}
-                loading="lazy"
-              />
-            </a>
-            <a 
-              href="https://github.com/clarvia-org/clarvia-graph/blob/main/LICENSE-DATA" 
-              target="_blank" 
-              rel="noopener noreferrer" 
-              className="inline-block transition-transform hover:scale-[1.02] active:scale-[0.98]"
-            >
-              <img 
-                src="https://img.shields.io/badge/Data-CC--BY--4.0-green.svg" 
-                alt="License: CC-BY-4.0" 
-                className="h-6 w-auto"
-                width={110}
-                height={24}
-                loading="lazy"
-              />
-            </a>
           </div>
         </div>
 
@@ -276,10 +77,17 @@ export default function FooterSection({ lang }: { lang: Lang }) {
           </p>
         </div>
 
+        <div id="cookie-consent-slot-footer" className="mt-8" />
+
         <div className="text-center text-xs text-calm-blue-500 pt-6 mt-6 border-t border-calm-blue-200/50 space-y-1">
           <p className="font-medium text-sm">Clarvia ASBL</p>
           <p>RCS Luxembourg F15680</p>
           <p>46, Rue de la Lavande · 1923 Luxembourg</p>
+          <p>
+            <a href={`/${lang}/contact`} className="hover:text-calm-blue-800 transition-colors">
+              {l(lang, "Contact form", "Formulaire de contact", "Kontaktformular", "Kontaktformulaire")}
+            </a>
+          </p>
           <p className="mt-2 text-calm-blue-400">
             {l(lang, "clarvia.org · clarvia.eu", "clarvia.org · clarvia.eu", "clarvia.org · clarvia.eu", "clarvia.org · clarvia.eu")}
             {" · "}

--- a/apps/web/src/app/[lang]/sections/HeroSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HeroSection.tsx
@@ -307,7 +307,7 @@ export default function HeroSection({ lang }: { lang: Lang }) {
             >
               {status === "sending"
                 ? l(lang, "Sending...", "Envoi...", "Senden...", "Gëtt geschéckt...")
-                : l(lang, "Send", "Envoyer", "Senden", "Schécken")}
+                : l(lang, "Ask Clarvia", "Demandez à Clarvia", "Clarvia fragen", "Frot Clarvia")}
             </button>
           </div>
 

--- a/apps/web/src/app/[lang]/sections/HomeActionsSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HomeActionsSection.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { type Lang, l } from "@/lib/i18n";
+import { headlineStyle } from "../data";
+
+export default function HomeActionsSection({ lang }: { lang: Lang }) {
+  const cards = [
+    {
+      title: l(lang, "Ask Clarvia", "Demandez à Clarvia", "Clarvia fragen", "Frot Clarvia"),
+      body: l(
+        lang,
+        "Describe what happened. We reply by email, usually within a few minutes, with sources.",
+        "Décrivez ce qui s’est passé. Nous vous répondons par e-mail, généralement en quelques minutes, avec des liens vers les sources.",
+        "Schildern Sie, was passiert ist. Wir antworten Ihnen per E-Mail, in der Regel innerhalb weniger Minuten und mit Links zu den Quellen.",
+        "Beschreift, wat geschitt ass. Mir äntweren Iech per E-Mail, normalerweis bannent e puer Minutten, a mat Linken op d’Quellen."
+      ),
+      href: `/${lang}#ask-us`,
+      cta: l(lang, "Ask Clarvia →", "Demandez à Clarvia →", "Clarvia fragen →", "Frot Clarvia →"),
+    },
+    {
+      title: l(lang, "Contact the organisation", "Contacter l’association", "Den Verein kontaktieren", "De Veräin kontaktéieren"),
+      body: l(
+        lang,
+        "Partnerships, press, volunteering, and other questions. Use the contact form.",
+        "Partenariats, demandes de presse, bénévolat et autres questions. Utilisez le formulaire de contact.",
+        "Partnerschaften, Presseanfragen, ehrenamtliche Mitarbeit und andere Fragen. Nutzen Sie dafür das Kontaktformular.",
+        "Partnerschaften, Presseufroen, Benevolat an aner Froen. Benotzt dofir de Kontaktformulaire."
+      ),
+      href: `/${lang}/contact`,
+      cta: l(lang, "Contact →", "Contact →", "Kontakt →", "Kontakt →"),
+    },
+    {
+      title: l(lang, "Donate", "Faire un don", "Spenden", "Spenden"),
+      body: l(
+        lang,
+        "Keep the service free. Clarvia is a non-profit.",
+        "Aidez-nous à maintenir ce service gratuit. Clarvia est une association à but non lucratif.",
+        "Helfen Sie mit, das Angebot kostenlos zu halten. Clarvia ist ein gemeinnütziger Verein.",
+        "Hëlleft eis, de Service gratis ze halen. Clarvia ass en net gewënnorientéierte Veräin."
+      ),
+      href: `/${lang}/support`,
+      cta: l(lang, "Donate →", "Faire un don →", "Spenden →", "Spenden →"),
+    },
+  ];
+
+  return (
+    <section className="mb-16" aria-labelledby="what-you-can-do-heading">
+      <h2
+        id="what-you-can-do-heading"
+        className="text-2xl sm:text-3xl font-semibold text-center mb-8"
+        style={headlineStyle}
+      >
+        {l(lang, "What you can do", "Ce que vous pouvez faire", "Was Sie tun können", "Wat Dir maache kënnt")}
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 max-w-5xl mx-auto">
+        {cards.map((card) => (
+          <div key={card.href} className="glass-panel p-6 flex flex-col">
+            <h3 className="text-lg font-semibold text-calm-blue-800 mb-2">{card.title}</h3>
+            <p className="text-base text-calm-blue-600 leading-relaxed flex-grow mb-4">{card.body}</p>
+            <Link
+              href={card.href}
+              className="text-calm-blue-700 font-medium hover:text-calm-blue-900 underline underline-offset-2 transition-colors"
+            >
+              {card.cta}
+            </Link>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/[lang]/sections/HomeMissionSection.tsx
+++ b/apps/web/src/app/[lang]/sections/HomeMissionSection.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { type Lang, l } from "@/lib/i18n";
+import { headlineStyle } from "../data";
+
+export default function HomeMissionSection({ lang }: { lang: Lang }) {
+  return (
+    <section className="mb-16" aria-labelledby="who-we-are-heading">
+      <h2
+        id="who-we-are-heading"
+        className="text-2xl sm:text-3xl font-semibold text-center mb-4"
+        style={headlineStyle}
+      >
+        {l(
+          lang,
+          "A free public service from Clarvia ASBL",
+          "Un service gratuit d’intérêt général proposé par Clarvia ASBL",
+          "Ein kostenloses gemeinnütziges Angebot von Clarvia ASBL",
+          "E gratis Service am Déngscht vun der Allgemengheet vu Clarvia ASBL"
+        )}
+      </h2>
+      <div className="glass-panel p-6 sm:p-8 max-w-3xl mx-auto space-y-4">
+        <p className="text-base text-calm-blue-600 leading-relaxed">
+          {l(
+            lang,
+            "Clarvia ASBL is a registered non-profit association in Luxembourg (RCS F15680), dedicated to helping families navigate the administrative burden that follows the death of a loved one. All of our services are free, multilingual, and open to the public.",
+            "Clarvia ASBL est une association sans but lucratif enregistrée au Luxembourg (RCS F15680). Elle aide les familles à faire face aux démarches administratives qui suivent le décès d'un proche. Tous nos services sont gratuits, multilingues et accessibles au public.",
+            "Clarvia ASBL ist ein in Luxemburg eingetragener gemeinnütziger Verein (RCS F15680). Wir unterstützen Familien dabei, die administrativen Aufgaben zu bewältigen, die nach dem Tod eines nahestehenden Menschen entstehen. Alle unsere Angebote sind kostenlos, mehrsprachig und öffentlich zugänglich.",
+            "Clarvia ASBL ass eng zu Lëtzebuerg registréiert Associatioun ouni Gewënnzweck (RCS F15680). Si hëlleft Familljen, sech an den administrativen Demarchen nom Doud vun engem nooste Mënsch zurechtzefannen. All eis Servicer si gratis, méisproocheg an ëffentlech zougänglech."
+          )}
+        </p>
+        <p className="text-base text-calm-blue-700 font-medium leading-relaxed">
+          {l(
+            lang,
+            "Clarvia is a non-profit association. We do not charge fees, display advertisements, or monetise personal data. There are no premium tiers or paid features. All services are free for every family.",
+            "Clarvia est une association sans but lucratif. Nous ne facturons aucun frais, n'affichons pas de publicité et ne monétisons pas les données personnelles. Il n'existe ni offre premium ni fonctionnalité payante : tous les services sont gratuits pour toutes les familles.",
+            "Clarvia ist ein gemeinnütziger Verein. Wir erheben keine Gebühren, schalten keine Werbung und monetarisieren keine personenbezogenen Daten. Es gibt keine Premium-Stufen und keine kostenpflichtigen Funktionen. Alle Angebote sind für jede Familie kostenlos.",
+            "Clarvia ass eng Associatioun ouni Gewënnzweck. Mir froe keng Fraisen, weisen keng Reklammen a verdéngen net un perséinlechen Donnéeën. Et gëtt keng Premium-Offeren a keng bezuelte Funktiounen. All Servicer si fir all Famill gratis."
+          )}
+        </p>
+        <p>
+          <Link
+            href={`/${lang}/about`}
+            className="text-calm-blue-700 font-medium hover:text-calm-blue-900 underline underline-offset-2 transition-colors"
+          >
+            {l(lang, "About Clarvia →", "À propos de Clarvia →", "Über Clarvia →", "Iwwer Clarvia →")}
+          </Link>
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/[lang]/sections/LatestUpdatesSection.tsx
+++ b/apps/web/src/app/[lang]/sections/LatestUpdatesSection.tsx
@@ -11,8 +11,16 @@ function formatDate(dateStr: string, lang: Lang): string {
   );
 }
 
-export default function LatestUpdatesSection({ lang }: { lang: Lang }) {
-  const latest = UPDATES.slice(0, 3);
+export default function LatestUpdatesSection({
+  lang,
+  omitAlphaHeadlines = false,
+}: {
+  lang: Lang;
+  omitAlphaHeadlines?: boolean;
+}) {
+  const latest = UPDATES.filter((update) =>
+    omitAlphaHeadlines ? !/alpha/i.test(update.headline.en) : true
+  ).slice(0, 3);
 
   return (
     <section className="py-16">

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -26,7 +26,10 @@ export default function CookieConsent({ lang }: { lang: Lang }) {
       console.error("Error reading consent from localStorage", e);
     }
 
-    setSlot(document.getElementById("cookie-consent-slot"));
+    setSlot(
+      document.getElementById("cookie-consent-slot") ??
+        document.getElementById("cookie-consent-slot-footer")
+    );
 
     if (showBanner) {
       const t1 = setTimeout(() => setIsRendered(true), 50);

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,292 +1,72 @@
-"use client";
-
-import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { type Lang, l, LANGUAGES } from "@/lib/i18n";
 
+const NAV_CLASS =
+  "text-sm font-semibold text-calm-blue-600 hover:text-calm-blue-800 transition-colors min-h-11 inline-flex items-center";
+
 export default function Header({ lang }: { lang: Lang }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const drawerRef = useRef<HTMLDivElement>(null);
-  const menuButtonRef = useRef<HTMLButtonElement>(null);
-
-  const toggleMenu = () => setIsOpen((open) => !open);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const drawer = drawerRef.current;
-    if (!drawer) return;
-    const focusable = drawer.querySelectorAll<HTMLElement>(
-      'a[href], button, [tabindex]:not([tabindex="-1"])'
-    );
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    first?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setIsOpen(false);
-        menuButtonRef.current?.focus();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      if (!drawer.contains(document.activeElement)) {
-        e.preventDefault();
-        (e.shiftKey ? last : first)?.focus();
-        return;
-      }
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last?.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first?.focus();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [isOpen]);
-
   return (
-    <>
-      <header
-        aria-label={l(lang, "Site header", "En-tête du site", "Seitenkopf", "Kappberäich vun der Websäit")}
-        className="py-5 px-6 sm:px-12 flex items-center justify-between z-50 relative"
+    <header
+      aria-label={l(lang, "Site header", "En-tête du site", "Seitenkopf", "Kappberäich vun der Websäit")}
+      className="py-4 px-4 sm:px-8 lg:px-12 flex flex-wrap items-center justify-between gap-x-4 gap-y-3 z-50 relative"
+    >
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-white focus:text-calm-blue-800 focus:rounded-lg focus:shadow-lg focus:outline-2 focus:outline-calm-blue-400 focus:text-sm focus:font-medium"
       >
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-white focus:text-calm-blue-800 focus:rounded-lg focus:shadow-lg focus:outline-2 focus:outline-calm-blue-400 focus:text-sm focus:font-medium"
-        >
-          {l(lang, "Skip to content", "Aller au contenu", "Zum Inhalt springen")}
-        </a>
-        <Link
-          href={`/${lang}`}
-          aria-label={l(lang, "Clarvia home", "Accueil Clarvia", "Clarvia Startseite", "Clarvia Startsäit")}
-          className="block relative w-40 h-20 transition-transform duration-200 hover:scale-[1.02]"
-        >
-          <Image
-            src="/clarvia-logo.webp"
-            alt="Clarvia"
-            fill
-            sizes="160px"
-            priority
-            className="object-contain"
-          />
+        {l(lang, "Skip to content", "Aller au contenu", "Zum Inhalt springen")}
+      </a>
+      <Link
+        href={`/${lang}`}
+        aria-label={l(lang, "Clarvia home", "Accueil Clarvia", "Clarvia Startseite", "Clarvia Startsäit")}
+        className="block relative w-32 h-14 sm:w-40 sm:h-20 transition-transform duration-200 hover:scale-[1.02] shrink-0"
+      >
+        <Image
+          src="/clarvia-logo.webp"
+          alt="Clarvia"
+          fill
+          sizes="160px"
+          priority
+          className="object-contain"
+        />
+      </Link>
+
+      <nav
+        aria-label={l(lang, "Site navigation", "Navigation du site", "Seiten-Navigation", "Navigatioun vun der Websäit")}
+        className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:gap-x-6"
+      >
+        <Link href={`/${lang}#ask-us`} className={NAV_CLASS}>
+          {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
+        </Link>
+        <Link href={`/${lang}/about`} className={NAV_CLASS}>
+          {l(lang, "About", "À propos", "Über uns", "Iwwer eis")}
+        </Link>
+        <Link href={`/${lang}/contact`} className={NAV_CLASS}>
+          {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
+        </Link>
+        <Link href={`/${lang}/support`} className={`${NAV_CLASS} sm:ml-1`}>
+          {l(lang, "Donate", "Faire un don", "Spenden", "Spenden")}
         </Link>
 
-        <nav
-          aria-label={l(lang, "Site navigation", "Navigation du site", "Seiten-Navigation", "Navigatioun vun der Websäit")}
-          className="flex items-center gap-6"
-        >
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-4 lg:gap-6 text-sm font-semibold">
+        <div className="flex items-center gap-1 sm:gap-2 sm:ml-2">
+          {LANGUAGES.map((code) => (
             <Link
-              href={`/${lang}#ask-us`}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
+              key={code}
+              href={`/${code}`}
+              aria-label={l(lang, `Switch to ${code.toUpperCase()}`, `Passer en ${code.toUpperCase()}`, `Zu ${code.toUpperCase()} wechseln`, `Op ${code.toUpperCase()} wiesselen`)}
+              aria-current={lang === code ? "page" : undefined}
+              className={`px-2.5 py-1.5 rounded-full text-sm font-medium transition-all min-h-11 inline-flex items-center ${
+                lang === code
+                  ? "bg-white text-calm-blue-800 shadow-sm border border-calm-blue-200"
+                  : "text-calm-blue-500 hover:bg-white/40"
+              }`}
             >
-              {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
+              {code.toUpperCase()}
             </Link>
-            <Link
-              href={`/${lang}/checklist`}
-              aria-label={l(
-                lang,
-                "Checklist (public alpha)",
-                "Checklist (version alpha publique)",
-                "Checkliste (öffentliche Alpha-Version)",
-                "Checklëscht (ëffentlech Alpha-Versioun)"
-              )}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              <span className="inline-flex items-baseline gap-1">
-                {l(lang, "Checklist", "Checklist", "Checkliste", "Checklëscht")}
-                <span className="text-[11px] font-medium text-calm-blue-400">
-                  {l(lang, "alpha", "alpha", "Alpha", "Alpha")}
-                </span>
-              </span>
-            </Link>
-            <Link
-              href={`/${lang}/about`}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(lang, "About", "À propos", "Über uns", "Iwwer eis")}
-            </Link>
-            <Link
-              href={`/${lang}/contact`}
-              className="text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
-            </Link>
-            <Link
-              href={`/${lang}/updates`}
-              className="hidden lg:inline text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten")}
-            </Link>
-            <Link
-              href={`/${lang}/contribute`}
-              className="hidden lg:inline text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(lang, "Contribute", "Contribuer", "Mitwirken", "Matmaachen")}
-            </Link>
-          </div>
-
-          <div className="hidden md:flex items-center gap-2">
-            <Link
-              href={`/${lang}/support`}
-              className="btn-secondary inline-flex items-center gap-1.5 px-4 py-2 text-sm mr-3"
-            >
-              ♥ {l(lang, "Support", "Soutenir", "Unterstützen", "Ënnerstëtzen")}
-            </Link>
-            {LANGUAGES.map((code) => (
-              <Link
-                key={code}
-                href={`/${code}`}
-                aria-label={l(lang, `Switch to ${code.toUpperCase()}`, `Passer en ${code.toUpperCase()}`, `Zu ${code.toUpperCase()} wechseln`, `Op ${code.toUpperCase()} wiesselen`)}
-                aria-current={lang === code ? "page" : undefined}
-                className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
-                  lang === code
-                    ? "bg-white text-calm-blue-800 shadow-sm border border-calm-blue-200"
-                    : "text-calm-blue-500 hover:bg-white/40"
-                }`}
-              >
-                {code.toUpperCase()}
-              </Link>
-            ))}
-          </div>
-
-          {/* Mobile Hamburger Menu Button */}
-          <button
-            ref={menuButtonRef}
-            type="button"
-            onClick={toggleMenu}
-            className="md:hidden p-2 rounded-xl text-calm-blue-600 hover:bg-white/40 transition-colors focus:outline-none focus:ring-2 focus:ring-calm-lilac-400 z-50 relative"
-            aria-expanded={isOpen}
-            aria-controls="mobile-navigation-menu"
-            aria-label={l(lang, "Toggle menu", "Menu", "Menü ein-/ausblenden", "Menü op- an zouklappen")}
-          >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              strokeWidth="2"
-            >
-              {isOpen ? (
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              ) : (
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-              )}
-            </svg>
-          </button>
-        </nav>
-      </header>
-
-      {/* Mobile Drawer Backdrop */}
-      {isOpen && (
-        <div
-          aria-hidden="true"
-          onClick={() => {
-            setIsOpen(false);
-            menuButtonRef.current?.focus();
-          }}
-          className="fixed inset-0 bg-slate-900/20 backdrop-blur-sm z-40 md:hidden transition-opacity"
-        />
-      )}
-
-      {/* Mobile Drawer (Calm/Glass aesthetic) */}
-      <div
-        id="mobile-navigation-menu"
-        ref={drawerRef}
-        role="dialog"
-        aria-modal="true"
-        aria-hidden={!isOpen}
-        inert={!isOpen}
-        aria-label={l(lang, "Navigation menu", "Menu de navigation", "Navigationsmenü")}
-        className={`fixed top-0 right-0 h-full w-72 max-w-[80vw] bg-white/80 backdrop-blur-xl border-l border-white/50 shadow-2xl z-40 transform transition-transform duration-300 ease-out md:hidden flex flex-col p-6 pt-24 ${
-          isOpen ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <nav className="flex flex-col gap-5 text-lg font-semibold flex-grow">
-          <Link
-            href={`/${lang}#ask-us`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "Ask us", "Posez-nous votre question", "Fragen Sie uns", "Frot eis")}
-          </Link>
-          <Link
-            href={`/${lang}/checklist`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(
-              lang,
-              "Checklist (alpha)",
-              "Checklist (alpha)",
-              "Checkliste (Alpha-Version)",
-              "Checklëscht (Alpha-Versioun)"
-            )}
-          </Link>
-          <Link
-            href={`/${lang}/about`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "About", "À propos", "Über uns", "Iwwer eis")}
-          </Link>
-          <Link
-            href={`/${lang}/contact`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "Contact", "Contact", "Kontakt", "Kontakt")}
-          </Link>
-          <Link
-            href={`/${lang}/updates`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "Updates", "Actualités", "Aktuelles", "Neiegkeeten")}
-          </Link>
-          <Link
-            href={`/${lang}/contribute`}
-            onClick={toggleMenu}
-            className="text-calm-blue-700 hover:text-calm-blue-900 transition-colors py-1.5 border-b border-calm-blue-100/50"
-          >
-            {l(lang, "Contribute", "Contribuer", "Mitwirken", "Matmaachen")}
-          </Link>
-          <Link
-            href={`/${lang}/support`}
-            onClick={toggleMenu}
-            className="btn-primary text-center py-3 text-base mt-4 shadow-md inline-flex items-center justify-center gap-1.5"
-          >
-            ♥ {l(lang, "Support Our Mission", "Soutenir notre mission", "Mission unterstützen", "Eis Missioun ënnerstëtzen")}
-          </Link>
-        </nav>
-
-        {/* Mobile Language Switcher */}
-        <div className="pt-6 border-t border-calm-blue-200/50">
-          <p className="text-xs font-semibold uppercase tracking-wider text-calm-blue-400 mb-3">
-            {l(lang, "Language", "Langue", "Sprache", "Sprooch")}
-          </p>
-          <div className="flex gap-2">
-            {LANGUAGES.map((code) => (
-              <Link
-                key={code}
-                href={`/${code}`}
-                onClick={toggleMenu}
-                className={`px-4 py-2 rounded-xl text-sm font-semibold transition-all flex-1 text-center ${
-                  lang === code
-                    ? "bg-calm-blue-800 text-white shadow-sm"
-                    : "bg-calm-blue-50 text-calm-blue-600 hover:bg-calm-blue-100"
-                }`}
-              >
-                {code.toUpperCase()}
-              </Link>
-            ))}
-          </div>
+          ))}
         </div>
-      </div>
-    </>
+      </nav>
+    </header>
   );
 }

--- a/apps/web/src/features/donations/DonationLandingPage.tsx
+++ b/apps/web/src/features/donations/DonationLandingPage.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import Image from "next/image";
-import { type Lang, l, LANGUAGES } from "@/lib/i18n";
+import { type Lang, l } from "@/lib/i18n";
 import { headlineStyle, TESTIMONIALS } from "@/app/[lang]/data";
 import FooterSection from "@/app/[lang]/sections/FooterSection";
 import Header from "@/components/Header";
@@ -76,56 +76,7 @@ export default function DonationLandingPage({ config }: DonationLandingPageProps
 
   return (
     <>
-      {config.showFullNavigation ? (
-        <Header lang={lang} />
-      ) : (
-        /* Simplified ad landing page header */
-        <header className="py-5 px-6 sm:px-12 flex items-center justify-between z-50 relative">
-          <Link
-            href={`/${lang}/checklist`}
-            aria-label={l(lang, "Clarvia home", "Accueil Clarvia", "Clarvia Startseite", "Clarvia Startsäit")}
-            className="block relative w-40 h-20 transition-transform duration-200 hover:scale-[1.02]"
-          >
-            <Image
-              src="/clarvia-logo.webp"
-              alt="Clarvia logo"
-              fill
-              sizes="160px"
-              priority
-              className="object-contain"
-            />
-          </Link>
-          <div className="flex items-center gap-6">
-            <Link
-              href={`/${lang}/checklist`}
-              className="text-sm font-semibold text-calm-blue-600 hover:text-calm-blue-800 transition-colors"
-            >
-              {l(
-                lang,
-                "View free checklist",
-                "Voir la liste gratuite",
-                "Kostenlose Checkliste ansehen",
-                "Gratis Checklëscht uweisen"
-              )}
-            </Link>
-            <div className="flex items-center gap-2">
-              {LANGUAGES.map((code) => (
-                <Link
-                  key={code}
-                  href={`/${code}/support`}
-                  className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
-                    lang === code
-                      ? "bg-white text-calm-blue-800 shadow-sm border border-calm-blue-200"
-                      : "text-calm-blue-500 hover:bg-white/40"
-                  }`}
-                >
-                  {code.toUpperCase()}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </header>
-      )}
+      <Header lang={lang} />
 
       <main
         id="main-content"
@@ -307,10 +258,10 @@ export default function DonationLandingPage({ config }: DonationLandingPageProps
               <p>
                 {l(
                   lang,
-                  "Your gift keeps Clarvia’s free services running: Ask us by email for families worldwide, and the Luxembourg checklist now in public alpha. We do not show ads.",
-                  "Votre don permet à Clarvia de maintenir ses services gratuits : des réponses par e-mail pour les familles du monde entier et la checklist Luxembourg, actuellement en version alpha publique. Nous n’affichons aucune publicité.",
-                  "Mit Ihrer Spende sichern Sie den Betrieb der kostenlosen Angebote von Clarvia: Antworten per E-Mail für Familien weltweit und die Luxemburg-Checkliste, die derzeit als öffentliche Alpha-Version verfügbar ist. Wir zeigen keine Werbung.",
-                  "Mat Ärem Don hëlleft Dir, dem Clarvia seng gratis Servicer um Lafen ze halen: Äntwerten per E-Mail fir Famillje weltwäit an d’Lëtzebuerg-Checklëscht, déi elo an der ëffentlecher Alpha-Versioun disponibel ass. Mir weise keng Reklammen."
+                  "Your gift keeps Clarvia’s free services running: Ask Clarvia by email for families worldwide, and the Luxembourg checklist we are building. We do not show ads.",
+                  "Votre don permet à Clarvia de maintenir ses services gratuits : « Demandez à Clarvia » par e-mail pour les familles du monde entier et la checklist Luxembourg que nous développons actuellement. Nous n’affichons aucune publicité.",
+                  "Mit Ihrer Spende sichern Sie den Betrieb der kostenlosen Angebote von Clarvia: „Clarvia fragen“ per E-Mail für Familien weltweit und die Luxemburg-Checkliste, die wir derzeit entwickeln. Wir zeigen keine Werbung.",
+                  "Mat Ärem Don hëlleft Dir, dem Clarvia seng gratis Servicer um Lafen ze halen: „Frot Clarvia“ per E-Mail fir Famillje weltwäit an d’Lëtzebuerg-Checklëscht, déi mir amgaang sinn ze entwéckelen. Mir weise keng Reklammen."
                 )}
               </p>
               <p>


### PR DESCRIPTION
## Summary
- Always-visible Ask us / About / Contact / Donate links; drop the hamburger and footer CI badges so the site loads lighter and navigation is obvious on phones.
- Keep Ask Clarvia as the homepage hero, then add mission, three CTAs, and latest news. Hide the checklist from public chrome for this review.
- Allow Google Ads to iframe the site, park the cookie bar so it cannot cover RCS/address, and point organisation contact at the form (no public mailto).

## Test plan
- [ ] Phone + desktop: `https://clarvia.org/en` shows four text nav links and the Ask Clarvia button
- [ ] Scroll the homepage: mission, Donate/Contact cards, latest news, footer with ASBL / RCS / address / Contact form
- [ ] `/en/about`: checklist is described as in development, no Try link
- [ ] `/en/contact`: form works; no public email address
- [ ] `/en/support`: donation copy has no alpha; footer identity is visible
- [ ] `/robots.txt` allows AdsBot and does not disallow `/_next/`
- [ ] After deploy, resubmit the Ad Grants activation request