### PR TITLE
Fix Search Console duplicate canonicals on Updates, Contribute, and brochure

### DIFF
--- a/apps/web/public/brochure.html
+++ b/apps/web/public/brochure.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Clarvia ASBL — Interactive Presentation Brochure</title>
+  <link rel="canonical" href="https://clarvia.org/brochure.html">
+  <meta name="robots" content="noindex, follow">
   
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/apps/web/src/app/[lang]/brochure/page.tsx
+++ b/apps/web/src/app/[lang]/brochure/page.tsx
@@ -2,6 +2,9 @@ import { redirect } from "next/navigation";
 
 export const metadata = {
   robots: { index: false, follow: true },
+  alternates: {
+    canonical: "https://clarvia.org/brochure.html",
+  },
 };
 
 export default async function BrochurePage() {

--- a/apps/web/src/app/[lang]/contribute/page.tsx
+++ b/apps/web/src/app/[lang]/contribute/page.tsx
@@ -1,4 +1,5 @@
-import { type Lang, l } from "@/lib/i18n";
+import { type Metadata } from "next";
+import { type Lang, l, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import { headlineStyle } from "../data";
 import FooterSection from "../sections/FooterSection";
@@ -6,6 +7,59 @@ import AccessSection from "../sections/AccessSection";
 import PublicInterestSection from "../sections/PublicInterestSection";
 import TrustSection from "../sections/TrustSection";
 import FormsSection from "../sections/FormsSection";
+
+const BASE_URL = "https://clarvia.org";
+
+const META: Record<Lang, { title: string; description: string }> = {
+  en: {
+    title: "Help Clarvia help families",
+    description:
+      "Clarvia is a Luxembourg non-profit building a free, multilingual bereavement guide for families after the loss of a loved one. Every contribution — however small — makes that guidance more accurate, more accessible, and more trustworthy.",
+  },
+  fr: {
+    title: "Contribuez à Clarvia pour aider les familles",
+    description:
+      "Clarvia est une association sans but lucratif luxembourgeoise qui développe un guide gratuit et multilingue pour accompagner les familles en deuil. Chaque contribution, même modeste, rend ce guide plus précis, plus accessible et plus fiable.",
+  },
+  de: {
+    title: "Helfen Sie Clarvia, Familien zu unterstützen",
+    description:
+      "Clarvia ist ein gemeinnütziger Verein in Luxemburg, der einen kostenlosen, mehrsprachigen Leitfaden für trauernde Familien aufbaut. Jeder Beitrag – noch so klein – macht diesen Leitfaden präziser, zugänglicher und vertrauenswürdiger.",
+  },
+  lu: {
+    title: "Hëlleft Clarvia, Familljen ze hëllefen",
+    description:
+      "Clarvia ass eng lëtzebuergesch Associatioun ouni Gewënnzweck, déi e gratis, méisproochege Guide fir Familljen nom Verloscht vun engem nooste Mënsch opbaut. All Bäitrag – egal wéi kleng – mécht dës Orientéierung méi genee, méi zougänglech a méi vertrauenswierdeg.",
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang: rawLang } = await params;
+  const lang = (LANGUAGES.includes(rawLang as Lang) ? rawLang : "en") as Lang;
+  const meta = META[lang];
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: {
+      canonical: `${BASE_URL}/${lang}/contribute`,
+      languages: hreflangLanguages("contribute"),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: `${BASE_URL}/${lang}/contribute`,
+      siteName: "Clarvia",
+      locale: lang,
+      type: "website",
+      images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630 }],
+    },
+  };
+}
 
 export default async function ContributePage({
   params,

--- a/apps/web/src/app/[lang]/layout.tsx
+++ b/apps/web/src/app/[lang]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next";
-import { LANGUAGES, type Lang, hreflangLanguages } from "@/lib/i18n";
+import { LANGUAGES, type Lang } from "@/lib/i18n";
 import AnalyticsRouteTracker from "@/components/AnalyticsRouteTracker";
 import CookieConsent from "@/components/CookieConsent";
 
@@ -47,10 +47,6 @@ export async function generateMetadata({
   return {
     title: meta.title,
     description: meta.description,
-    alternates: {
-      canonical: `${BASE_URL}/${lang}`,
-      languages: hreflangLanguages(),
-    },
     openGraph: {
       title: meta.title,
       description: meta.description,

--- a/apps/web/src/app/[lang]/updates/page.tsx
+++ b/apps/web/src/app/[lang]/updates/page.tsx
@@ -1,11 +1,61 @@
+import { Metadata } from "next";
 import Link from "next/link";
 import Image from "next/image";
-import { type Lang, l } from "@/lib/i18n";
+import { type Lang, l, LANGUAGES, hreflangLanguages } from "@/lib/i18n";
 import Header from "@/components/Header";
 import { headlineStyle } from "../data";
 import { UPDATES } from "./updates-data";
 import FooterSection from "../sections/FooterSection";
 import VideoSection from "../sections/VideoSection";
+
+const BASE_URL = "https://clarvia.org";
+
+const META: Record<Lang, { title: string; description: string }> = {
+  en: {
+    title: "Updates — Clarvia",
+    description: "Milestones and news from the Clarvia project.",
+  },
+  fr: {
+    title: "Actualités | Clarvia",
+    description: "Étapes clés et actualités du projet Clarvia.",
+  },
+  de: {
+    title: "Aktuelles | Clarvia",
+    description: "Meilensteine und Neuigkeiten aus dem Clarvia-Projekt.",
+  },
+  lu: {
+    title: "Neiegkeeten | Clarvia",
+    description: "Meilesteng an Neiegkeeten aus dem Clarvia-Projet.",
+  },
+};
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}): Promise<Metadata> {
+  const { lang: rawLang } = await params;
+  const lang = (LANGUAGES.includes(rawLang as Lang) ? rawLang : "en") as Lang;
+  const meta = META[lang];
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: {
+      canonical: `${BASE_URL}/${lang}/updates`,
+      languages: hreflangLanguages("updates"),
+    },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: `${BASE_URL}/${lang}/updates`,
+      siteName: "Clarvia",
+      locale: lang,
+      type: "website",
+      images: [{ url: `${BASE_URL}/og-image.png`, width: 1200, height: 630 }],
+    },
+  };
+}
 
 function formatDate(dateStr: string, lang: Lang): string {
   const date = new Date(dateStr + "T00:00:00");


### PR DESCRIPTION
## Summary
- `/updates` and `/contribute` now have their own titles, self-canonicals, and hreflang, matching About.
- Language layout no longer sets a homepage canonical that leaked onto every page without metadata.
- `brochure.html` is `noindex` with a self-canonical so Google stops clustering it as a duplicate without a canonical.

## Test plan
- [ ] View source on `/en/updates`: canonical is `https://clarvia.org/en/updates`, not `/en`
- [ ] View source on `/en/contribute`: canonical is `https://clarvia.org/en/contribute`
- [ ] `/en` still canonicalises to itself with hreflang for FR/DE/LU
- [ ] `https://clarvia.org/brochure.html` has `noindex, follow` and a self-canonical
- [ ] After deploy, in Search Console validate the duplicate-canonical reports