### PR TITLE
Align LU bereavement graph with live Guichet and CSSF English

### DIFF
--- a/graph/consequences/bereavement/lu/arrange_funeral_or_cremation.yml
+++ b/graph/consequences/bereavement/lu/arrange_funeral_or_cremation.yml
@@ -2,8 +2,12 @@ id: consequence.lu.bereavement.funeral.arrange_funeral_or_cremation
 schema_version: "0.1.0"
 title: Arrange burial or cremation
 description: >
-  Burial or cremation requires civil registrar authorisation and must respect
-  the 24–72 hour timing window.
+  Burial or the laying of ashes requires written authorisation from the civil
+  registrar of the commune where the death occurred. The cited burial/cremation
+  page states that burial must take place between the 24th and the 72nd hour
+  following death, and that remains for cremation may not be removed before the
+  24th hour and must be removed before the 72nd hour, unless extended with a
+  medical examiner certificate.
 consequence_type: administrative_step
 jurisdiction: LU
 jurisdiction_uri: http://publications.europa.eu/resource/authority/country/LUX
@@ -33,4 +37,4 @@ provenance:
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"
   reviewed_by: reviewer.founder.001
-  reviewed_at: "2026-06-05T10:00:00Z"
+  reviewed_at: "2026-08-25T12:00:00Z"

--- a/graph/consequences/bereavement/lu/declare_death.yml
+++ b/graph/consequences/bereavement/lu/declare_death.yml
@@ -17,6 +17,7 @@ task_template_refs:
 source_assertion_refs:
   - assertion.guichet_lu.bereavement.death_must_be_declared
   - assertion.guichet_lu.bereavement.declaration_within_24h
+  - assertion.guichet_lu.bereavement.who_may_declare
 standards_export:
   cccev_requirement:
     enabled: true
@@ -33,4 +34,4 @@ provenance:
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"
   reviewed_by: reviewer.founder.001
-  reviewed_at: "2026-06-05T10:00:00Z"
+  reviewed_at: "2026-08-25T12:00:00Z"

--- a/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
+++ b/graph/deadlines/bereavement/lu/death_declaration_deadline.yml
@@ -2,9 +2,10 @@ id: deadline.lu.bereavement.death_registration.declaration_deadline
 schema_version: "0.1.0"
 title: "Declare death within 24 hours"
 description: >
-  A death occurring in Luxembourg must be declared to the Bureau de l'état civil
-  within 24 hours. In practice, hospitals and funeral homes often handle the
-  declaration, but the legal obligation rests with the family.
+  A death occurring in Luxembourg must be declared within 24 hours to the civil
+  registrar's office in the commune where it occurred. Guichet.lu states that
+  the procedure can be carried out by a member of the deceased's family, the
+  funeral home appointed by the family, or any other person authorised to do so.
 deadline_type: filing_deadline
 jurisdiction: LU
 life_event: bereavement
@@ -17,6 +18,7 @@ calculation:
   if_weekend_or_holiday: unknown
 source_assertion_refs:
   - assertion.guichet_lu.bereavement.declaration_within_24h
+  - assertion.guichet_lu.bereavement.who_may_declare
 record_valid_from: "2026-06-03"
 authoring_status: approved
 distribution_status: public_open

--- a/graph/deadlines/bereavement/lu/funeral_cremation_72h.yml
+++ b/graph/deadlines/bereavement/lu/funeral_cremation_72h.yml
@@ -2,9 +2,11 @@ id: deadline.lu.bereavement.funeral.funeral_cremation_72h
 schema_version: "0.1.0"
 title: "Complete burial/cremation handling within 72 hours"
 description: >
-  Burial or cremation must generally be handled within 72 hours of the death,
-  unless a special authorisation (dérogation) is obtained from the communal
-  authorities.
+  The cited Guichet.lu burial/cremation page states that burial must take place
+  between the 24th and the 72nd hour following death. Remains for cremation may
+  not be removed before the 24th hour and must be removed before the 72nd hour.
+  A substantiated request with a medical examiner certificate may extend the
+  limit beyond the 72nd hour.
 deadline_type: filing_deadline
 jurisdiction: LU
 life_event: bereavement

