### PR TITLE
feat(generator): full resolved subject model for multi-person scenarios

### DIFF
--- a/packages/generator/src/__snapshots__/golden.test.ts.snap
+++ b/packages/generator/src/__snapshots__/golden.test.ts.snap
@@ -59,6 +59,7 @@ exports[`golden: checklist output snapshots > scenario: lu/core_bereavement 1`] 
         "top_tier": null,
       },
       "status": "applies",
+      "subject_label": "deceased person",
       "title": "Register the death at the commune and request death-certificate copies",
       "urgency": {
         "deadline_label": "Declare death within 24 hours (PT24H)",
@@ -163,6 +164,7 @@ exports[`golden: checklist output snapshots > scenario: lu/core_married_employed
         "top_tier": null,
       },
       "status": "applies",
+      "subject_label": "deceased person",
       "title": "Register the death at the commune and request death-certificate copies",
       "urgency": {
         "deadline_label": "Declare death within 24 hours (PT24H)",
@@ -273,6 +275,7 @@ exports[`golden: checklist output snapshots > scenario: lu/minimal_unknown 1`] =
         "top_tier": null,
       },
       "status": "applies",
+      "subject_label": "deceased person",
       "title": "Register the death at the commune and request death-certificate copies",
       "urgency": {
         "deadline_label": "Declare death within 24 hours (PT24H)",
@@ -373,6 +376,7 @@ exports[`golden: checklist output snapshots > scenario: lu/self_employed_propert
         "top_tier": null,
       },
       "status": "applies",
+      "subject_label": "deceased person",
       "title": "Register the death at the commune and request death-certificate copies",
       "urgency": {
         "deadline_label": "Declare death within 24 hours (PT24H)",
@@ -483,6 +487,7 @@ exports[`golden: checklist output snapshots > scenario: lu/self_employed_propert
         "top_tier": null,
       },
       "status": "applies",
+      "subject_label": "deceased person",
       "title": "Register the death at the commune and request death-certificate copies",
       "urgency": {
         "deadline_label": "Declare death within 24 hours (PT24H)",

--- a/packages/generator/src/generator.ts
+++ b/packages/generator/src/generator.ts
@@ -36,6 +36,7 @@ import {
   type ExplanationTrace,
 } from "./explanation.js";
 import { recordApplies, type TemporalContext } from "./temporal.js";
+import { resolveSubjects, type ResolvedSubject } from "./subjects.js";
 
 // Re-export types for convenience
 export type { Fact } from "./evaluator.js";
@@ -52,6 +53,8 @@ export type ItemStatus =
 export interface ChecklistItem {
   id: string;
   resolved_subject_id: string;
+  /** Neutral, non-personal label for the subject (e.g. "survivor", "child 2"). */
+  subject_label: string;
   status: ItemStatus;
   title: string;
   description: string | null;
@@ -160,30 +163,9 @@ function makeItemId(
   return `checklist_item.${scenarioHash}.${hash}`;
 }
 
-// ── Resolved subject ID ─────────────────────────────────────────────
-// Alpha deterministic mapping from task_template.target.subject_role.
-// Fallback for bereavement: person.deceased.
-
-const SUBJECT_ROLE_MAP: Record<string, string> = {
-  deceased: "person.deceased",
-  survivor: "person.survivor",
-  surviving_spouse: "person.survivor",
-  surviving_partner: "person.survivor",
-  child: "person.child",
-  dependant: "person.dependant",
-  estate: "estate.primary",
-};
-
-function resolveSubjectId(
-  template: TaskTemplate | null,
-): string {
-  const role = template?.target?.subject_role;
-  if (role && SUBJECT_ROLE_MAP[role]) {
-    return SUBJECT_ROLE_MAP[role];
-  }
-  // Bereavement alpha fallback
-  return "person.deceased";
-}
+// ── Resolved subject ─────────────────────────────────────────────────
+// Subject resolution (role mapping, multi-person fan-out from scenario
+// facts, bereavement fallback) lives in subjects.ts.
 
 // ── Deduplication and Merging helpers ────────────────────────────────
 
@@ -349,6 +331,7 @@ interface CandidateItem {
   item: ChecklistItem;
   consequence: Consequence;
   template: TaskTemplate | null;
+  subject: ResolvedSubject;
   trace: ExplanationTrace | null;
   dedupeKey: string;
   strategy: string;
@@ -458,39 +441,23 @@ interface ExpandContext {
   scenarioHash: string;
   graph: LoadedGraph;
   temporalCtx: TemporalContext;
+  facts: Fact[];
 }
 
 function expandConsequenceToItems(ctx: ExpandContext): CandidateItem[] {
-  const { consequence, overallResult, allMissingFacts, conditionRefs, conditionResultCache, scenarioHash, graph, temporalCtx } = ctx;
+  const { consequence, overallResult, allMissingFacts, conditionRefs, conditionResultCache, scenarioHash, graph, temporalCtx, facts } = ctx;
   const taskRefs = consequence.task_template_refs ?? [];
   const results: CandidateItem[] = [];
 
-  if (taskRefs.length === 0) {
-    const item = makeItem(scenarioHash, consequence, null, overallResult, allMissingFacts, graph, temporalCtx);
-    let trace: ExplanationTrace | null = null;
-    if (item.status !== "does_not_apply") {
-      trace = buildExplanationTrace(
-        `trace.${item.id}`,
-        consequence.id,
-        conditionRefs,
-        conditionResultCache,
-        graph,
-        temporalCtx,
-      );
-      item.explanation_trace_id = trace.id;
-    }
-    const { key, strategy } = resolveDedupeKey(null, consequence);
-    results.push({ item, consequence, template: null, trace, dedupeKey: key, strategy });
-  } else {
-    for (const taskRef of taskRefs) {
-      const template = graph.taskTemplates.get(taskRef);
-      if (template && !recordApplies(template, temporalCtx)) {
-        continue;
-      }
+  const expandForTemplate = (template: TaskTemplate | null) => {
+    // One candidate per resolved subject. Single-subject scenarios resolve
+    // to exactly one subject with the legacy ID, preserving alpha behavior.
+    for (const subject of resolveSubjects(template, facts)) {
       const item = makeItem(
         scenarioHash,
         consequence,
-        template ?? null,
+        template,
+        subject,
         overallResult,
         allMissingFacts,
         graph,
@@ -509,8 +476,30 @@ function expandConsequenceToItems(ctx: ExpandContext): CandidateItem[] {
         );
         item.explanation_trace_id = trace.id;
       }
-      const { key, strategy } = resolveDedupeKey(template ?? null, consequence);
-      results.push({ item, consequence, template: template ?? null, trace, dedupeKey: key, strategy });
+      const { key, strategy } = resolveDedupeKey(template, consequence);
+      // The resolved subject is always part of the dedupe key: items for
+      // different subjects never merge (issue #36 decision).
+      results.push({
+        item,
+        consequence,
+        template,
+        subject,
+        trace,
+        dedupeKey: `${key}::${subject.id}`,
+        strategy,
+      });
+    }
+  };
+
+  if (taskRefs.length === 0) {
+    expandForTemplate(null);
+  } else {
+    for (const taskRef of taskRefs) {
+      const template = graph.taskTemplates.get(taskRef);
+      if (template && !recordApplies(template, temporalCtx)) {
+        continue;
+      }
+      expandForTemplate(template ?? null);
     }
   }
 
@@ -580,10 +569,16 @@ function mergeCandidateGroup(
 
   const mergedStatus = mergeStatuses(statuses);
 
+  // All candidates in a group share the same subject (it is part of the
+  // dedupe key). First-ordinal subjects keep the pre-#36 merged identity so
+  // existing merged item IDs stay stable; additional subjects append their
+  // ID so per-subject merged groups cannot collide.
+  const subject = subList[0].subject;
+  const subjectSuffix = subject.ordinal === 1 ? "" : `|subject:${subject.id}`;
   const mergedIdentity = subList
     .map(c => `${c.consequence.id}::${c.template?.id ?? c.consequence.id}`)
     .sort((a, b) => a.localeCompare(b))
-    .join("|");
+    .join("|") + subjectSuffix;
   const mergedGroupHash = createHash("sha256")
     .update(mergedIdentity)
     .digest("hex")
@@ -768,7 +763,7 @@ export function generateChecklist(opts: GenerateOptions): ChecklistOutput {
     );
     candidatesList.push(...expandConsequenceToItems({
       consequence, overallResult, allMissingFacts, conditionRefs,
-      conditionResultCache, scenarioHash, graph, temporalCtx,
+      conditionResultCache, scenarioHash, graph, temporalCtx, facts,
     }));
   }
 
@@ -833,6 +828,7 @@ function makeItem(
   scenarioHash: string,
   consequence: Consequence,
   template: TaskTemplate | null,
+  subject: ResolvedSubject,
   conditionResult: TriValue,
   missingFacts: string[],
   graph: LoadedGraph,
@@ -872,18 +868,17 @@ function makeItem(
     return !ass || recordApplies(ass, temporalCtx);
   });
 
-  const resolvedSubjectId = resolveSubjectId(template);
-
   return {
     id: makeItemId(
       scenarioHash,
       template?.id ?? consequence.id,
-      resolvedSubjectId,
+      subject.id,
       consequence.jurisdiction,
       template?.authority_refs?.[0] ?? null,
       null,
     ),
-    resolved_subject_id: resolvedSubjectId,
+    resolved_subject_id: subject.id,
+    subject_label: subject.label,
     status,
     title: template?.title ?? consequence.title,
     description: template?.description ?? null,

--- a/packages/generator/src/index.ts
+++ b/packages/generator/src/index.ts
@@ -16,3 +16,6 @@ export type { ChecklistOutput, ChecklistItem, GenerateOptions, ItemStatus } from
 
 export { evaluateCondition, buildFactData } from "./evaluator.js";
 export type { Fact, TriValue } from "./evaluator.js";
+
+export { resolveSubjects } from "./subjects.js";
+export type { ResolvedSubject } from "./subjects.js";

--- a/packages/generator/src/subject-fanout.test.ts
+++ b/packages/generator/src/subject-fanout.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Generator-level tests for multi-person subject fan-out (issue #36).
+ *
+ * Verifies the pipeline end to end: keyed multi-person facts produce one
+ * checklist item per subject with distinct, deterministic IDs; the subject
+ * is always part of the dedupe key; single-subject output keeps the alpha
+ * shape (plus the new subject_label field).
+ */
+
+import { describe, it, expect } from "vitest";
+import { generateChecklist } from "./index.js";
+import type { Fact } from "./evaluator.js";
+
+const FIXED_AS_OF = "2026-06-03";
+
+type MockGraph = Parameters<typeof generateChecklist>[0]["graph"];
+
+function makeGraph(overrides: {
+  consequences: Array<[string, Record<string, unknown>]>;
+  taskTemplates: Array<[string, Record<string, unknown>]>;
+}): MockGraph {
+  return {
+    consequences: new Map(overrides.consequences),
+    taskTemplates: new Map(overrides.taskTemplates),
+    conditions: new Map(),
+    deadlines: new Map(),
+    authorities: new Map(),
+    evidenceTypes: new Map(),
+    intakeFactTypes: new Map(),
+    sources: new Map(),
+    assertions: new Map(),
+  } as unknown as MockGraph;
+}
+
+function makeConsequence(id: string, extra?: Record<string, unknown>) {
+  return [id, {
+    id,
+    schema_version: "0.1.0",
+    title: `Title of ${id}`,
+    consequence_type: "obligation",
+    jurisdiction: "LU",
+    life_event: "bereavement",
+    domain: "death_registration",
+    authoring_status: "approved",
+    distribution_status: "public_open",
+    record_valid_from: "2026-01-01",
+    ...extra,
+  }] as [string, Record<string, unknown>];
+}
+
+function makeTemplate(id: string, extra?: Record<string, unknown>) {
+  return [id, {
+    id,
+    schema_version: "0.1.0",
+    title: `Task ${id}`,
+    action_type: "file_declaration",
+    jurisdiction: "LU",
+    life_event: "bereavement",
+    domain: "death_registration",
+    authoring_status: "approved",
+    distribution_status: "public_open",
+    record_valid_from: "2026-01-01",
+    rendering: { checklist_group: "money_and_benefits", urgency_score: 50 },
+    ...extra,
+  }] as [string, Record<string, unknown>];
+}
+
+const BASE_FACTS: Fact[] = [{ fact_type: "death.place.country", value: "LU" }];
+
+const TWO_CHILDREN_FACTS: Fact[] = [
+  ...BASE_FACTS,
+  { fact_type: "child.1.date_of_birth", value: "2015-03-01" },
+  { fact_type: "child.2.date_of_birth", value: "2019-11-14" },
+];
+
+describe("generator: multi-person subject fan-out", () => {
+  const childGraph = () => makeGraph({
+    consequences: [
+      makeConsequence("c.orphan_pension", { task_template_refs: ["t.claim_orphan_pension"] }),
+    ],
+    taskTemplates: [
+      makeTemplate("t.claim_orphan_pension", {
+        title: "Claim orphan pension",
+        target: { subject_role: "child" },
+      }),
+    ],
+  });
+
+  it("two children produce two items with distinct IDs and subjects", () => {
+    const output = generateChecklist({
+      graph: childGraph(),
+      facts: TWO_CHILDREN_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+
+    expect(output.items).toHaveLength(2);
+    const [first, second] = [...output.items].sort((a, b) =>
+      a.resolved_subject_id.localeCompare(b.resolved_subject_id));
+    expect(first.resolved_subject_id).toBe("person.child");
+    expect(second.resolved_subject_id).toBe("person.child.2");
+    expect(first.subject_label).toBe("child");
+    expect(second.subject_label).toBe("child 2");
+    expect(first.id).not.toBe(second.id);
+    // Both items share the template title; the subject fields disambiguate.
+    expect(first.title).toBe(second.title);
+    // Each item carries its own explanation trace.
+    expect(output.explanation_traces).toHaveLength(2);
+  });
+
+  it("first child's item ID equals the single-child item ID for the same fact set", () => {
+    // Same scenario facts, but only one child declared: the single item must
+    // hash identically to the first item of the two-children run, because
+    // index 1 keeps the bare legacy subject ID and the scenario hash prefix
+    // is the only part allowed to differ... so compare the task-hash suffix.
+    const two = generateChecklist({
+      graph: childGraph(),
+      facts: TWO_CHILDREN_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+    const one = generateChecklist({
+      graph: childGraph(),
+      facts: [...BASE_FACTS, { fact_type: "child.1.date_of_birth", value: "2015-03-01" }],
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+
+    const taskHash = (id: string) => id.split(".").at(-1);
+    const firstOfTwo = two.items.find((i) => i.resolved_subject_id === "person.child")!;
+    expect(one.items).toHaveLength(1);
+    expect(taskHash(one.items[0].id)).toBe(taskHash(firstOfTwo.id));
+  });
+
+  it("without keyed facts the output keeps the alpha single-subject shape", () => {
+    const output = generateChecklist({
+      graph: childGraph(),
+      facts: BASE_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+    expect(output.items).toHaveLength(1);
+    expect(output.items[0].resolved_subject_id).toBe("person.child");
+    expect(output.items[0].subject_label).toBe("child");
+  });
+
+  it("determinism: repeated runs and reordered facts give identical IDs", () => {
+    const a = generateChecklist({
+      graph: childGraph(),
+      facts: TWO_CHILDREN_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+    const b = generateChecklist({
+      graph: childGraph(),
+      facts: [...TWO_CHILDREN_FACTS].reverse(),
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+    expect(a.items.map((i) => i.id)).toEqual(b.items.map((i) => i.id));
+  });
+});
+
+describe("generator: dedupe/merge never crosses subjects", () => {
+  it("merge strategy produces one merged item per subject", () => {
+    const graph = makeGraph({
+      consequences: [
+        makeConsequence("c.merge1", { title: "Merge One", task_template_refs: ["t.merged"] }),
+        makeConsequence("c.merge2", { title: "Merge Two", task_template_refs: ["t.merged"] }),
+      ],
+      taskTemplates: [
+        makeTemplate("t.merged", {
+          title: "Merged child task",
+          target: { object_type: "orphan_pension_application", subject_role: "child" },
+          dedupe: {
+            default_strategy: "merge",
+            dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}",
+          },
+        }),
+      ],
+    });
+
+    const output = generateChecklist({
+      graph,
+      facts: TWO_CHILDREN_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+
+    // Two consequences × two children → four candidates → two merged items,
+    // one per child, each covering both consequences.
+    expect(output.items).toHaveLength(2);
+    const ids = output.items.map((i) => i.id);
+    expect(new Set(ids).size).toBe(2);
+    for (const item of output.items) {
+      expect(item.needed_for).toEqual(["Merge One", "Merge Two"]);
+    }
+    const subjects = output.items.map((i) => i.resolved_subject_id).sort();
+    expect(subjects).toEqual(["person.child", "person.child.2"]);
+  });
+
+  it("merged item ID for the first subject matches the pre-fan-out merged ID", () => {
+    const consequences = [
+      makeConsequence("c.merge1", { title: "Merge One", task_template_refs: ["t.merged"] }),
+      makeConsequence("c.merge2", { title: "Merge Two", task_template_refs: ["t.merged"] }),
+    ];
+    const template = (role: string) => makeTemplate("t.merged", {
+      title: "Merged task",
+      target: { object_type: "death_declaration", subject_role: role },
+      dedupe: {
+        default_strategy: "merge",
+        dedupe_key_template: "{action_type}.{target.object_type}.{jurisdiction}",
+      },
+    });
+
+    // The merged identity for ordinal-1 subjects must not carry a subject
+    // suffix, so single-subject merged IDs are unchanged from alpha. Compare
+    // the merged task-hash across two different roles: identity depends only
+    // on (consequence, template) pairs, exactly as before #36.
+    const run = (role: string) => generateChecklist({
+      graph: makeGraph({ consequences, taskTemplates: [template(role)] }),
+      facts: BASE_FACTS,
+      lifeEvent: "bereavement",
+      asOfDate: FIXED_AS_OF,
+      eventDate: FIXED_AS_OF,
+    });
+
+    const taskHash = (id: string) => id.split(".").at(-1);
+    expect(run("survivor").items).toHaveLength(1);
+    expect(taskHash(run("survivor").items[0].id)).toBe(taskHash(run("deceased").items[0].id));
+  });
+});

--- a/packages/generator/src/subjects.test.ts
+++ b/packages/generator/src/subjects.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the resolved subject model (issue #36).
+ *
+ * The contract under test:
+ * - Without multi-person facts, resolution is exactly the alpha behavior:
+ *   one subject, legacy ID string, for every role in use.
+ * - Flat keyed facts (`child.1.date_of_birth`, ...) fan a mapped role out
+ *   into one subject per index; index 1 keeps the bare legacy ID.
+ * - Unmapped roles and missing targets keep the person.deceased fallback
+ *   and never fan out.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveSubjects } from "./subjects.js";
+import type { TaskTemplate } from "./loader.js";
+import type { Fact } from "./evaluator.js";
+
+function templateWithRole(role: string | null): TaskTemplate {
+  return {
+    id: "t.probe",
+    schema_version: "0.1.0",
+    title: "Probe",
+    action_type: "file_declaration",
+    jurisdiction: "LU",
+    life_event: "bereavement",
+    domain: "death_registration",
+    authoring_status: "approved",
+    distribution_status: "public_open",
+    record_valid_from: "2026-01-01",
+    target: role === null ? null : { subject_role: role },
+  } as TaskTemplate;
+}
+
+const NO_FACTS: Fact[] = [];
+
+describe("resolveSubjects: single-subject legacy parity", () => {
+  const LEGACY_CASES: Array<[string, string]> = [
+    ["deceased", "person.deceased"],
+    ["survivor", "person.survivor"],
+    ["surviving_spouse", "person.survivor"],
+    ["surviving_partner", "person.survivor"],
+    ["child", "person.child"],
+    ["dependant", "person.dependant"],
+    ["estate", "estate.primary"],
+    // Unmapped roles in use in the graph — bereavement fallback.
+    ["heir", "person.deceased"],
+    ["declarant", "person.deceased"],
+    ["heir_or_legatee", "person.deceased"],
+    ["heir_or_tax_representative", "person.deceased"],
+    ["heir_or_business_successor", "person.deceased"],
+    ["heir_or_surviving_spouse", "person.deceased"],
+    ["survivor_or_heir", "person.deceased"],
+    ["person_who_advanced_funeral_costs", "person.deceased"],
+  ];
+
+  for (const [role, expectedId] of LEGACY_CASES) {
+    it(`role ${role} → single subject ${expectedId}`, () => {
+      const subjects = resolveSubjects(templateWithRole(role), NO_FACTS);
+      expect(subjects).toHaveLength(1);
+      expect(subjects[0].id).toBe(expectedId);
+      expect(subjects[0].ordinal).toBe(1);
+    });
+  }
+
+  it("no target and no template → person.deceased fallback", () => {
+    expect(resolveSubjects(templateWithRole(null), NO_FACTS)[0].id).toBe("person.deceased");
+    expect(resolveSubjects(null, NO_FACTS)[0].id).toBe("person.deceased");
+    expect(resolveSubjects(null, NO_FACTS)[0].source).toBe("fallback");
+  });
+});
+
+describe("resolveSubjects: multi-person fan-out from flat keyed facts", () => {
+  const TWO_CHILDREN: Fact[] = [
+    { fact_type: "child.1.date_of_birth", value: "2015-03-01" },
+    { fact_type: "child.2.date_of_birth", value: "2019-11-14" },
+  ];
+
+  it("two children → person.child and person.child.2", () => {
+    const subjects = resolveSubjects(templateWithRole("child"), TWO_CHILDREN);
+    expect(subjects.map((s) => s.id)).toEqual(["person.child", "person.child.2"]);
+    expect(subjects.map((s) => s.ordinal)).toEqual([1, 2]);
+    expect(subjects.map((s) => s.label)).toEqual(["child", "child 2"]);
+    expect(subjects.every((s) => s.source === "facts")).toBe(true);
+  });
+
+  it("fact order does not matter", () => {
+    const reversed = [...TWO_CHILDREN].reverse();
+    expect(resolveSubjects(templateWithRole("child"), reversed)).toEqual(
+      resolveSubjects(templateWithRole("child"), TWO_CHILDREN),
+    );
+  });
+
+  it("indices are taken literally: child.2 + child.5 without child.1", () => {
+    const facts: Fact[] = [
+      { fact_type: "child.5.date_of_birth", value: "2010-01-01" },
+      { fact_type: "child.2.date_of_birth", value: "2012-01-01" },
+    ];
+    const subjects = resolveSubjects(templateWithRole("child"), facts);
+    expect(subjects.map((s) => s.id)).toEqual(["person.child.2", "person.child.5"]);
+  });
+
+  it("multiple facts for the same index count once", () => {
+    const facts: Fact[] = [
+      { fact_type: "child.1.date_of_birth", value: "2015-03-01" },
+      { fact_type: "child.1.residence.country", value: "LU" },
+    ];
+    const subjects = resolveSubjects(templateWithRole("child"), facts);
+    expect(subjects.map((s) => s.id)).toEqual(["person.child"]);
+  });
+
+  it("survivor family fans out too (surviving_spouse role)", () => {
+    const facts: Fact[] = [
+      { fact_type: "survivor.1.residence.country", value: "LU" },
+      { fact_type: "survivor.2.residence.country", value: "DE" },
+    ];
+    const subjects = resolveSubjects(templateWithRole("surviving_spouse"), facts);
+    expect(subjects.map((s) => s.id)).toEqual(["person.survivor", "person.survivor.2"]);
+    expect(subjects[1].label).toBe("survivor 2");
+  });
+
+  it("child facts do not fan out a survivor-role template", () => {
+    const subjects = resolveSubjects(templateWithRole("survivor"), TWO_CHILDREN);
+    expect(subjects.map((s) => s.id)).toEqual(["person.survivor"]);
+  });
+
+  it("unmapped roles never fan out, even with keyed facts present", () => {
+    const subjects = resolveSubjects(templateWithRole("heir"), TWO_CHILDREN);
+    expect(subjects.map((s) => s.id)).toEqual(["person.deceased"]);
+  });
+
+  it("deceased and estate are singletons regardless of facts", () => {
+    const facts: Fact[] = [
+      { fact_type: "deceased.1.name_known", value: "true" },
+      { fact_type: "estate.1.asset_location.country", value: "LU" },
+    ];
+    expect(resolveSubjects(templateWithRole("deceased"), facts).map((s) => s.id)).toEqual(["person.deceased"]);
+    expect(resolveSubjects(templateWithRole("estate"), facts).map((s) => s.id)).toEqual(["estate.primary"]);
+  });
+
+  it("non-indexed family facts (e.g. survivor.residence.country) do not fan out", () => {
+    const facts: Fact[] = [{ fact_type: "survivor.residence.country", value: "LU" }];
+    const subjects = resolveSubjects(templateWithRole("survivor"), facts);
+    expect(subjects.map((s) => s.id)).toEqual(["person.survivor"]);
+  });
+});

--- a/packages/generator/src/subjects.ts
+++ b/packages/generator/src/subjects.ts
@@ -1,0 +1,121 @@
+/**
+ * Resolved subject model (issue #36).
+ *
+ * Maps a task template's target.subject_role — plus any multi-person scenario
+ * facts — to the list of concrete subjects the task applies to.
+ *
+ * ID grammar (decided on issue #36):
+ * - The first subject of a role family keeps the legacy alpha ID unchanged
+ *   (person.child, person.survivor, ...), so existing single-subject checklist
+ *   item IDs are preserved by construction.
+ * - Additional subjects use the fact index as an ordinal suffix:
+ *   person.child.2, person.child.3, ...
+ *
+ * Multi-person facts use the flat keyed convention `<family>.<n>.<path>`
+ * (e.g. child.1.date_of_birth, child.2.date_of_birth). Fan-out only happens
+ * for roles with a genuine SUBJECT_ROLE_MAP entry; unmapped roles keep the
+ * single person.deceased bereavement fallback untouched — mapping them is an
+ * intentional future migration (see issue #36 discussion).
+ */
+
+import type { Fact } from "./evaluator.js";
+import type { TaskTemplate } from "./loader.js";
+
+export interface ResolvedSubject {
+  /** Deterministic subject ID used in checklist item hashes. */
+  id: string;
+  /** Role family the subject belongs to (child, survivor, ...). */
+  role_family: string;
+  /** 1-based index within the family; 1 keeps the legacy bare ID. */
+  ordinal: number;
+  /** Neutral, non-personal label identifying the subject (e.g. "child 2"). */
+  label: string;
+  /** How the subject was derived. */
+  source: "facts" | "role_default" | "fallback";
+}
+
+// Alpha deterministic mapping from task_template.target.subject_role.
+// Fallback for bereavement: person.deceased.
+const SUBJECT_ROLE_MAP: Record<string, string> = {
+  deceased: "person.deceased",
+  survivor: "person.survivor",
+  surviving_spouse: "person.survivor",
+  surviving_partner: "person.survivor",
+  child: "person.child",
+  dependant: "person.dependant",
+  estate: "estate.primary",
+};
+
+// Fact-type prefix family per base subject ID. Only these families can fan
+// out from scenario facts; person.deceased and estate.primary are singletons.
+const SUBJECT_FACT_FAMILY: Record<string, string> = {
+  "person.survivor": "survivor",
+  "person.child": "child",
+  "person.dependant": "dependant",
+};
+
+const SUBJECT_LABELS: Record<string, string> = {
+  "person.deceased": "deceased person",
+  "person.survivor": "survivor",
+  "person.child": "child",
+  "person.dependant": "dependant",
+  "estate.primary": "estate",
+};
+
+/** Distinct numeric indices found in `<family>.<n>.<path>` facts, ascending. */
+function factIndicesForFamily(family: string, facts: Fact[]): number[] {
+  const pattern = new RegExp(`^${family}\\.(\\d+)\\.`);
+  const indices = new Set<number>();
+  for (const fact of facts) {
+    const match = pattern.exec(fact.fact_type);
+    if (match) {
+      indices.add(Number(match[1]));
+    }
+  }
+  return [...indices].sort((a, b) => a - b);
+}
+
+function makeSubject(
+  baseId: string,
+  family: string,
+  index: number,
+  source: ResolvedSubject["source"],
+): ResolvedSubject {
+  const baseLabel = SUBJECT_LABELS[baseId] ?? family;
+  return {
+    id: index === 1 ? baseId : `${baseId}.${index}`,
+    role_family: family,
+    ordinal: index,
+    label: index === 1 ? baseLabel : `${baseLabel} ${index}`,
+    source,
+  };
+}
+
+/**
+ * Resolve the subjects a task template targets, given the scenario facts.
+ *
+ * Always returns at least one subject. Without multi-person facts the result
+ * is exactly the alpha single-subject behavior (same ID, same hash inputs).
+ */
+export function resolveSubjects(
+  template: TaskTemplate | null,
+  facts: Fact[],
+): ResolvedSubject[] {
+  const role = template?.target?.subject_role;
+  const mappedId = role ? SUBJECT_ROLE_MAP[role] : undefined;
+
+  if (!mappedId) {
+    // Bereavement alpha fallback — never fans out.
+    return [makeSubject("person.deceased", "deceased", 1, "fallback")];
+  }
+
+  const family = SUBJECT_FACT_FAMILY[mappedId];
+  if (family) {
+    const indices = factIndicesForFamily(family, facts);
+    if (indices.length > 0) {
+      return indices.map((n) => makeSubject(mappedId, family, n, "facts"));
+    }
+  }
+
+  return [makeSubject(mappedId, family ?? role, 1, "role_default")];
+}


### PR DESCRIPTION
## What does this PR do?

Implements the full resolved subject model for multi-person scenarios (#36), following the decisions from the issue discussion:

- **Ordinal subject IDs from flat keyed facts** (Q1/Q3): `child.1.date_of_birth`, `child.2.date_of_birth`, … fan a mapped subject role out into one checklist item per person. Index 1 keeps the bare legacy ID (`person.child`), later indices append the ordinal (`person.child.2`) — existing alpha single-subject item IDs are preserved by construction. Resolution lives in a new `packages/generator/src/subjects.ts` module (`resolveSubjects(template, facts)`, exported from the package index).
- **Subject always in the dedupe key** (Q5): items for different subjects never merge. Ordinal-1 merged identities keep the pre-#36 form, so existing merged item IDs are unchanged; additional subjects append their ID to the merged identity so per-subject merged groups cannot collide.
- **Structured `subject_label` on `ChecklistItem`** (Q7): neutral, non-personal labels ("survivor", "child 2") identify which person an item concerns. `why_visible` prose is untouched.
- **Unmapped roles unchanged** (Q2): `heir`, `declarant`, etc. keep the `person.deceased` fallback and never fan out — mapping them stays a future explicit migration.
- Hash inputs follow `docs/FOUNDATION.md` §14.1 unchanged (Q4). No schema, evaluator, or template `target` changes (Q6/KISS scope).

**ID stability evidence:** the characterization tables from #328 pass **byte-identical** — no existing item ID moved. Golden snapshots change only by the additive `subject_label` field (+5 lines).

**Tests:** two new test files — legacy parity for all 16 roles in use, fan-out ordinals/labels, determinism under fact reordering, literal indices, per-subject merge non-collision, and proof that the first child's item hash is identical whether or not a second child exists. Full suite: 326/326.

Scope notes / possible follow-ups:
- `exports/example-bereavement-lu.json` was not regenerated here (it predates the new field) — happy to regenerate in this PR or a follow-up, whichever you prefer.
- The scenario-test runner still matches items by title, so a multi-person scenario fixture under `tests/scenarios/` needs a subject dimension in the runner first — proposed as a follow-up.

## Checklist

- [x] CI passes (`pnpm validate`, `pnpm test`, `pnpm typecheck`)
- [ ] New graph records start as `draft` / `restricted_source` — n/a, no graph records touched
- [ ] Source assertions include `text_quote` anchors — n/a
- [ ] Scenario tests cover new consequences — n/a, no new consequences (multi-person fixture proposed as follow-up, see scope notes)
- [ ] Documentation updated (if applicable) — module-level docs in `subjects.ts`

## Related issues

Closes #36
