### PR TITLE
lex: drop gone citation URLs before mailing

### DIFF
--- a/services/lex/app/llm/url_liveness.py
+++ b/services/lex/app/llm/url_liveness.py
@@ -70,9 +70,15 @@ def _http_status(url: str, *, method: str, timeout: float) -> int:
 
 
 def probe_url(url: str, *, timeout: float = PER_URL_TIMEOUT) -> bool:
-    """True = keep (live or uncertain). False = drop (gone)."""
+    """True = keep (live or uncertain). False = drop (gone).
+
+    Plain HTTP government pages are probed the same way as HTTPS. Schema
+    ``HttpsUrl`` already allows ``http://``. mailto, tel, and schemeless
+    strings are not HEAD-able; keep them (fail open). Phone and email live
+    on contact fields, not ``website``.
+    """
     if not is_http_or_https_url(url):
-        return False
+        return True
     try:
         status = _http_status(url, method="HEAD", timeout=timeout)
         if status in _RETRY_GET_STATUS:

--- a/services/lex/app/llm/url_liveness.py
+++ b/services/lex/app/llm/url_liveness.py
@@ -1,0 +1,194 @@
+"""Drop gone source URLs (404/410/DNS/refused) before a letter is mailed.
+
+Search grounding only proves a URL appeared in this-turn results. It does not
+prove the page still exists. This check is conservative: 403, 429, 5xx, and
+timeouts are kept so official sites that block bots still reach the user.
+Checker errors fail open (keep the URL). Never log URLs.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import re
+import socket
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor, wait
+from typing import Final
+
+from app.llm.schema import LexContact, LexSource
+from app.llm.url_normalize import is_http_or_https_url
+
+_LOG = logging.getLogger(__name__)
+_CITATION_RE = re.compile(r"\[(\d+)\]")
+_USER_AGENT = "Clarvia-Lex/1.0"
+_DEAD_STATUS: Final[frozenset[int]] = frozenset({404, 410})
+_RETRY_GET_STATUS: Final[frozenset[int]] = frozenset({405, 501})
+PER_URL_TIMEOUT: Final[float] = 2.5
+OVERALL_TIMEOUT: Final[float] = 4.0
+MAX_WORKERS: Final[int] = 6
+
+
+class _LimitedRedirect(urllib.request.HTTPRedirectHandler):
+    max_redirections = 1
+
+
+def keep_after_status(status: int) -> bool:
+    """True when the URL should stay in the letter."""
+    return status not in _DEAD_STATUS
+
+
+def keep_after_error(exc: BaseException) -> bool:
+    """True when a transport error is not proof that the page is gone."""
+    if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, socket.gaierror):
+        return False
+    if isinstance(exc, ConnectionRefusedError):
+        return False
+    if isinstance(exc, urllib.error.URLError):
+        if isinstance(exc.reason, BaseException):
+            return keep_after_error(exc.reason)
+        return True
+    return not (isinstance(exc, OSError) and exc.errno == errno.ECONNREFUSED)
+
+
+def _http_status(url: str, *, method: str, timeout: float) -> int:
+    opener = urllib.request.build_opener(_LimitedRedirect)
+    request = urllib.request.Request(
+        url,
+        method=method,
+        headers={"User-Agent": _USER_AGENT, "Accept": "*/*"},
+    )
+    try:
+        with opener.open(request, timeout=timeout) as response:
+            return int(response.status)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code)
+
+
+def probe_url(url: str, *, timeout: float = PER_URL_TIMEOUT) -> bool:
+    """True = keep (live or uncertain). False = drop (gone)."""
+    if not is_http_or_https_url(url):
+        return False
+    try:
+        status = _http_status(url, method="HEAD", timeout=timeout)
+        if status in _RETRY_GET_STATUS:
+            status = _http_status(url, method="GET", timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 — fail open unless proven gone
+        return keep_after_error(exc)
+    return keep_after_status(status)
+
+
+def find_dead_urls(
+    urls: Sequence[str],
+    *,
+    probe: Callable[[str], bool] | None = None,
+) -> frozenset[str]:
+    """Return URLs the probe classified as gone. Unfinished probes are kept."""
+    check = probe or probe_url
+    unique = list(dict.fromkeys(url.strip() for url in urls if url.strip()))
+    if not unique:
+        return frozenset()
+
+    dead: set[str] = set()
+    workers = min(MAX_WORKERS, len(unique))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        future_map = {pool.submit(check, url): url for url in unique}
+        done, pending = wait(future_map, timeout=OVERALL_TIMEOUT)
+        for future in pending:
+            future.cancel()
+        for future in done:
+            url = future_map[future]
+            try:
+                if not future.result():
+                    dead.add(url)
+            except Exception:  # noqa: BLE001 — fail open
+                continue
+    return frozenset(dead)
+
+
+def strip_dead_urls(
+    body: str,
+    sources: list[LexSource],
+    contacts: list[LexContact],
+    *,
+    probe: Callable[[str], bool] | None = None,
+) -> tuple[str, list[LexSource], list[LexContact]]:
+    """Drop gone sources/contacts and rewrite citation markers."""
+    candidates = [source.url for source in sources] + [
+        contact.website for contact in contacts
+    ]
+    dead = find_dead_urls(candidates, probe=probe)
+    if not dead:
+        return body, sources, contacts
+
+    kept_sources: list[LexSource] = []
+    old_to_new: dict[int, int] = {}
+    for source in sources:
+        if source.url in dead:
+            continue
+        new_id = len(kept_sources) + 1
+        old_to_new[source.id] = new_id
+        kept_sources.append(source.model_copy(update={"id": new_id}))
+
+    def _rewrite_marker(match: re.Match[str]) -> str:
+        new_id = old_to_new.get(int(match.group(1)))
+        return f"[{new_id}]" if new_id is not None else ""
+
+    body = _CITATION_RE.sub(_rewrite_marker, body)
+    body = re.sub(r"[ \t]+\n", "\n", body)
+    body = re.sub(r" {2,}", " ", body)
+
+    source_by_new = {source.id: source for source in kept_sources}
+    kept_contacts: list[LexContact] = []
+    for contact in contacts:
+        new_source_id = old_to_new.get(contact.source_id)
+        if new_source_id is None:
+            continue
+        website = contact.website
+        if website in dead:
+            continue
+        kept_contacts.append(
+            contact.model_copy(
+                update={
+                    "id": len(kept_contacts) + 1,
+                    "source_id": new_source_id,
+                    "website": website or source_by_new[new_source_id].url,
+                }
+            )
+        )
+
+    cited_markers = {int(match) for match in _CITATION_RE.findall(body)}
+    used_by_contact = {contact.source_id for contact in kept_contacts}
+    for source in kept_sources:
+        if source.id in cited_markers or source.id in used_by_contact:
+            continue
+        insert = f" [{source.id}]"
+        stripped = body.rstrip()
+        if stripped.endswith("Lex."):
+            body = stripped[:-4].rstrip() + insert + "\n\nLex."
+        else:
+            body = stripped + insert + "\n\nLex."
+        cited_markers.add(source.id)
+
+    dropped_sources = len(sources) - len(kept_sources)
+    dropped_contacts = len(contacts) - len(kept_contacts)
+    if dropped_sources or dropped_contacts:
+        _LOG.info(
+            "lex_dead_urls_stripped sources=%s contacts=%s",
+            dropped_sources,
+            dropped_contacts,
+        )
+    return body, kept_sources, kept_contacts
+
+
+__all__ = [
+    "keep_after_status",
+    "keep_after_error",
+    "probe_url",
+    "find_dead_urls",
+    "strip_dead_urls",
+]

--- a/services/lex/app/services/model_pipeline.py
+++ b/services/lex/app/services/model_pipeline.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 from app.domain.ports import LlmGenerationResult, LlmPort, StructuredLlmResult
 from app.llm.schema import LexContact, LexSource
+from app.llm.url_liveness import strip_dead_urls
 from app.llm.url_normalize import match_search_url
 from app.llm.validation import LexValidationError, validate_lex_response
 
@@ -312,6 +313,9 @@ def _normalize_model_response(result: LlmGenerationResult) -> LlmGenerationResul
             contacts,
             search_urls=list(result.web_search_source_urls),
         )
+
+    if sources or contacts:
+        body, sources, contacts = strip_dead_urls(body, sources, contacts)
 
     body_folded = body.casefold()
     missing_names = [

--- a/services/lex/docs/adr/0007-single-search-generation.md
+++ b/services/lex/docs/adr/0007-single-search-generation.md
@@ -22,7 +22,9 @@ For in-scope mail that has passed operational gates:
 1. Call OpenAI Responses once with `web_search` enabled and schema
    `lex_response_v1` (prompt `lex-v1` at `runtime-private/prompts/lex-v1.txt`).
 2. Keep only source and contact URLs that appear in this-turn search results.
-   Drop citation markers that no longer resolve.
+   Drop citation markers that no longer resolve. Then drop remaining URLs that
+   are gone (HTTP 404/410, DNS failure, or connection refused). Keep 403, 429,
+   5xx, and timeouts. If the checker errors, keep the URL.
 3. If validation still fails, coerce: keep the prose, drop ungrounded sources
    and contacts, and send as `clarify` when an `answer` has no search evidence.
 4. Compose the outbound mail in application code (body, sources block,

--- a/services/lex/docs/architecture.md
+++ b/services/lex/docs/architecture.md
@@ -51,8 +51,9 @@ rejects any other `GCP_REGION` at startup.
 
 In-scope model-eligible mail uses **one** OpenAI Responses API call with web
 search and structured schema `lex_response_v1`. The application then keeps
-only this-turn search URLs, coerces a parsed body if remaining schema checks
-fail, and composes sources, `Lex.` sign-off, continuation, and footer.
+only this-turn search URLs, drops source URLs that are gone (HTTP 404/410,
+DNS failure, or connection refused), coerces a parsed body if remaining schema
+checks fail, and composes sources, `Lex.` sign-off, continuation, and footer.
 
 The reply body is written in the same language as the latest user message, or
 in a language the user asked for. No country graph or legislation files are

--- a/services/lex/tests/unit/conftest.py
+++ b/services/lex/tests/unit/conftest.py
@@ -69,6 +69,15 @@ _CONFIG_ENV_VARS = (
 )
 
 
+@pytest.fixture(autouse=True)
+def _keep_source_urls_in_unit_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Do not issue live HTTP from the dead-link strip during unit tests."""
+    monkeypatch.setattr(
+        "app.llm.url_liveness.probe_url",
+        lambda *_args, **_kwargs: True,
+    )
+
+
 @pytest.fixture
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Remove Lex config environment variables for deterministic defaults."""

--- a/services/lex/tests/unit/test_url_liveness.py
+++ b/services/lex/tests/unit/test_url_liveness.py
@@ -15,9 +15,40 @@ from app.llm.url_liveness import (
     keep_after_status,
     strip_dead_urls,
 )
+from app.llm.url_liveness import (
+    probe_url as _real_probe_url,
+)
 from app.services.model_pipeline import run_model_pipeline
 
 from .conftest import make_answer_response
+
+
+def test_probe_keeps_schemes_it_cannot_head() -> None:
+    assert _real_probe_url("mailto:lex@clarvia.org") is True
+    assert _real_probe_url("tel:+352123456") is True
+    assert _real_probe_url("not-a-url") is True
+
+
+def test_probe_checks_plain_http_government_urls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[str] = []
+
+    def fake_status(url: str, *, method: str, timeout: float) -> int:
+        seen.append(f"{method}:{url}")
+        return 200
+
+    monkeypatch.setattr("app.llm.url_liveness._http_status", fake_status)
+    assert _real_probe_url("http://www.moh.gov.zw/palliative-care") is True
+    assert seen[0].startswith("HEAD:http://")
+
+
+def test_probe_drops_gone_http_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "app.llm.url_liveness._http_status",
+        lambda *_args, **_kwargs: 404,
+    )
+    assert _real_probe_url("http://example.gov/gone") is False
 
 
 def test_keep_after_status_drops_only_gone_pages() -> None:

--- a/services/lex/tests/unit/test_url_liveness.py
+++ b/services/lex/tests/unit/test_url_liveness.py
@@ -1,0 +1,189 @@
+"""Dead-link strip: drop 404/410/DNS/refused; keep 403/timeout; fail open."""
+
+from __future__ import annotations
+
+import logging
+import socket
+import urllib.error
+
+import pytest
+from app.infrastructure.openai import FakeLlmAdapter, generation_result_from_response
+from app.llm.schema import LexContact, LexSource
+from app.llm.url_liveness import (
+    find_dead_urls,
+    keep_after_error,
+    keep_after_status,
+    strip_dead_urls,
+)
+from app.services.model_pipeline import run_model_pipeline
+
+from .conftest import make_answer_response
+
+
+def test_keep_after_status_drops_only_gone_pages() -> None:
+    assert keep_after_status(200) is True
+    assert keep_after_status(301) is True
+    assert keep_after_status(403) is True
+    assert keep_after_status(429) is True
+    assert keep_after_status(500) is True
+    assert keep_after_status(404) is False
+    assert keep_after_status(410) is False
+
+
+def test_keep_after_error_drops_dns_and_refused_only() -> None:
+    assert keep_after_error(TimeoutError()) is True
+    assert keep_after_error(socket.gaierror()) is False
+    assert keep_after_error(ConnectionRefusedError()) is False
+    assert keep_after_error(urllib.error.URLError(TimeoutError())) is True
+    assert keep_after_error(urllib.error.URLError(socket.gaierror())) is False
+    assert keep_after_error(RuntimeError("boom")) is True
+
+
+def test_strip_drops_404_source_and_rewrites_markers() -> None:
+    body = (
+        "Contact the Commune office [1]. The other registry page [2].\n\nLex."
+    )
+    sources = [
+        LexSource(
+            id=1,
+            title="Death registration guide",
+            publisher="Government of Luxembourg",
+            url="https://guichet.public.lu",
+        ),
+        LexSource(
+            id=2,
+            title="Gone page",
+            publisher="Example",
+            url="https://example.com/gone",
+        ),
+    ]
+    contacts = [
+        LexContact(
+            id=1,
+            name="Commune office",
+            kind="authority",
+            country_code="LU",
+            website="https://guichet.public.lu",
+            phone=None,
+            email=None,
+            commercial=False,
+            note="Handles death registration.",
+            source_id=1,
+        )
+    ]
+
+    def probe(url: str) -> bool:
+        return "gone" not in url
+
+    new_body, new_sources, new_contacts = strip_dead_urls(
+        body, sources, contacts, probe=probe
+    )
+
+    assert [source.url for source in new_sources] == ["https://guichet.public.lu"]
+    assert new_sources[0].id == 1
+    assert "[2]" not in new_body
+    assert "[1]" in new_body
+    assert len(new_contacts) == 1
+
+
+def test_strip_keeps_403_and_timeout_urls() -> None:
+    body = "See the ministry [1] and the registry [2].\n\nLex."
+    sources = [
+        LexSource(
+            id=1,
+            title="Ministry",
+            publisher="Gov",
+            url="https://example.com/forbidden",
+        ),
+        LexSource(
+            id=2,
+            title="Registry",
+            publisher="Gov",
+            url="https://example.com/slow",
+        ),
+    ]
+
+    def probe(url: str) -> bool:
+        return True
+
+    new_body, new_sources, new_contacts = strip_dead_urls(
+        body, sources, [], probe=probe
+    )
+    assert len(new_sources) == 2
+    assert new_contacts == []
+    assert "[1]" in new_body and "[2]" in new_body
+
+
+def test_strip_fails_open_when_probe_raises() -> None:
+    body = "Contact the Commune office [1].\n\nLex."
+    sources = [
+        LexSource(
+            id=1,
+            title="Death registration guide",
+            publisher="Government of Luxembourg",
+            url="https://guichet.public.lu",
+        )
+    ]
+
+    def probe(_url: str) -> bool:
+        raise RuntimeError("network down")
+
+    new_body, new_sources, _contacts = strip_dead_urls(
+        body, sources, [], probe=probe
+    )
+    assert len(new_sources) == 1
+    assert "[1]" in new_body
+
+
+def test_find_dead_urls_unfinished_probes_are_kept() -> None:
+    dead = find_dead_urls(
+        ["https://example.com/a"],
+        probe=lambda _url: True,
+    )
+    assert dead == frozenset()
+
+
+def test_pipeline_drops_dead_source_before_send(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        "app.llm.url_liveness.probe_url",
+        lambda url, *_args, **_kwargs: "gone" not in url,
+    )
+    live = "https://guichet.public.lu"
+    gone = "https://example.com/gone"
+    response = make_answer_response(
+        body_markdown=(
+            "Contact the Commune office [1]. Ignore this stale page [2].\n\nLex."
+        ),
+        sources=[
+            LexSource(
+                id=1,
+                title="Death registration guide",
+                publisher="Government of Luxembourg",
+                url=live,
+            ),
+            LexSource(
+                id=2,
+                title="Gone page",
+                publisher="Example",
+                url=gone,
+            ),
+        ],
+    )
+    allowed = frozenset({live, gone})
+    llm = FakeLlmAdapter(
+        responses=[generation_result_from_response(response, source_urls=allowed)]
+    )
+    with caplog.at_level(logging.INFO):
+        result = run_model_pipeline(
+            llm,
+            system_prompt="prompt",
+            runtime_envelope="envelope",
+        )
+
+    assert [source.url for source in result.response.sources] == [live]
+    assert "[2]" not in result.response.body_markdown
+    assert "[1]" in result.response.body_markdown
+    assert result.response.action == "answer"
+    assert "lex_dead_urls_stripped" in caplog.text


### PR DESCRIPTION
## What does this PR do?

Ask Clarvia already replies well. This keeps the quality bar and stops mailing **gone** source links.

After this-turn search grounding, Lex now probes remaining source/contact URLs and drops only proven-dead ones (HTTP 404/410, DNS failure, connection refused). 403, 429, 5xx, and timeouts are kept so official sites that block bots still appear. If the checker errors, the URL stays and the letter still goes out.

The live prompt (`runtime-private/prompts/lex-v1.txt`) was amended on this machine for the same pass: missing-person / later-admin scope, situation states, 3–5 actions first, ongoing-dialogue close, less over-certainty, compact privacy/scam guidance. That file is gitignored and is **not** in this PR. Rebuild the Cloud Run image to ship the prompt.

## Checklist

- [x] Lex unit tests (`uv run pytest tests/unit` in `services/lex`)
- [ ] CI passes (`pnpm validate`, `pnpm test`, `pnpm typecheck`) — graph records unchanged
- [ ] New graph records start as `draft` / `restricted_source` — N/A
- [ ] Source assertions include `text_quote` anchors — N/A
- [ ] Scenario tests cover new consequences — N/A
- [x] Documentation updated (architecture + ADR 0007)

## Test plan

- [ ] Replay a missing-person Ask: still a strong checklist; found-safe branch; no “call daily”; no 404s in Sources checked
- [ ] Replay “my father died, what do I do?”: no missing-person or remains-handling chapter
- [ ] Replay a later-admin Ask (pension/account years later): jumps to that task
- [ ] Replay a will / planning Ask: planning language, not as if the death has happened
- [ ] Confirm a known 404 cited URL is absent from the mailed source list
- [ ] Rebuild and deploy the image so the local prompt tune is in production

## Related issues

Spec: `I:\My Drive\Clarvia\docs\feature_spec-lex-v1-content-tune.md`