--- a/graph/evidence_types/lu/identity_document_declarant.yml
+++ b/graph/evidence_types/lu/identity_document_declarant.yml
@@ -1,0 +1,16 @@
+id: evidence_type.lu.identity_document_declarant
+schema_version: "0.1.0"
+canonical_name: Document d'identité du déclarant
+synonyms:
+- identity document of the declarant
+- Ausweisdokument der anzeigenden Person
+description: >
+  Valid identity document of the person making the death declaration, as
+  required by Guichet.lu.
+jurisdiction: LU
+broader: evidence_type.global.identity_document
+jurisdictional_variants: []
+authoring_status: approved
+distribution_status: public_open
+record_valid_from: "2026-08-25"
+record_valid_to: null

--- a/graph/evidence_types/lu/livret_de_famille.yml
+++ b/graph/evidence_types/lu/livret_de_famille.yml
@@ -4,7 +4,10 @@ canonical_name: Livret de famille
 synonyms:
 - family record book
 - Familienstammbuch
-description: Family record book or civil-status record supporting death declaration.
+description: >
+  Family record book. Guichet.lu asks for it at death declaration if possible,
+  with a certificate of identity or another civil-status document as
+  alternatives.
 jurisdiction: LU
 broader: null
 jurisdictional_variants: []

--- a/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
+++ b/graph/task_templates/bereavement/lu/arrange_funeral_or_cremation.yml
@@ -27,17 +27,22 @@ evidence_requirements:
       operator: all
       evidence_type_refs:
         - evidence_type.lu.burial_or_cremation_authorisation
-        - evidence_type.lu.cremation_intent_proof
-        - evidence_type.lu.non_violent_death_certificate
-        - evidence_type.lu.pacemaker_certificate
 source_assertion_refs:
   - assertion.guichet_lu.funeral_cremation.written_authorisation_required
   - assertion.guichet_lu.funeral_cremation.burial_or_cremation_before_72h
+  - assertion.guichet_lu.funeral_cremation.cremation_authorisation_required
+  - assertion.guichet_lu.funeral_cremation.cremation_medical_certificate_required
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 95
   dependency_rank: 3
-  user_visible_caveat: "Burial/cremation is normally within 24\u201372 hours; extensions need a m\u00E9decin-inspecteur certificate."
+  user_visible_caveat: >
+    The cited burial/cremation page states burial between the 24th and 72nd
+    hour, with remains for cremation not removed before the 24th hour and
+    removed before the 72nd hour, unless extended with a medical examiner
+    certificate. Cremation also requires proof of the deceased's wish or a
+    declaration by the closest family member, a medical certificate of
+    non-violent death, and a pacemaker certificate.
 dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
@@ -45,9 +50,9 @@ authoring_status: approved
 distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
-  derived_from_snapshot_ref: snapshot.guichet_lu.bereavement.2026_06_03
+  derived_from_snapshot_ref: snapshot.guichet_lu.funeral_cremation.2026_06_10
   extraction_method: ai_assisted
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"
   reviewed_by: reviewer.founder.001
-  reviewed_at: "2026-06-05T10:00:00Z"
+  reviewed_at: "2026-08-25T12:00:00Z"

--- a/graph/task_templates/bereavement/lu/file_death_declaration.yml
+++ b/graph/task_templates/bereavement/lu/file_death_declaration.yml
@@ -27,17 +27,24 @@ evidence_requirements:
     - id: evidence_set.lu.bereavement.death_registration.file_death_declaration.standard
       operator: all
       evidence_type_refs:
+        - evidence_type.lu.identity_document_declarant
         - evidence_type.lu.medical_death_certificate
-        - evidence_type.lu.identity_document_deceased
-        - evidence_type.lu.livret_de_famille
 source_assertion_refs:
   - assertion.guichet_lu.bereavement.death_must_be_declared
   - assertion.guichet_lu.bereavement.declaration_within_24h
+  - assertion.guichet_lu.bereavement.who_may_declare
+  - assertion.guichet_lu.bereavement.declarant_identity_required
+  - assertion.guichet_lu.bereavement.medical_certificate_required
+  - assertion.guichet_lu.bereavement.family_book_if_possible
 rendering:
   checklist_group: immediate_formalities
   urgency_score: 100
   dependency_rank: 2
-  user_visible_caveat: Request 10–15 multilingual copies if available; commune copy fees still need municipality-level verification.
+  user_visible_caveat: >
+    If possible, also present the deceased person's family record book, a
+    certificate of identity, or another civil-status document (for example a
+    marriage certificate). Ask the commune which death-certificate extracts
+    are available and whether fees apply.
 dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
@@ -50,4 +57,4 @@ provenance:
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"
   reviewed_by: reviewer.founder.001
-  reviewed_at: "2026-06-05T10:00:00Z"
+  reviewed_at: "2026-08-25T12:00:00Z"

