### PR TITLE
ci: ignore TypeScript 7.0.x in Dependabot (typescript-eslint incompatible)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     groups:
       all-npm:
         patterns: ["*"]
+    ignore:
+      # typescript-eslint does not support TS 7.0; remove when TS 7.1 lands
+      - dependency-name: "typescript"
+        versions: [">=7.0.0 <7.1.0"]
 
   - package-ecosystem: "pip"
     directory: "/services/lex"


### PR DESCRIPTION
Fixes the CI failure on PR #318.

- `.github/dependabot.yml`: add ignore rule for `typescript >=7.0.0 <7.1.0`. TS 7.1 will be picked up automatically when it lands.

Docs only.