--- a/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
+++ b/graph/task_templates/bereavement/lu/notify_banks_trace_assets.yml
@@ -27,13 +27,19 @@ evidence_requirements:
         - evidence_type.global.identity_document
         - evidence_type.lu.acte_de_notoriete
 source_assertion_refs:
+  - assertion.lu.cssf_tracing_assets.cssf_not_competent_for_asset_tracing
   - assertion.lu.cssf_tracing_assets.heirs_contact_banks_directly
   - assertion.lu.cssf_tracing_assets.death_certificate_for_asset_search
+  - assertion.lu.cssf_tracing_assets.id_card_and_legal_document_for_asset_search
+  - assertion.lu.cssf_tracing_assets.representative_proxy_required
 rendering:
   checklist_group: estate_and_inheritance
   urgency_score: 75
   dependency_rank: 7
-  user_visible_caveat: Bank-freeze and fee details vary by institution; do not quote amounts until bank-specific official sources are captured.
+  user_visible_caveat: >
+    The CSSF lists a death certificate, a certified copy of the heir's identity
+    card, and a legal document evidencing their rights; a proxy if someone acts
+    for the heirs. Account handling, freezes, and fees vary by institution.
 dedupe:
   default_strategy: do_not_merge_across_jurisdictions
   dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}.{target.primary_authority_ref}"
@@ -41,9 +47,9 @@ authoring_status: approved
 distribution_status: public_open
 record_valid_from: "2026-06-05"
 provenance:
-  derived_from_snapshot_ref: snapshot.guichet_lu.declaration_succession.2026_06_05
+  derived_from_snapshot_ref: snapshot.lu.cssf_tracing_assets.2026_06_10
   extraction_method: ai_assisted
   extracted_by: software.extractor.v0.1
   extracted_at: "2026-06-04T08:00:00Z"
   reviewed_by: reviewer.founder.001
-  reviewed_at: "2026-06-05T10:00:00Z"
+  reviewed_at: "2026-08-25T12:00:00Z"

--- a/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/check-anchors.test.ts.snap
@@ -150,6 +150,13 @@ exports[`runCheckAnchors characterization > snapshots the full results array for
     "textQuote": "declared within 24 hours to the civil registrar's office",
   },
   {
+    "assertionId": "assertion.guichet_lu.bereavement.declarant_identity_required",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "a valid identity document",
+  },
+  {
     "assertionId": "assertion.guichet_lu.bereavement.declaration_within_24h",
     "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
     "found": true,
@@ -157,11 +164,32 @@ exports[`runCheckAnchors characterization > snapshots the full results array for
     "textQuote": "within 24 hours",
   },
   {
+    "assertionId": "assertion.guichet_lu.bereavement.family_book_if_possible",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "family record book",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.bereavement.medical_certificate_required",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "medical certificate attesting",
+  },
+  {
     "assertionId": "assertion.guichet_lu.bereavement.survivor_pension_available",
     "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
     "found": true,
     "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
     "textQuote": "survivor's pension",
+  },
+  {
+    "assertionId": "assertion.guichet_lu.bereavement.who_may_declare",
+    "file": "sources/assertions/lu/guichet_lu/bereavement.yml",
+    "found": true,
+    "snapshotId": "snapshot.guichet_lu.bereavement.2026_06_03",
+    "textQuote": "funeral home appointed by the family",
   },
   {
     "assertionId": "assertion.guichet_lu.declaration_deces.medical_attestation_required",

--- a/packages/cli/src/commands/__snapshots__/export-json.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/export-json.test.ts.snap
@@ -6,9 +6,9 @@ exports[`export-json: runExportJson > pins record counts against snapshot 1`] = 
   "conditions": 18,
   "consequences": 19,
   "deadlines": 10,
-  "evidence_types": 28,
+  "evidence_types": 29,
   "intake_fact_types": 15,
   "task_templates": 19,
-  "total": 131,
+  "total": 132,
 }
 `;

--- a/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/export-web.test.ts.snap
@@ -157,7 +157,7 @@ exports[`export-web characterization > produces runtime/bereavement.json with ex
     "consequence.lu.bereavement.survivor_pension.claim_survivor_pension",
   ],
   "deadline_count": 7,
-  "evidence_type_count": 24,
+  "evidence_type_count": 20,
   "task_template_count": 15,
   "task_template_ids": [
     "task_template.lu.bereavement.death_registration.file_death_declaration",

--- a/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/validate.characterization.test.ts.snap
@@ -425,6 +425,11 @@ exports[`runValidate characterization against real graph > pins schema assignmen
     "valid": true,
   },
   {
+    "file": "graph/evidence_types/lu/identity_document_declarant.yml",
+    "schema": "evidence_type.schema.json",
+    "valid": true,
+  },
+  {
     "file": "graph/evidence_types/lu/livret_de_famille.yml",
     "schema": "evidence_type.schema.json",
     "valid": true,
@@ -910,8 +915,8 @@ exports[`runValidate characterization against real graph > pins schema assignmen
 exports[`runValidate characterization against real graph > pins total file count and pass/fail breakdown 1`] = `
 {
   "invalid": 0,
-  "total": 180,
-  "valid": 180,
+  "total": 181,
+  "valid": 181,
 }
 `;
 

--- a/packages/cli/src/commands/check-anchors.test.ts
+++ b/packages/cli/src/commands/check-anchors.test.ts
@@ -17,7 +17,7 @@ describe("runCheckAnchors characterization", () => {
 
   it("pins the total result count", () => {
     // Will fail on first run — update with actual value
-    expect(results.length).toMatchInlineSnapshot(`82`);
+    expect(results.length).toMatchInlineSnapshot(`86`);
   });
 
   it("pins the error count", () => {
@@ -29,7 +29,7 @@ describe("runCheckAnchors characterization", () => {
     const notFound = results.filter((r) => !r.found).length;
     expect({ found, notFound }).toMatchInlineSnapshot(`
       {
-        "found": 82,
+        "found": 86,
         "notFound": 0,
       }
     `);
@@ -55,8 +55,12 @@ describe("runCheckAnchors characterization", () => {
         "assertion.guichet_lu.accept_renounce_succession.reflection_forty_days",
         "assertion.guichet_lu.accept_renounce_succession.renunciation_at_court_registry",
         "assertion.guichet_lu.bereavement.death_must_be_declared",
+        "assertion.guichet_lu.bereavement.declarant_identity_required",
         "assertion.guichet_lu.bereavement.declaration_within_24h",
+        "assertion.guichet_lu.bereavement.family_book_if_possible",
+        "assertion.guichet_lu.bereavement.medical_certificate_required",
         "assertion.guichet_lu.bereavement.survivor_pension_available",
+        "assertion.guichet_lu.bereavement.who_may_declare",
         "assertion.guichet_lu.bereavement_leave.employee_entitled_to_extraordinary_leave",
         "assertion.guichet_lu.bereavement_leave.employee_must_request_leave",
         "assertion.guichet_lu.bereavement_leave.first_degree_relative_three_days",

--- a/sources/assertions/lu/guichet_lu/bereavement.yml
+++ b/sources/assertions/lu/guichet_lu/bereavement.yml
@@ -5,8 +5,8 @@ assertions:
     schema_version: "0.1.0"
     claim_type: legal_scope
     claim_text: >
-      When a death occurs in Luxembourg, the family must declare the death to
-      the Bureau de l'état civil of the commune where the death took place.
+      When a death occurs in Luxembourg, it must be declared to the civil
+      registrar's office in the commune where it occurred.
     claim_scope:
       jurisdiction: LU
       life_event: bereavement
@@ -66,3 +66,89 @@ assertions:
       extraction_method: ai_assisted
       extracted_at: "2026-06-03T12:00:00Z"
 
+  - id: assertion.guichet_lu.bereavement.who_may_declare
+    schema_version: "0.1.0"
+    claim_type: procedural_step
+    claim_text: >
+      The death declaration can be carried out by a member of the deceased's
+      family, the funeral home appointed by the family, or any other person
+      authorised to do so.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "funeral home appointed by the family"
+    source_tier: official_guidance
+    record_valid_from: "2026-08-25"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: manual
+      extracted_at: "2026-08-25T12:00:00Z"
+
+  - id: assertion.guichet_lu.bereavement.declarant_identity_required
+    schema_version: "0.1.0"
+    claim_type: document_required
+    claim_text: >
+      The person making the declaration of death must present a valid identity
+      document.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "a valid identity document"
+    source_tier: official_guidance
+    record_valid_from: "2026-08-25"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: manual
+      extracted_at: "2026-08-25T12:00:00Z"
+
+  - id: assertion.guichet_lu.bereavement.medical_certificate_required
+    schema_version: "0.1.0"
+    claim_type: document_required
+    claim_text: >
+      The person making the declaration of death must present the medical
+      certificate attesting to the death.
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "medical certificate attesting"
+    source_tier: official_guidance
+    record_valid_from: "2026-08-25"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: manual
+      extracted_at: "2026-08-25T12:00:00Z"
+
+  - id: assertion.guichet_lu.bereavement.family_book_if_possible
+    schema_version: "0.1.0"
+    claim_type: document_required
+    claim_text: >
+      If possible, the person making the declaration of death should also
+      present the deceased person's family record book, a certificate of
+      identity, or any document attesting to their civil status (for example a
+      marriage certificate).
+    claim_scope:
+      jurisdiction: LU
+      life_event: bereavement
+      domain: death_registration
+    anchor:
+      selector_type: text_quote
+      text_quote: "family record book"
+    source_tier: official_guidance
+    record_valid_from: "2026-08-25"
+    review_status: approved
+    confidence: high
+    provenance:
+      extraction_method: manual
+      extracted_at: "2026-08-25T12:00:00Z"

--- a/sources/assertions/lu/guichet_lu/funeral_cremation.yml
+++ b/sources/assertions/lu/guichet_lu/funeral_cremation.yml
@@ -5,7 +5,7 @@ assertions:
   schema_version: "0.1.0"
   claim_type: legal_scope
   claim_text: >-
-    A burial or deposit of ashes may take place only on the basis of written authorisation from the civil registrar of the commune where the death occurred.
+    A burial or laying of ashes can only be performed with the written authorisation of the civil registrar of the commune where the death occurred.
   claim_scope:
     jurisdiction: LU
     life_event: bereavement
@@ -25,7 +25,7 @@ assertions:
   schema_version: "0.1.0"
   claim_type: deadline
   claim_text: >-
-    The burial of a human body, and removal of remains for cremation, must take place no later than the 72nd hour after death unless an extension is granted.
+    The burial of a human body must take place between the 24th and the 72nd hour following the death. Further to a substantiated request, this time limit may be extended beyond the 72nd hour on production of a certificate issued by the medical examiner. This also applies for human remains that will be cremated. They may not be removed for cremation before the 24th hour, but must be removed before the 72nd hour.
   claim_scope:
     jurisdiction: LU
     life_event: bereavement
@@ -47,7 +47,7 @@ assertions:
   schema_version: "0.1.0"
   claim_type: procedural_step
   claim_text: >-
-    Cremation of a person who died in Luxembourg requires authorisation from the civil registrar of the place of death.
+    The cremation of a deceased person in Luxembourg can only take place with the authorisation of the civil registrar for the district in which the death occurred.
   claim_scope:
     jurisdiction: LU
     life_event: bereavement
@@ -67,7 +67,7 @@ assertions:
   schema_version: "0.1.0"
   claim_type: document_required
   claim_text: >-
-    For cremation, a medical certificate must attest that there is no sign or indication of violent death.
+    For cremation authorisation, a medical certificate must attest that there was no sign or indication of a violent death.
   claim_scope:
     jurisdiction: LU
     life_event: bereavement

--- a/sources/assertions/lu/lu/cssf_tracing_assets.yml
+++ b/sources/assertions/lu/lu/cssf_tracing_assets.yml
@@ -5,7 +5,7 @@ assertions:
   schema_version: "0.1.0"
   claim_type: legal_scope
   claim_text: >-
-    Requests to trace assets of a deceased person do not fall within the CSSF’s competence.
+    Queries relating to tracing a deceased person's assets do not fall under the competence of the CSSF.
   claim_scope:
     jurisdiction: LU
     life_event: bereavement


### PR DESCRIPTION
## Summary
- Death declaration now requires the **declarant's** identity document and the medical certificate. The family record book is if-possible, not required. The unverified 10–15 copy count is omitted.
- Funeral timing follows **only** the cited burial/cremation page. Live English on that page is burial between the 24th and 72nd hour, with cremation removal before the 72nd hour, unless extended with a medical examiner certificate. The life-event page's 24–72h / Ministry of Health wording is not merged in.
- CSSF asset-tracing claims are aligned to the live English page (not CSSF's competence; heirs contact banks; listed documents and proxy).

Website copy is not in this PR.

## Test plan
- [ ] Confirm this PR contains graph, assertions, and CLI snapshots only — no `apps/web` copy.
- [ ] CI: `pnpm validate`, `pnpm test`, `pnpm typecheck`.
- [ ] Death declaration: required evidence is declarant ID + medical certificate; family book is caveat only.
- [ ] Funeral records cite the burial/cremation page only; no Ministry of Health extension language.
- [ ] CSSF task cites the tracing-assets assertions and does not quote bank-specific fees.
